### PR TITLE
chore: help string if no options

### DIFF
--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -293,6 +293,10 @@ def main():
 
     parsed_options, parsed_configs = parser.parse_args()
 
+    if not parsed_configs: # if no configs to run provided
+        parser.print_help()
+        sys.exit(1)
+
     executor = CLI(parsed_options)
 
     try:

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.3.2 (next)
+  - print help string if no configs provided
 
 
 ## 0.3.1


### PR DESCRIPTION
Print help string if no config provided. Currently Taurus is trying to run test, creating temp directory and print error:
```
$ bzt/cli.py
18:42:57 INFO: Taurus CLI Tool v0.2.22
18:42:57 INFO: Starting with configs: []
18:42:57 INFO: Configuring...
18:42:57 INFO: Artifacts dir: /Users/marianna/perf/taurus/2015-07-07_18-42-57.01nM9r
18:42:57 INFO: Preparing...
18:42:57 ERROR: Exception: No execution is configured
18:42:57 WARNING: Please wait for graceful shutdown...
18:42:57 INFO: Post-processing...
18:42:57 INFO: Artifacts dir: /Users/marianna/perf/taurus/2015-07-07_18-42-57.01nM9r
18:42:57 INFO: Done performing with code: 1
```

After the change:
```
$ bzt/cli.py
Usage: bzt [options] [configs] [-aliases]

BlazeMeter Taurus Tool v0.2.22, the configuration-driven test running engine

Options:
  -h, --help            show this help message and exit
  -d DATADIR, --datadir=DATADIR
                        Artifacts base dir
  -l LOG, --log=LOG     Log file location
  -o OPTION, --option=OPTION
                        Override option in config
  -q, --quiet           Only errors and warnings printed to console
  -v, --verbose         Prints all logging messages to console
```