### PR TITLE
Add `loop` logic blocks for JMeter 

### DIFF
--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -917,10 +917,15 @@ class JMX(object):
         return controller
 
     @staticmethod
-    def _get_loop_controller(loops, loop_forever):
+    def _get_loop_controller(loops):
+        loop_forever = loops == 'forever'
+        if loop_forever:
+            iterations = -1
+        else:
+            iterations = loops
         controller = etree.Element("LoopController", guiclass="LoopControllerPanel", testclass="LoopController",
                                    testname="Loop Controller")
         controller.append(JMX._bool_prop("LoopController.continue_forever", loop_forever))
-        controller.append(JMX._string_prop("LoopController.loops", str(loops)))
+        controller.append(JMX._string_prop("LoopController.loops", str(iterations)))
         return controller
 

--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -921,6 +921,6 @@ class JMX(object):
         controller = etree.Element("LoopController", guiclass="LoopControllerPanel", testclass="LoopController",
                                    testname="Loop Controller")
         controller.append(JMX._bool_prop("LoopController.continue_forever", loop_forever))
-        controller.append(JMX.int_prop("LoopController.loops", loops))
+        controller.append(JMX._string_prop("LoopController.loops", str(loops)))
         return controller
 

--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -915,3 +915,12 @@ class JMX(object):
                                    testname="If Controller")
         controller.append(JMX._string_prop("IfController.condition", condition))
         return controller
+
+    @staticmethod
+    def _get_loop_controller(loops, loop_forever):
+        controller = etree.Element("LoopController", guiclass="LoopControllerPanel", testclass="LoopController",
+                                   testname="Loop Controller")
+        controller.append(JMX._bool_prop("LoopController.continue_forever", loop_forever))
+        controller.append(JMX.int_prop("LoopController.loops", loops))
+        return controller
+

--- a/bzt/jmx2yaml.py
+++ b/bzt/jmx2yaml.py
@@ -104,24 +104,6 @@ class JMXasDict(JMX):
             self.log.debug("stringProp %s was not found in %s element!", prop_name, element.tag)
             return default
 
