### PR TITLE
Fix JUnit reporting for pass-fail criteria without `label` property

### DIFF
--- a/bzt/modules/reporting.py
+++ b/bzt/modules/reporting.py
@@ -370,7 +370,7 @@ class JUnitXMLReporter(Reporter, AggregatorListener):
         return root_xml_element
 
     def __process_criteria(self, classname, fc_obj, report_urls):
-        if fc_obj.config['label']:
+        if 'label' in fc_obj.config:
             data = (fc_obj.config['subject'], fc_obj.config['label'],
                     fc_obj.config['condition'], fc_obj.config['threshold'])
             tpl = "%s of %s%s%s"

--- a/site/dat/docs/Services.md
+++ b/site/dat/docs/Services.md
@@ -247,8 +247,8 @@ services:
 - module: passfail
   criterias:
   - class: bzt.modules.monitoring.MonitoringCriteria
-    subject: 127.0.0.1/cpu:idle
-    condition: '<'
-    threshold: 5
+    subject: local/cpu
+    condition: '>'
+    threshold: 90
     timeframe: 5s
 ```

--- a/tests/modules/test_JUnitXMLReporter.py
+++ b/tests/modules/test_JUnitXMLReporter.py
@@ -298,3 +298,25 @@ class TestJUnitXML(BZTestCase):
         rep.parameters.merge({'test': 'test2'})
         report_info = obj.get_bza_report_info()
         self.assertEqual(report_info, [('BlazeMeter report link: url2\n', 'test2')])
+
+    def test_report_criteria_without_label(self):
+        obj = JUnitXMLReporter()
+        obj.engine = EngineEmul()
+        obj.parameters = BetterDict()
+
+        pass_fail = PassFailStatus()
+
+        criteria = DataCriteria({'stop': True, 'fail': True, 'timeframe': -1, 'threshold': '150ms',
+                                 'condition': '<', 'subject': 'avg-rt'},
+                                pass_fail)
+        pass_fail.criterias.append(criteria)
+        criteria.is_triggered = True
+
+        obj.engine.reporters.append(pass_fail)
+
+        path_from_config = tempfile.mktemp(suffix='.xml', prefix='junit-xml_passfail', dir=obj.engine.artifacts_dir)
+        obj.parameters.merge({"filename": path_from_config, "data-source": "pass-fail"})
+        obj.prepare()
+        obj.last_second = DataPoint(0)
+        obj.post_process()
+


### PR DESCRIPTION
+ correct documentation sample on using pass-fail criteria on monitoring data.