### PR TITLE
Fix unicode handling in JMeter's jmx scripts

### DIFF
--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -22,7 +22,7 @@ from itertools import chain
 
 from cssselect import GenericTranslator
 
-from bzt.six import etree, iteritems, string_types, parse
+from bzt.six import etree, iteritems, string_types, parse, text_type
 from bzt.engine import Scenario
 
 
@@ -350,11 +350,7 @@ class JMX(object):
         :return:
         """
         res = etree.Element("stringProp", name=name)
-        try:
-            res.text = str(value)
-        except ValueError:
-            logging.warning("Failed to set string prop: %s=%s", name, value)
-            res.text = 'BINARY'
+        res.text = text_type(value)
         return res
 
     @staticmethod
@@ -367,7 +363,7 @@ class JMX(object):
         :return:
         """
         res = etree.Element("longProp", name=name)
-        res.text = str(value)
+        res.text = text_type(value)
         return res
 
     @staticmethod
@@ -392,7 +388,7 @@ class JMX(object):
         :return:
         """
         res = etree.Element("intProp", name=name)
-        res.text = str(value)
+        res.text = text_type(value)
         return res
 
     @staticmethod
@@ -733,7 +729,7 @@ class JMX(object):
         :type is_invert:  bool
         :rtype: lxml.etree.Element
         """
-        tname = "Assert %s has %s" % ("not" if is_invert else "", [str(x) for x in contains])
+        tname = "Assert %s has %s" % ("not" if is_invert else "", [text_type(x) for x in contains])
         element = etree.Element("ResponseAssertion", guiclass="AssertionGui",
                                 testclass="ResponseAssertion", testname=tname)
         if field == Scenario.FIELD_HEADERS:
