### PR TITLE
Parse values from CLI overrides as YAML

### DIFF
--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -14,6 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import json
 import logging
 import os
 import platform
@@ -289,12 +290,25 @@ class ConfigOverrider(object):
             else:
                 self.log.debug("No value to delete: %s", item)
         else:
-            if value.isdigit():
-                value = float(value)
+            parsed_value = self.__parse_override_value(value)
+            self.log.debug("parse override value: %r -> %r", value, parsed_value)
             if isinstance(pointer, list) and parts[-1] < 0:
-                pointer.append(value)
+                pointer.append(parsed_value)
             else:
-                pointer[parts[-1]] = value
+                pointer[parts[-1]] = parsed_value
+
+    def __parse_override_value(self, override):
+        try:
+            value = json.loads(override)
+
+            # this is useful for strings that contain quotes
+            # e.g. __parse_override_value('"asd"') == '"asd"'
+            if isinstance(value, string_types):
+                return override
+            return value
+        except ValueError:
+            # we treat non-json values as literal strings
+            return override
 
     def __ensure_list_capacity(self, pointer, part, next_part=None):
         """

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -14,7 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import json
 import logging
 import os
 import platform
@@ -27,6 +26,7 @@ from select import select
 from tempfile import NamedTemporaryFile
 
 from colorlog import ColoredFormatter
+import yaml
 
 import bzt
 from bzt import ManualShutdown, NormalShutdown, RCProvider, AutomatedShutdown
@@ -303,9 +303,8 @@ class ConfigOverrider(object):
 
     def __parse_override_value(self, override):
         """
-        Parse overrides values as if they are JSON. If they're not valid JSON - treat them as strings.
-
-        Has special behaviour for quoted strings.
+        Parse overrides values as if they are YAML values.
+        If they're not valid YAML - treat them as strings.
 
         Examples:
         '' -> None
@@ -315,7 +314,6 @@ class ConfigOverrider(object):
         'null' -> None,
         'abcdef' -> str("abcdef")
         '"abcdef"' -> str('"abcdef"')
-        '"true"' -> "true"
 
         :param override:
         :return: Any
@@ -324,15 +322,9 @@ class ConfigOverrider(object):
             return None
 
         try:
-            value = json.loads(override)
-            if isinstance(value, string_types):
-                try:
-                    json.loads(value)
-                    return value
-                except ValueError:
-                    return override
+            value = yaml.load(override)
             return value
-        except ValueError:
+        except BaseException:
             return override
 
     def __ensure_list_capacity(self, pointer, part, next_part=None):

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -311,19 +311,13 @@ class ConfigOverrider(object):
         'abcdef' -> str("abcdef")
         '"abcdef"' -> str('"abcdef"')
 
-        '"true"' -> str("true") - because true is a literal value
-
         :param override:
         :return: Any
         """
         try:
             value = json.loads(override)
             if isinstance(value, string_types):
-                try:
-                    json.loads(value)
-                    return value
-                except ValueError:
-                    return override
+                return override
             else:
                 return value
         except ValueError:

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -302,28 +302,8 @@ class ConfigOverrider(object):
                 pointer[parts[-1]] = parsed_value
 
     def __parse_override_value(self, override):
-        """
-        Parse overrides values as if they are YAML values.
-        If they're not valid YAML - treat them as strings.
-
-        Examples:
-        '' -> None
-        '123' -> int(123)
-        '12.1' -> float(12.1)
-        'true' -> bool(True)
-        'null' -> None,
-        'abcdef' -> str("abcdef")
-        '"abcdef"' -> str('"abcdef"')
-
-        :param override:
-        :return: Any
-        """
-        if not override:
-            return None
-
         try:
-            value = yaml.load(override)
-            return value
+            return yaml.load(override)
         except BaseException:
             return override
 

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -308,18 +308,21 @@ class ConfigOverrider(object):
         Has special behaviour for quoted strings.
 
         Examples:
+        '' -> None
         '123' -> int(123)
         '12.1' -> float(12.1)
         'true' -> bool(True)
         'null' -> None,
         'abcdef' -> str("abcdef")
         '"abcdef"' -> str('"abcdef"')
+        '"true"' -> "true"
 
         :param override:
         :return: Any
         """
         if not override:
             return None
