### PR TITLE
Get rid of repeat '.jmx.jmx' extension in modified JMeter script

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -557,7 +557,8 @@ class JMeterExecutor(ScenarioExecutor, WidgetProvider, FileLister):
         self.__add_result_writers(jmx)
         self.__force_tran_parent_sample(jmx)
 
-        prefix = "modified_" + os.path.basename(original)
+        script_name, _ = os.path.splitext(os.path.basename(original))
+        prefix = "modified_" + script_name
         filename = self.engine.create_artifact(prefix, ".jmx")
         jmx.save(filename)
         return filename

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -277,7 +277,7 @@ class TestJMeterExecutor(BZTestCase):
         obj.prepare()
         artifacts = os.listdir(obj.engine.artifacts_dir)
         self.assertEqual(len(artifacts), 9)  # minus jmeter.log
-        target_jmx = os.path.join(obj.engine.artifacts_dir, "modified_files.jmx.jmx")
+        target_jmx = os.path.join(obj.engine.artifacts_dir, "modified_files.jmx")
         self.__check_path_resource_files(target_jmx, exclude_jtls=True)
 
     def test_resource_files_from_requests_remote_prov(self):
@@ -296,11 +296,11 @@ class TestJMeterExecutor(BZTestCase):
         obj.engine.config = json.loads(open(__dir__() + "/../json/get-post.json").read())
         obj.execution = obj.engine.config['execution']
         obj.prepare()
-        files = ['http.jmx', 'jmeter-bzt.properties', 'modified_requests.jmx.jmx']
+        files = ['http.jmx', 'jmeter-bzt.properties', 'modified_requests.jmx']
         files += ['requests.jmx', 'system.properties', 'test1.csv']
         artifacts = os.listdir(obj.engine.artifacts_dir)
         self.assertTrue(all([_file in artifacts for _file in files]))  # +system.properties, -jmeter.log
-        target_jmx = os.path.join(obj.engine.artifacts_dir, "modified_requests.jmx.jmx")
+        target_jmx = os.path.join(obj.engine.artifacts_dir, "modified_requests.jmx")
         self.__check_path_resource_files(target_jmx, exclude_jtls=True)
 
     def test_http_request_defaults(self):
@@ -590,7 +590,7 @@ class TestJMeterExecutor(BZTestCase):
         obj.execution.merge({"scenario": {"script": __dir__() + "/../jmx/files.jmx"}})
         obj.distributed_servers = ["127.0.0.1", "127.0.0.1"]
         obj.prepare()
-        target_jmx = os.path.join(obj.engine.artifacts_dir, "modified_files.jmx.jmx")
+        target_jmx = os.path.join(obj.engine.artifacts_dir, "modified_files.jmx")
         self.__check_path_resource_files(target_jmx, exclude_jtls=True, reverse_check=True)
 
     def test_duration_loops_bug(self):
@@ -681,7 +681,7 @@ class TestJMeterExecutor(BZTestCase):
         obj.prepare()
         artifacts = os.listdir(obj.engine.artifacts_dir)
         self.assertEqual(len(artifacts), 5)  # minus jmeter.log
-        target_jmx = os.path.join(obj.engine.artifacts_dir, "modified_variable_csv.jmx.jmx")
+        target_jmx = os.path.join(obj.engine.artifacts_dir, "modified_variable_csv.jmx")
         with open(target_jmx) as fds:
             jmx = fds.read()
             self.assertIn('<stringProp name="filename">${root}/csvfile.csv</stringProp>', jmx)


### PR DESCRIPTION
Not sure if this change deserves some unittests or a changelog entry.