@@ -804,7 +800,7 @@ class JMX(object):
         """
         items = self.get(sel)
         for item in items:
-            item.text = str(text)
+            item.text = text_type(text)
 
     @staticmethod
     def _get_simple_controller(name):

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -9,7 +9,7 @@
  - add Apache Benchmark executor
  - extend script path recognition for Jmeter
  - fix PBench not working with cloud provisioning
-
+ - fix unicode handling in JMeter's jmx script
 
 ## 1.2.0
  - maximize browser window in Selenium test, when possible

--- a/tests/jmx/dummy_plan.jmx
+++ b/tests/jmx/dummy_plan.jmx
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="2.3" jmeter="2.8.20130705">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+    </TestPlan>
+    <hashTree>
+      <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="true">
+        <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+          <collectionProp name="Arguments.arguments"/>
+        </elementProp>
+        <stringProp name="HTTPSampler.domain">localhost</stringProp>
+        <stringProp name="HTTPSampler.port">8002</stringProp>
+        <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+        <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        <stringProp name="HTTPSampler.protocol">http</stringProp>
+        <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+        <stringProp name="HTTPSampler.path"></stringProp>
+        <stringProp name="HTTPSampler.concurrentPool">4</stringProp>
+      </ConfigTestElement>
+      <hashTree/>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Front Page Crawler" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <longProp name="ThreadGroup.start_time">1367790220000</longProp>
+        <longProp name="ThreadGroup.end_time">1367790220000</longProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Home Page" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="param" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">placeholder</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+                <boolProp name="HTTPArgument.use_equals">true</boolProp>
+                <stringProp name="Argument.name">param</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain"></stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <boolProp name="HTTPSampler.monitor">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <RegexExtractor guiclass="RegexExtractorGui" testclass="RegexExtractor" testname="Regular Expression Extractor" enabled="true">
+            <stringProp name="RegexExtractor.useHeaders">false</stringProp>
+            <stringProp name="RegexExtractor.refname">links</stringProp>
+            <stringProp name="RegexExtractor.regex">&lt;a class=&quot;comments.*?href=&quot;([^&quot;]+)&quot;</stringProp>
+            <stringProp name="RegexExtractor.template">$1$</stringProp>
+            <stringProp name="RegexExtractor.default"></stringProp>
+            <stringProp name="RegexExtractor.match_number">-1</stringProp>
+          </RegexExtractor>
+          <hashTree/>
+        </hashTree>
+        <DebugSampler guiclass="TestBeanGUI" testclass="DebugSampler" testname="Debug Sampler" enabled="true">
+          <boolProp name="displayJMeterProperties">false</boolProp>
+          <boolProp name="displayJMeterVariables">true</boolProp>
+          <boolProp name="displaySystemProperties">false</boolProp>
+        </DebugSampler>
+        <hashTree/>
+        <ForeachController guiclass="ForeachControlPanel" testclass="ForeachController" testname="ForEach Controller" enabled="true">
+          <stringProp name="ForeachController.inputVal">links</stringProp>
+          <stringProp name="ForeachController.returnVal">link</stringProp>
+          <boolProp name="ForeachController.useSeparator">true</boolProp>
+        </ForeachController>
+        <hashTree>
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Comment Page: ${link}" enabled="true">
+            <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+              <collectionProp name="Arguments.arguments"/>
+            </elementProp>
+            <stringProp name="HTTPSampler.domain"></stringProp>
+            <stringProp name="HTTPSampler.port"></stringProp>
+            <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+            <stringProp name="HTTPSampler.response_timeout"></stringProp>
+            <stringProp name="HTTPSampler.protocol"></stringProp>
+            <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+            <stringProp name="HTTPSampler.path">${link}</stringProp>
+            <stringProp name="HTTPSampler.method">GET</stringProp>
+            <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+            <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+            <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+            <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+            <boolProp name="HTTPSampler.monitor">false</boolProp>
+            <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          </HTTPSamplerProxy>
+          <hashTree/>
+        </hashTree>
+        <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>false</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>false</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>false</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>false</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -916,10 +916,34 @@ class TestJMeterExecutor(BZTestCase):
                 }]}})
         obj.prepare()
 
+    def test_jmx_modification_unicode(self):
+        obj = JMeterExecutor()
+        obj.engine = EngineEmul()
+        cfg_selector = ('Home Page>HTTPsampler.Arguments>Arguments.arguments'
+                        '>param>Argument.value')
+
+        obj.execution.merge({
+            "scenario": {
+                "script": __dir__() + "/../jmx/dummy_plan.jmx",
+                "modifications": {
+                    "set-prop": {
+                        cfg_selector: u"✓",
+                    }
+                }
+            }
+        })
+        selector = ("[testname='Home Page']>[name='HTTPsampler.Arguments']"
+                    ">[name='Arguments.arguments']>[name='param']>[name='Argument.value']")
+        obj.prepare()
+        jmx = JMX(obj.modified_jmx)
+        self.assertEqual(jmx.get(selector)[0].text, u"✓")
+
+
 
 class TestJMX(BZTestCase):
-    def test_checkmark(self):
+    def test_jmx_unicode_checkmark(self):
         obj = JMX()
-        res = obj._get_http_request("url", "label", "method", 0, {"param": "✓"}, True)
+        res = obj._get_http_request("url", "label", "method", 0, {"param": u"✓"}, True)
         prop = res.find(".//stringProp[@name='Argument.value']")
         self.assertNotEqual("BINARY", prop.text)
+        self.assertEqual(u"✓", prop.text)

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 """ test """
 import json
 import logging
@@ -123,7 +124,7 @@ class TestJMeterExecutor(BZTestCase):
         obj.prepare()
 
     def test_path_processing(self):
-        class FakeTool:
+        class FakeTool(object):
             tool_path = ''
             installed = None
 
@@ -914,3 +915,11 @@ class TestJMeterExecutor(BZTestCase):
                     "url": "http://blazedemo.com",
                 }]}})
         obj.prepare()
+
+
+class TestJMX(BZTestCase):
+    def test_checkmark(self):
+        obj = JMX()
+        res = obj._get_http_request("url", "label", "method", 0, {"param": "✓"}, True)
+        prop = res.find(".//stringProp[@name='Argument.value']")
+        self.assertNotEqual("BINARY", prop.text)


### PR DESCRIPTION
This fix changes all usages of `str()` (which has different semantics in py2 and py3) to `six.text_type()` (which is `unicode` in python2 and `str` in python3) for writing all text fields into jmx's xml representation.