-    def _get_int_prop(self, element, prop_name, default=None):
-        """
-        Gets string prop from element
-        :param element:
-        :param prop_name:
-        :return:
-        """
-        prop_element = element.find(".//intProp[@name='" + prop_name + "']")
-        if prop_element is not None and prop_element.text:
-            if prop_element.text.isdigit():
-                return int(prop_element.text)
-            else:
-                self.log.debug("intProp %s in %s doesn't contain integer", prop_name, element.tag)
-                return default
-        else:
-            self.log.debug("stringProp %s was not found in %s element!", prop_name, element.tag)
-            return default
-
     def _get_concurrency(self, element):
         """
         concurrency option in tg execution settings
@@ -857,7 +839,9 @@ class JMXasDict(JMX):
         return {'if': condition, 'then': requests}
 
     def __extract_loop_controller(self, controller, ht_element):
-        iterations = self._get_int_prop(controller, "LoopController.loops", 1)
+        iterations = self._get_string_prop(controller, "LoopController.loops")
+        if iterations.isdigit():
+            iterations = int(iterations)
         forever = self._get_bool_prop(controller, "LoopController.continue_forever")
         requests = self.__extract_requests(ht_element)
         loops = 'forever' if forever else iterations

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1380,11 +1380,7 @@ class JMeterScenarioBuilder(JMX):
     def compile_loop_block(self, block):
         elements = []
 
-        if block.loops == 'forever':
-            iterations, loop_forever = -1, True
-        else:
-            iterations, loop_forever = block.loops, False
-        loop_controller = JMX._get_loop_controller(iterations, loop_forever)
+        loop_controller = JMX._get_loop_controller(block.loops)
         children = etree.Element("hashTree")
         for compiled in self.compile_requests(block.requests):
             for element in compiled:

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1634,8 +1634,6 @@ class RequestsParser(object):
             return IfBlock(condition, then_requests, else_requests, req)
         elif 'loop' in req:
             loops = req.get("loop")
-            if not isinstance(loops, int) and not loops == "forever":
-                raise ValueError("Value of `loop` should be either integer or 'forever'")
             do_block = req.get("do")
             if not do_block:
                 raise ValueError("`do` field is mandatory for loop blocks")

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1380,8 +1380,11 @@ class JMeterScenarioBuilder(JMX):
     def compile_loop_block(self, block):
         elements = []
 
-        loop_forever = block.loops == 'forever'
-        loop_controller = JMX._get_loop_controller(block.loops, loop_forever)
+        if block.loops == 'forever':
+            iterations, loop_forever = -1, True
+        else:
+            iterations, loop_forever = block.loops, False
+        loop_controller = JMX._get_loop_controller(iterations, loop_forever)
         children = etree.Element("hashTree")
         for compiled in self.compile_requests(block.requests):
             for element in compiled:

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -6,7 +6,7 @@
  - add `delete-test-files` option to cloud provisioning
  - fix reading piped config from stdin
  - don't trap KeyboardInterrupt in tool install
- - add [`if` blocks](JMeter.md#Logic-blocks) to `scenario.requests` syntax for JMeter
+ - add [logic blocks](JMeter.md#Logic-blocks) to `scenario.requests` syntax for JMeter
 
 ## 1.5.0 <sup>4 may 2016</sup>
  - add [Tsung](Tsung.md) executor

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -6,7 +6,7 @@
  - add `delete-test-files` option to cloud provisioning
  - fix reading piped config from stdin
  - don't trap KeyboardInterrupt in tool install
- - add [logic blocks](JMeter.md#Logic-blocks) to `scenario.requests` syntax for JMeter
+ - add [logic blocks](JMeter.md#Logic-Blocks) to `scenario.requests` syntax for JMeter
 
 ## 1.5.0 <sup>4 may 2016</sup>
  - add [Tsung](Tsung.md) executor

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -388,10 +388,16 @@ scenarios:
 ```
 
 
-#### Logic blocks
+#### Logic Blocks
 
-The only kind of logic block Taurus supports right now is `if` block. `if` blocks allow conditional execution of
-HTTP requests.
+
+Taurus allows to control execution flow with the following constructs:
+- `if` blocks
+- `loop` blocks
+
+##### If Blocks
+
+`if` blocks allow conditional execution of HTTP requests.
 
 Each `if` block should contain a mandatory `then` field, and an optional `else` field. Both `then` and `else` fields
 should contain lists of requests.
@@ -446,6 +452,29 @@ scenario:
     then:
       - https://example.com/${username}
 ```
+
+##### Loop Blocks
+
+`loop` blocks allow repeated execution of requests. Nested requests are to be specified with `do` field.
+
+```yaml
+scenario:
+  requests:
+  - loop: 10
+    do:
+    - http://blazedemo.com/
+```
+
+If you want to loop requests forever, you can specify string `forever` as `loop` value.
+```yaml
+scenario:
+  requests:
+  - loop: forever
+    do:
+    - http://blazedemo.com/
+```
+
+Note that `loop` blocks correspond to JMeter's `Loop Controllers`.
 
 
 ## JMeter Test Log

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1174,6 +1174,103 @@ class TestJMeterExecutor(BZTestCase):
         res_files = self.obj.resource_files()
         self.assertEqual(len(res_files), 2)
 
+    def test_request_logic_loop(self):
+        self.obj.engine.config.merge({
+            'execution': {
+                'scenario': {
+                    "requests": [
+                        {
+                            "loop": 10,
+                            "do": [
+                                "http://blazedemo.com/",
+                            ],
+                        }
+                    ],
+                }
+            },
+        })
+        self.obj.engine.config.merge({"provisioning": "local"})
+        self.obj.execution = self.obj.engine.config['execution']
+        self.obj.settings.merge(self.obj.engine.config.get("modules").get("jmeter"))
+        self.obj.prepare()
+        xml_tree = etree.fromstring(open(self.obj.modified_jmx, "rb").read())
+        controller = xml_tree.find(".//LoopController")
+        self.assertIsNotNone(controller)
+        loops = xml_tree.find(".//LoopController/intProp[@name='LoopController.loops']")
+        self.assertEqual(loops.text, "10")
+        forever = xml_tree.find(".//LoopController/boolProp[@name='LoopController.continue_forever']")
+        self.assertEqual(forever.text, "false")
+
+    def test_request_logic_loop_forever(self):
+        self.obj.engine.config.merge({
+            'execution': {
+                'scenario': {
+                    "requests": [
+                        {
+                            "loop": "forever",
+                            "do": [
+                                "http://blazedemo.com/",
+                            ],
+                        }
+                    ],
+                }
+            },
+        })
+        self.obj.engine.config.merge({"provisioning": "local"})
+        self.obj.execution = self.obj.engine.config['execution']
+        self.obj.settings.merge(self.obj.engine.config.get("modules").get("jmeter"))
+        self.obj.prepare()
+        xml_tree = etree.fromstring(open(self.obj.modified_jmx, "rb").read())
+        controller = xml_tree.find(".//LoopController")
+        self.assertIsNotNone(controller)
+        forever = xml_tree.find(".//LoopController/boolProp[@name='LoopController.continue_forever']")
+        self.assertEqual(forever.text, "true")
+
+    def test_request_logic_loop_invalid(self):
+        self.obj.engine.config.merge({
+            'execution': {
+                'scenario': {
+                    "requests": [
+                        {
+                            "loop": "one hundred times",
+                            "do": [
+                                "http://blazedemo.com/",
+                            ],
+                        }
+                    ],
+                }
+            },
+        })
+        self.obj.engine.config.merge({"provisioning": "local"})
+        self.obj.execution = self.obj.engine.config['execution']
+        self.obj.settings.merge(self.obj.engine.config.get("modules").get("jmeter"))
+        self.assertRaises(ValueError, self.obj.prepare)
+
+    def test_resource_files_loops(self):
+        self.obj.engine.config.merge({
+            'execution': {
+                'scenario': {
+                    "requests": [
+                        {
+                            "loop": 100,
+                            "do": [
+                                {
+                                    "url": "http://demo.blazemeter.com/",
+                                    "method": "POST",
+                                    "body-file": __dir__() + "/../jmeter/jmx/dummy.jmx",
+                                },
+                            ],
+                        }
+                    ],
+                }
+            },
+        })
+        self.obj.engine.config.merge({"provisioning": "local"})
+        self.obj.execution = self.obj.engine.config['execution']
+        res_files = self.obj.resource_files()
+        self.assertEqual(len(res_files), 1)
+
+
 
 class TestJMX(BZTestCase):
     def test_jmx_unicode_checkmark(self):

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1196,7 +1196,7 @@ class TestJMeterExecutor(BZTestCase):
         xml_tree = etree.fromstring(open(self.obj.modified_jmx, "rb").read())
         controller = xml_tree.find(".//LoopController")
         self.assertIsNotNone(controller)
-        loops = xml_tree.find(".//LoopController/intProp[@name='LoopController.loops']")
+        loops = xml_tree.find(".//LoopController/stringProp[@name='LoopController.loops']")
         self.assertEqual(loops.text, "10")
         forever = xml_tree.find(".//LoopController/boolProp[@name='LoopController.continue_forever']")
         self.assertEqual(forever.text, "false")
@@ -1225,26 +1225,6 @@ class TestJMeterExecutor(BZTestCase):
         self.assertIsNotNone(controller)
         forever = xml_tree.find(".//LoopController/boolProp[@name='LoopController.continue_forever']")
         self.assertEqual(forever.text, "true")
-
-    def test_request_logic_loop_invalid(self):
-        self.obj.engine.config.merge({
-            'execution': {
-                'scenario': {
-                    "requests": [
-                        {
-                            "loop": "one hundred times",
-                            "do": [
-                                "http://blazedemo.com/",
-                            ],
-                        }
-                    ],
-                }
-            },
-        })
-        self.obj.engine.config.merge({"provisioning": "local"})
-        self.obj.execution = self.obj.engine.config['execution']
-        self.obj.settings.merge(self.obj.engine.config.get("modules").get("jmeter"))
-        self.assertRaises(ValueError, self.obj.prepare)
 
     def test_resource_files_loops(self):
         self.obj.engine.config.merge({

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1225,6 +1225,8 @@ class TestJMeterExecutor(BZTestCase):
         self.assertIsNotNone(controller)
         forever = xml_tree.find(".//LoopController/boolProp[@name='LoopController.continue_forever']")
         self.assertEqual(forever.text, "true")
+        loops = xml_tree.find(".//LoopController/stringProp[@name='LoopController.loops']")
+        self.assertEqual(loops.text, "-1")
 
     def test_resource_files_loops(self):
         self.obj.engine.config.merge({

--- a/tests/yaml/converter/controllers.jmx
+++ b/tests/yaml/converter/controllers.jmx
@@ -78,6 +78,32 @@
             <hashTree/>
           </hashTree>
         </hashTree>
+        <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">true</boolProp>
+          <stringProp name="LoopController.loops">10</stringProp>
+        </LoopController>
+        <hashTree>
+          <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="HTTP Request" enabled="true">
+            <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+              <collectionProp name="Arguments.arguments"/>
+            </elementProp>
+            <stringProp name="HTTPSampler.domain">example.com</stringProp>
+            <stringProp name="HTTPSampler.port"></stringProp>
+            <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+            <stringProp name="HTTPSampler.response_timeout"></stringProp>
+            <stringProp name="HTTPSampler.protocol"></stringProp>
+            <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+            <stringProp name="HTTPSampler.path">/</stringProp>
+            <stringProp name="HTTPSampler.method">GET</stringProp>
+            <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+            <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+            <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+            <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+            <boolProp name="HTTPSampler.monitor">false</boolProp>
+            <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          </HTTPSamplerProxy>
+          <hashTree/>
+        </hashTree>
         <ForeachController guiclass="ForeachControlPanel" testclass="ForeachController" testname="ForEach Controller" enabled="true">
           <stringProp name="ForeachController.inputVal"></stringProp>
           <stringProp name="ForeachController.returnVal"></stringProp>

--- a/tests/yaml/converter/controllers.jmx
+++ b/tests/yaml/converter/controllers.jmx
@@ -79,8 +79,8 @@
           </hashTree>
         </hashTree>
         <LoopController guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
-          <boolProp name="LoopController.continue_forever">true</boolProp>
-          <stringProp name="LoopController.loops">10</stringProp>
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">42</stringProp>
         </LoopController>
         <hashTree>
           <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="HTTP Request" enabled="true">

--- a/tests/yaml/converter/controllers.yml
+++ b/tests/yaml/converter/controllers.yml
@@ -18,6 +18,11 @@ scenarios:
         - label: BD/reserve
           method: GET
           url: http://blazedemo.com/reserve.php
+    - do:
+      - label: HTTP Request
+        method: GET
+        url: http://example.com/
+      loop: forever
     - label: demo/BM
       method: GET
       url: http://demo.blazemeter.com/

--- a/tests/yaml/converter/controllers.yml
+++ b/tests/yaml/converter/controllers.yml
@@ -22,7 +22,7 @@ scenarios:
       - label: HTTP Request
         method: GET
         url: http://example.com/
-      loop: forever
+      loop: 42
     - label: demo/BM
       method: GET
       url: http://demo.blazemeter.com/


### PR DESCRIPTION
[Full proposal text](https://gist.github.com/dmand/0076bd99f0da5fa02572212405eba454).

Syntax example:
```yaml
scenario:
  requests:
  - loop: 20
    do:
    - http://blazedemo.com/
```

Checklist:
- [x] Parse loop blocks from scenario.requests
- [x] Compile loop blocks to JMeter Loop Controllers
- [x] jmx2yaml
- [x] Docs
- [x] Changelog