### PR TITLE
Added detection of pyenv/python3 virtualenvs

### DIFF
--- a/bzt/__init__.py
+++ b/bzt/__init__.py
@@ -65,7 +65,8 @@ def get_configs_dir():
     Generate configs dir path on install, moved from utils due to import error
     :return: str
     """
-    if hasattr(sys, 'real_prefix'):
+    # detect virtualenv or pyenv usage
+    if hasattr(sys, 'real_prefix') or (hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
         path = sys.prefix
     else:
         path = os.path.splitdrive(sys.executable)[0]


### PR DESCRIPTION
Installing into jenkins where pyenv was used to activate a python3 virtualenv was failing because the install was trying to write to /etc/bzt.d. This is because the virtualenv test was failing and sys.executable was empty, causing the calculated config dir path to be `"" + "/" + os.path.join("etc", "bzt.d")`.

I think this should detect pyenv and python3 virtualenvs. https://www.python.org/dev/peps/pep-0405/ has more info.