+
         try:
             value = json.loads(override)
             if isinstance(value, string_types):

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -291,7 +291,7 @@ class ConfigOverrider(object):
                 self.log.debug("No value to delete: %s", item)
         else:
             parsed_value = self.__parse_override_value(value)
-            self.log.debug("parsed override value: %r -> %r (%s)", value, parsed_value, type(parsed_value))
+            self.log.info("Parsed override value: %r -> %r (%s)", value, parsed_value, type(parsed_value))
             if isinstance(pointer, list) and parts[-1] < 0:
                 pointer.append(parsed_value)
             else:
@@ -317,9 +317,12 @@ class ConfigOverrider(object):
         try:
             value = json.loads(override)
             if isinstance(value, string_types):
-                return override
-            else:
-                return value
+                try:
+                    json.loads(value)
+                    return value
+                except ValueError:
+                    return override
+            return value
         except ValueError:
             return override
 

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -292,6 +292,10 @@ class ConfigOverrider(object):
         else:
             parsed_value = self.__parse_override_value(value)
             self.log.info("Parsed override value: %r -> %r (%s)", value, parsed_value, type(parsed_value))
+            if isinstance(parsed_value, dict):
+                dict_value = BetterDict()
+                dict_value.merge(parsed_value)
+                parsed_value = dict_value
             if isinstance(pointer, list) and parts[-1] < 0:
                 pointer.append(parsed_value)
             else:

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -318,6 +318,8 @@ class ConfigOverrider(object):
         :param override:
         :return: Any
         """
+        if not override:
+            return None
         try:
             value = json.loads(override)
             if isinstance(value, string_types):

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -291,7 +291,7 @@ class ConfigOverrider(object):
                 self.log.debug("No value to delete: %s", item)
         else:
             parsed_value = self.__parse_override_value(value)
-            self.log.info("Parsed override value: %r -> %r (%s)", value, parsed_value, type(parsed_value))
+            self.log.debug("Parsed override value: %r -> %r (%s)", value, parsed_value, type(parsed_value))
             if isinstance(parsed_value, dict):
                 dict_value = BetterDict()
                 dict_value.merge(parsed_value)

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -6,6 +6,7 @@
  - fix Gatling `download-link` option handling
  - add Tsung support for Mac OS (and for non-standard installations of Tsung)
  - fix `browser-open` regression
+ - allow CLI overrides to be arbitrary YAML values
 
 ## 1.4.4 <sup>25 apr 2016</sup>
  - fix enhanced PBench schedule generation crash on Python 3

--- a/site/dat/docs/CommandLine.md
+++ b/site/dat/docs/CommandLine.md
@@ -59,6 +59,29 @@ The following override example creates the `data-sources` list (as it isn't spec
 bzt -o execution.scenario.data-sources.0=data.csv config.yaml
 ```
 
+Note that Taurus parses overridden values as YAML. This means that you can override all types of values: numbers,
+strings, booleans and even lists and objects. Also, YAML is a superset of JSON, so you can use JSON syntax too.
+
+Example:
+```bash
+# overriding JMeter property with a floating-point number
+bzt -o modules.jmeter.properties.pi=3.141592 script.yaml
+
+# overriding requests list in scenario
+# (note that you have to take whole override value in quotes because quotes and brackets have special meaning in shell)
+bzt -o scenarios.my-scenario.requests="['http://example.com/', 'http://blazedemo.com/']" script.yaml
+
+# overriding objects
+bzt -o scenarios.my-scenario="{default-address: 'http://blazedemo.com/', requests: ['/', '/reserve.php']}" script.yaml
+```
+
+And if you need to pass a string with quotations, you have to add an escaped level of quotes to it:
+
+```bash
+# this will set JMeter property `name` to value `"string with quotes"`.
+bzt -o modules.jmeter.properties.name='"\"string with quotes\""' script.yaml
+```
+
 ## Aliases
 
 There is a way to create some config chunks and apply them from command-line like this: `bzt -gui-mode -scenario1`

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -167,3 +167,6 @@ class TestConfigOverrider(BZTestCase):
         self.obj.apply_overrides(['man={"name": "Robert \\"Destroyer of Worlds\\" Oppenheimer"}'], self.config)
         self.assertEqual(self.config.get("man").get("name"), str('Robert "Destroyer of Worlds" Oppenheimer'))
 
+    def test_no_override(self):
+        self.obj.apply_overrides(['nothing='], self.config)
+        self.assertEqual(self.config.get("nothing"), None)

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -131,25 +131,39 @@ class TestConfigOverrider(BZTestCase):
 
     def test_numbers(self):
         self.obj.apply_overrides(["int=11", "float=3.14"], self.config)
-        self.assertEqual(self.config.get("int"), 11)
-        self.assertEqual(self.config.get("float"), 3.14)
+        self.assertEqual(self.config.get("int"), int(11))
+        self.assertEqual(self.config.get("float"), float(3.14))
 
     def test_booleans(self):
         self.obj.apply_overrides(["yes=true", "no=false"], self.config)
-        self.assertEqual(self.config.get("yes"), True)
-        self.assertEqual(self.config.get("no"), False)
+        self.assertEqual(self.config.get("yes"), bool(True))
+        self.assertEqual(self.config.get("no"), bool(False))
 
     def test_strings(self):
         self.obj.apply_overrides(["plain=ima plain string",
                                   'quoted="ima quoted string"'], self.config)
-        self.assertEqual(self.config.get("plain"), "ima plain string")
-        self.assertEqual(self.config.get("quoted"), '"ima quoted string"')
+        self.assertEqual(self.config.get("plain"), str("ima plain string"))
+        self.assertEqual(self.config.get("quoted"), str('"ima quoted string"'))
 
     def test_strings_literals_clash(self):
         # what if we want to pass literal string 'true' (and not have it converted to bool(True))
         self.obj.apply_overrides(['yes="true"'], self.config)
-        self.assertEqual(self.config.get("yes"), "true")
+        self.assertEqual(self.config.get("yes"), str("true"))
 
     def test_null(self):
         self.obj.apply_overrides(['nothing=null'], self.config)
         self.assertEqual(self.config.get("nothing"), None)
+
+    def test_objects(self):
+        self.obj.apply_overrides(['obj={"key": "value"}'], self.config)
+        self.assertEqual(self.config.get("obj").get("key"), str("value"))
+
+    def test_lists(self):
+        self.obj.apply_overrides(['list=[1, 2.0, "str", []]'], self.config)
+        self.assertEqual(self.config.get("list"), list([1, 2.0, "str", []]))
+
+    def test_nested_quotation(self):
+        # bzt -o man='{"name": "Robert \"Destroyer of Worlds\" Oppenheimer"}'
+        self.obj.apply_overrides(['man={"name": "Robert \\"Destroyer of Worlds\\" Oppenheimer"}'], self.config)
+        self.assertEqual(self.config.get("man").get("name"), str('Robert "Destroyer of Worlds" Oppenheimer'))
+

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -148,9 +148,11 @@ class TestConfigOverrider(BZTestCase):
         self.assertEqual(self.config.get("empty-quoted"), str('""'))
 
     def test_strings_literals_clash(self):
-        # what if we want to pass literal string 'true' (and not have it converted to bool(True))
-        self.obj.apply_overrides(['yes="true"'], self.config)
+        # we want to pass literal string 'true' (and not have it converted to bool(True))
+        self.obj.apply_overrides(['yes="true"',
+                                  'list="[1,2,3]"'], self.config)
         self.assertEqual(self.config.get("yes"), str("true"))
+        self.assertEqual(self.config.get("list"), str("[1,2,3]"))
 
     def test_null(self):
         self.obj.apply_overrides(['nothing=null'], self.config)

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -141,9 +141,11 @@ class TestConfigOverrider(BZTestCase):
 
     def test_strings(self):
         self.obj.apply_overrides(["plain=ima plain string",
-                                  'quoted="ima quoted string"'], self.config)
+                                  'quoted="ima quoted string"',
+                                  'empty-quoted=""'], self.config)
         self.assertEqual(self.config.get("plain"), str("ima plain string"))
         self.assertEqual(self.config.get("quoted"), str('"ima quoted string"'))
+        self.assertEqual(self.config.get("empty-quoted"), str('""'))
 
     def test_strings_literals_clash(self):
         # what if we want to pass literal string 'true' (and not have it converted to bool(True))

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -147,6 +147,12 @@ class TestConfigOverrider(BZTestCase):
 
     def test_strings_literals_clash(self):
         # what if we want to pass literal string 'true' (and not have it converted to json)
-        self.obj.apply_overrides(['yes="true"'], self.config)
+        self.obj.apply_overrides(['yes="true"', 'nothing="null"'], self.config)
         self.assertEqual(self.config.get("yes"), "true")
+        self.assertEqual(self.config.get("nothing"), "null")
+
+    def test_null(self):
+        self.obj.apply_overrides(['nothing=null'], self.config)
+        self.assertEqual(self.config.get("nothing"), None)
+
 

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -146,13 +146,10 @@ class TestConfigOverrider(BZTestCase):
         self.assertEqual(self.config.get("quoted"), '"ima quoted string"')
 
     def test_strings_literals_clash(self):
-        # what if we want to pass literal string 'true' (and not have it converted to json)
-        self.obj.apply_overrides(['yes="true"', 'nothing="null"'], self.config)
+        # what if we want to pass literal string 'true' (and not have it converted to bool(True))
+        self.obj.apply_overrides(['yes="true"'], self.config)
         self.assertEqual(self.config.get("yes"), "true")
-        self.assertEqual(self.config.get("nothing"), "null")
 
     def test_null(self):
         self.obj.apply_overrides(['nothing=null'], self.config)
         self.assertEqual(self.config.get("nothing"), None)
-
-

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -142,10 +142,14 @@ class TestConfigOverrider(BZTestCase):
     def test_strings(self):
         self.obj.apply_overrides(["plain=ima plain string",
                                   'quoted="ima quoted string"',
-                                  'empty-quoted=""'], self.config)
+                                  'empty-quoted=""',
+                                  'escaped="a "b" \'c\' d"',
+                                  'escaped-quoted="a "b" \'c\' d"'], self.config)
         self.assertEqual(self.config.get("plain"), str("ima plain string"))
         self.assertEqual(self.config.get("quoted"), str('"ima quoted string"'))
         self.assertEqual(self.config.get("empty-quoted"), str('""'))
+        self.assertEqual(self.config.get("escaped"), str('"a "b" \'c\' d"'))
+        self.assertEqual(self.config.get("escaped-quoted"), str('"a "b" \'c\' d"'))
 
     def test_strings_literals_clash(self):
         # we want to pass literal string 'true' (and not have it converted to bool(True))
@@ -159,10 +163,18 @@ class TestConfigOverrider(BZTestCase):
         self.assertEqual(self.config.get("nothing"), None)
 
     def test_objects(self):
+        self.config.merge({
+            "obj": {
+                "key": "142857",
+            },
+        })
         self.obj.apply_overrides(['obj={"key": "value"}'], self.config)
         self.assertEqual(self.config.get("obj").get("key"), str("value"))
 
     def test_lists(self):
+        self.config.merge({
+            "list": ["stuff"],
+        })
         self.obj.apply_overrides(['list=[1, 2.0, "str", []]'], self.config)
         self.assertEqual(self.config.get("list"), list([1, 2.0, "str", []]))
 

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -141,15 +141,15 @@ class TestConfigOverrider(BZTestCase):
 
     def test_strings(self):
         self.obj.apply_overrides(["plain=ima plain string",
-                                  'quoted=\'"ima quoted string"\'',
-                                  'empty-quoted=\'""\'',
-                                  'escaped="a "b" \'c\' d"',
-                                  'escaped-quoted="a "b" \'c\' d"'], self.config)
+                                  """quoted='"ima quoted string"'""",
+                                  """empty-quoted='""'""",
+                                  '''escaped="a "b" 'c' d"''',
+                                  '''escaped-quoted="a "b" 'c' d"'''], self.config)
         self.assertEqual(self.config.get("plain"), str("ima plain string"))
-        self.assertEqual(self.config.get("quoted"), str('"ima quoted string"'))
+        self.assertEqual(self.config.get("quoted"), str('''"ima quoted string"'''))
         self.assertEqual(self.config.get("empty-quoted"), str('""'))
-        self.assertEqual(self.config.get("escaped"), str('"a "b" \'c\' d"'))
-        self.assertEqual(self.config.get("escaped-quoted"), str('"a "b" \'c\' d"'))
+        self.assertEqual(self.config.get("escaped"), str('''"a "b" 'c' d"'''))
+        self.assertEqual(self.config.get("escaped-quoted"), str('''"a "b" 'c' d"'''))
 
     def test_strings_literals_clash(self):
         # we want to pass literal string 'true' (and not have it converted to bool(True))
@@ -180,9 +180,13 @@ class TestConfigOverrider(BZTestCase):
 
     def test_nested_quotation(self):
         # bzt -o man='{"name": "Robert \"Destroyer of Worlds\" Oppenheimer"}'
-        self.obj.apply_overrides(['man={"name": "Robert \\"Destroyer of Worlds\\" Oppenheimer"}'], self.config)
+        self.obj.apply_overrides(['''man={"name": "Robert \\"Destroyer of Worlds\\" Oppenheimer"}'''], self.config)
         self.assertEqual(self.config.get("man").get("name"), str('Robert "Destroyer of Worlds" Oppenheimer'))
 
     def test_no_override(self):
         self.obj.apply_overrides(['nothing='], self.config)
         self.assertEqual(self.config.get("nothing"), None)
+
+    def test_unquoted_keys(self):
+        self.obj.apply_overrides(['obj={abc: def}'], self.config)
+        self.assertEqual(self.config.get("obj").get("abc"), str("def"))

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -141,8 +141,8 @@ class TestConfigOverrider(BZTestCase):
 
     def test_strings(self):
         self.obj.apply_overrides(["plain=ima plain string",
-                                  'quoted="ima quoted string"',
-                                  'empty-quoted=""',
+                                  'quoted=\'"ima quoted string"\'',
+                                  'empty-quoted=\'""\'',
                                   'escaped="a "b" \'c\' d"',
                                   'escaped-quoted="a "b" \'c\' d"'], self.config)
         self.assertEqual(self.config.get("plain"), str("ima plain string"))


### PR DESCRIPTION
This should resolve floating-point vs. whole numbers conflict and will also:
* Allow users to override list/dict values directly with one option (instead of having a `-o` option for every list/dict element) (e.g `bzt config.yml -o execution.0.scenario.requests=["http://example.com/", "http://blazedemo.com/"]`)
* Properly handle overrides for boolean values and null values


TODO:
- Needs some work to play well with string quotations/escapes (i.e. should `bzt -o foo.bar="true"` be recognized as a string `true`, as a boolean `true` or as a quoted string `"true"`?)