### PR TITLE
Add `foreach` block to JMeter

### DIFF
--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -930,17 +930,13 @@ class JMX(object):
         return controller
 
     @staticmethod
-    def _get_foreach_controller(input_var, loop_var, start_index, stop_index):
+    def _get_foreach_controller(input_var, loop_var):
         # TODO: useSeparator option
         controller = etree.Element("ForeachController", guiclass="ForeachControlPanel", testclass="ForeachController",
                                    testname="ForEach Controller")
         controller.append(JMX._string_prop("ForeachController.inputVal", input_var))
         controller.append(JMX._string_prop("ForeachController.returnVal", loop_var))
         controller.append(JMX._bool_prop("ForeachController.useSeparator", True))
-        if start_index is not None:
-            controller.append(JMX._string_prop("ForeachController.startIndex", start_index))
-        if stop_index is not None:
-            controller.append(JMX._string_prop("ForeachController.endIndex", stop_index))
         return controller
 
     @staticmethod

--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -934,8 +934,9 @@ class JMX(object):
         # TODO: useSeparator option
         controller = etree.Element("ForeachController", guiclass="ForeachControlPanel", testclass="ForeachController",
                                    testname="ForEach Controller")
+        return_val = loop_var if loop_var is not None else ""
         controller.append(JMX._string_prop("ForeachController.inputVal", input_var))
-        controller.append(JMX._string_prop("ForeachController.returnVal", loop_var))
+        controller.append(JMX._string_prop("ForeachController.returnVal", return_val))
         controller.append(JMX._bool_prop("ForeachController.useSeparator", True))
         return controller
 

--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -928,7 +928,7 @@ class JMX(object):
         controller.append(JMX._bool_prop("LoopController.continue_forever", loop_forever))
         controller.append(JMX._string_prop("LoopController.loops", str(iterations)))
         return controller
-  
+
     @staticmethod
     def _get_foreach_controller(input_var, loop_var, start_index, stop_index):
         # TODO: useSeparator option

--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -934,9 +934,8 @@ class JMX(object):
         # TODO: useSeparator option
         controller = etree.Element("ForeachController", guiclass="ForeachControlPanel", testclass="ForeachController",
                                    testname="ForEach Controller")
-        return_val = loop_var if loop_var is not None else ""
         controller.append(JMX._string_prop("ForeachController.inputVal", input_var))
-        controller.append(JMX._string_prop("ForeachController.returnVal", return_val))
+        controller.append(JMX._string_prop("ForeachController.returnVal", loop_var))
         controller.append(JMX._bool_prop("ForeachController.useSeparator", True))
         return controller
 

--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -928,6 +928,20 @@ class JMX(object):
         controller.append(JMX._bool_prop("LoopController.continue_forever", loop_forever))
         controller.append(JMX._string_prop("LoopController.loops", str(iterations)))
         return controller
+  
+    @staticmethod
+    def _get_foreach_controller(input_var, loop_var, start_index, stop_index):
+        # TODO: useSeparator option
+        controller = etree.Element("ForeachController", guiclass="ForeachControlPanel", testclass="ForeachController",
+                                   testname="ForEach Controller")
+        controller.append(JMX._string_prop("ForeachController.inputVal", input_var))
+        controller.append(JMX._string_prop("ForeachController.returnVal", loop_var))
+        controller.append(JMX._bool_prop("ForeachController.useSeparator", True))
+        if start_index is not None:
+            controller.append(JMX._string_prop("ForeachController.startIndex", start_index))
+        if stop_index is not None:
+            controller.append(JMX._string_prop("ForeachController.endIndex", stop_index))
+        return controller
 
     @staticmethod
     def _get_while_controller(condition):

--- a/bzt/jmx2yaml.py
+++ b/bzt/jmx2yaml.py
@@ -54,6 +54,7 @@ KNOWN_TAGS = ["hashTree", "jmeterTestPlan", "TestPlan", "ResultCollector",
               "IfController",
               "LoopController",
               "WhileController",
+              "ForeachController",
               ]
 
 
@@ -830,6 +831,10 @@ class JMXasDict(JMX):
                 hash_tree = next(children)
                 while_block = self.__extract_while_controller(elem, hash_tree)
                 requests.append(while_block)
+            elif elem.tag == 'ForeachController':
+                hash_tree = next(children)
+                block = self.__extract_foreach_controller(elem, hash_tree)
+                requests.append(block)
             elif elem.tag == 'HTTPSamplerProxy':
                 request = self._get_request_settings(elem)
                 requests.append(request)
@@ -856,6 +861,20 @@ class JMXasDict(JMX):
         condition = self._get_string_prop(controller, "WhileController.condition")
         requests = self.__extract_requests(ht_element)
         return {'while': condition, 'do': requests}
+
+    def __extract_foreach_controller(self, controller, ht_element):
+        block = {}
+        block['foreach'] = self._get_string_prop(controller, "ForeachController.inputVal", default="")
+        block['loop-variable'] = self._get_string_prop(controller, "ForeachController.returnVal", default="")
+
+        start_index = self._get_string_prop(controller, "ForeachController.startIndex")
+        end_index = self._get_string_prop(controller, "ForeachController.endIndex")
+
+        if start_index is not None and end_index is not None:
+            block['range'] = '%s to %s' % (start_index, end_index)
+
+        block['requests'] = self.__extract_requests(ht_element)
+        return block
 
     def _get_request_settings(self, request_element):
         """

--- a/bzt/jmx2yaml.py
+++ b/bzt/jmx2yaml.py
@@ -866,7 +866,8 @@ class JMXasDict(JMX):
         input_var = self._get_string_prop(controller, "ForeachController.inputVal", default="")
         loop_var = self._get_string_prop(controller, "ForeachController.returnVal", default="")
         requests = self.__extract_requests(ht_element)
-        return {'foreach': input_var, 'loop-variable': loop_var, 'do': requests}
+        iteration_str = '%s in %s' % (loop_var, input_var)
+        return {'foreach': iteration_str, 'do': requests}
 
     def _get_request_settings(self, request_element):
         """

--- a/bzt/jmx2yaml.py
+++ b/bzt/jmx2yaml.py
@@ -863,18 +863,10 @@ class JMXasDict(JMX):
         return {'while': condition, 'do': requests}
 
     def __extract_foreach_controller(self, controller, ht_element):
-        block = {}
-        block['foreach'] = self._get_string_prop(controller, "ForeachController.inputVal", default="")
-        block['loop-variable'] = self._get_string_prop(controller, "ForeachController.returnVal", default="")
-
-        start_index = self._get_string_prop(controller, "ForeachController.startIndex")
-        end_index = self._get_string_prop(controller, "ForeachController.endIndex")
-
-        if start_index is not None and end_index is not None:
-            block['range'] = '%s to %s' % (start_index, end_index)
-
-        block['requests'] = self.__extract_requests(ht_element)
-        return block
+        input_var = self._get_string_prop(controller, "ForeachController.inputVal", default="")
+        loop_var = self._get_string_prop(controller, "ForeachController.returnVal", default="")
+        requests = self.__extract_requests(ht_element)
+        return {'foreach': input_var, 'loop-variable': loop_var, 'do': requests}
 
     def _get_request_settings(self, request_element):
         """

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1677,9 +1677,7 @@ class RequestsParser(object):
         if 'if' in req:
             condition = req.get("if")
             # TODO: apply some checks to `condition`?
-            then_clause = req.get("then")
-            if not then_clause:
-                raise ValueError("'then' clause is mandatory for 'if' blocks")
+            then_clause = req.get("then", ValueError("'then' clause is mandatory for 'if' blocks"))
             then_requests = self.__parse_requests(then_clause)
             else_clause = req.get("else", [])
             else_requests = self.__parse_requests(else_clause)

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1409,7 +1409,7 @@ class JMeterScenarioBuilder(JMX):
 
         elements = []
 
-        controller = JMX._get_foreach_controller(block.input_var, block.loop_var, block.start_index, block.end_index)
+        controller = JMX._get_foreach_controller(block.input_var, block.loop_var)
         children = etree.Element("hashTree")
         for compiled in self.compile_requests(block.requests):
             for element in compiled:
@@ -1657,18 +1657,16 @@ class WhileBlock(Request):
 
 
 class ForEachBlock(Request):
-    def __init__(self, input_var, loop_var, start_index, end_index, requests, config):
+    def __init__(self, input_var, loop_var, requests, config):
         super(ForEachBlock, self).__init__(config)
         self.input_var = input_var
         self.loop_var = loop_var
-        self.start_index = start_index
-        self.end_index = end_index
         self.requests = requests
 
     def __repr__(self):
         requests = [repr(req) for req in self.requests]
-        fmt = "ForEachBlock(input=%s, loop_var=%s, start=%s, end=%s, requests=%s)"
-        return fmt % (self.input_var, self.loop_var, self.start_index, self.end_index, requests)
+        fmt = "ForEachBlock(input=%s, loop_var=%s, requests=%s)"
+        return fmt % (self.input_var, self.loop_var, requests)
 
 
 class RequestsParser(object):
@@ -1699,18 +1697,9 @@ class RequestsParser(object):
         elif 'foreach' in req:
             input_var = req.get("foreach")
             loop_var = req.get("loop-variable")
-            loop_range = req.get("range")
-            if range:
-                match = re.match(r"(\d+) to (\d+)", loop_range)
-                if not match:
-                    raise ValueError("'range' value should be in format '<start> to <end>'")
-                start_index = int(match.group(1))
-                end_index = int(match.group(2))
-            else:
-                start_index = end_index = None
             do_block = req.get("do", ValueError("'do' field is mandatory for 'foreach' blocks"))
             do_requests = self.__parse_requests(do_block)
-            return ForEachBlock(input_var, loop_var, start_index, end_index, do_requests, req)
+            return ForEachBlock(input_var, loop_var, do_requests, req)
         else:
             url = req.get("url", ValueError("Option 'url' is mandatory for request"))
             label = req.get("label", url)

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1694,7 +1694,7 @@ class RequestsParser(object):
             return WhileBlock(condition, do_requests, req)
         elif 'foreach' in req:
             input_var = req.get("foreach")
-            loop_var = req.get("loop-variable")
+            loop_var = req.get("loop-variable", None)
             do_block = req.get("do", ValueError("'do' field is mandatory for 'foreach' blocks"))
             do_requests = self.__parse_requests(do_block)
             return ForEachBlock(input_var, loop_var, do_requests, req)

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1699,9 +1699,9 @@ class RequestsParser(object):
         elif 'foreach' in req:
             input_var = req.get("foreach")
             loop_var = req.get("loop-variable")
-            range = req.get("range")
+            loop_range = req.get("range")
             if range:
-                match = re.match(r"(\d+) to (\d+)", range)
+                match = re.match(r"(\d+) to (\d+)", loop_range)
                 if not match:
                     raise ValueError("'range' value should be in format '<start> to <end>'")
                 start_index = int(match.group(1))

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1693,8 +1693,11 @@ class RequestsParser(object):
             do_requests = self.__parse_requests(do_block)
             return WhileBlock(condition, do_requests, req)
         elif 'foreach' in req:
-            input_var = req.get("foreach")
-            loop_var = req.get("loop-variable", None)
+            iteration_str = req.get("foreach")
+            match = re.match(r'(.+) in (.+)', iteration_str)
+            if not match:
+                raise ValueError("'foreach' value should be in format '<elementName> in <collection>'")
+            loop_var, input_var = match.groups()
             do_block = req.get("do", ValueError("'do' field is mandatory for 'foreach' blocks"))
             do_requests = self.__parse_requests(do_block)
             return ForEachBlock(input_var, loop_var, do_requests, req)

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -495,14 +495,22 @@ scenario:
 
 `foreach` blocks allow you to iterate over a collection of values. They are compiled to JMeter `ForEach Controllers`.
 
+Syntax:
+```yaml
+requests:
+- foreach: <elementName> in <collection>
+  do:
+  - http://${elementName}/
+```
+
+Concrete example:
 ```yaml
 scenario:
   requests:
   - url: https://api.example.com/v1/media/search
     extract-jsonpath:
-      usernames: $.data.[:100].user.username
-  - foreach: usernames  
-    loop-variable: name  # `loop-variable` field is optional
+      usernames: $.data.[:100].user.username  # grab first 100 usernames
+  - foreach: name in usernames
     do:
     - https://example.com/user/${name}
 ```

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -395,6 +395,7 @@ Taurus allows to control execution flow with the following constructs:
 - `if` blocks
 - `loop` blocks
 - `while` blocks
+- `foreach` blocks
 
 ##### If Blocks
 
@@ -490,6 +491,21 @@ scenario:
     - http://blazedemo.com/
 ```
 
+##### Foreach Blocks
+
+`foreach` blocks allow you to iterate over a collection of values. They are compiled to JMeter `ForEach Controllers`.
+
+```yaml
+scenario:
+  requests:
+  - url: https://api.example.com/v1/media/search
+    extract-jsonpath:
+      usernames: $.data.[:100].user.username
+  - foreach: usernames  
+    loop-variable: name  # `loop-variable` field is optional
+    do:
+    - https://example.com/user/${name}
+```
 
 ## JMeter Test Log
 You can tune JTL file verbosity with option `write-xml-jtl`. Possible values are 'error' (default), 'full', or any other value for 'none'. Keep in mind: max verbosity can seriously load your system.

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1340,7 +1340,6 @@ class TestJMeterExecutor(BZTestCase):
                     "requests": [
                         {
                             "foreach": "usernames",
-                            "range": "1 to 10",
                             "loop-variable": "name",
                             "do": [
                                 "http://site.com/users/${name}",
@@ -1359,10 +1358,6 @@ class TestJMeterExecutor(BZTestCase):
         self.assertEqual(input.text, "usernames")
         loop_var = xml_tree.find(".//ForeachController/stringProp[@name='ForeachController.returnVal']")
         self.assertEqual(loop_var.text, "name")
-        start = xml_tree.find(".//ForeachController/stringProp[@name='ForeachController.startIndex']")
-        self.assertEqual(start.text, "1")
-        end = xml_tree.find(".//ForeachController/stringProp[@name='ForeachController.endIndex']")
-        self.assertEqual(end.text, "10")
 
 
 class TestJMX(BZTestCase):

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1340,8 +1340,7 @@ class TestJMeterExecutor(BZTestCase):
                 'scenario': {
                     "requests": [
                         {
-                            "foreach": "usernames",
-                            "loop-variable": "name",
+                            "foreach": "name in usernames",
                             "do": [
                                 "http://site.com/users/${name}",
                             ],
@@ -1360,39 +1359,13 @@ class TestJMeterExecutor(BZTestCase):
         loop_var = xml_tree.find(".//ForeachController/stringProp[@name='ForeachController.returnVal']")
         self.assertEqual(loop_var.text, "name")
 
-    def test_request_logic_foreach_no_iterator(self):
-        self.obj.engine.config.merge({
-            'execution': {
-                'scenario': {
-                    "requests": [
-                        {
-                            "foreach": "usernames",
-                            "do": [
-                                "http://site.com/",
-                            ],
-                        }
-                    ],
-                }
-            },
-            "provisioning": "local",
-        })
-        self.obj.execution = self.obj.engine.config['execution']
-        self.obj.prepare()
-        xml_tree = etree.fromstring(open(self.obj.modified_jmx, "rb").read())
-        self.assertIsNotNone(xml_tree.find(".//ForeachController"))
-        input = xml_tree.find(".//ForeachController/stringProp[@name='ForeachController.inputVal']")
-        self.assertEqual(input.text, "usernames")
-        loop_var = xml_tree.find(".//ForeachController/stringProp[@name='ForeachController.returnVal']")
-        self.assertEqual(loop_var.text, None)
-
     def test_request_logic_foreach_resources(self):
         self.obj.engine.config.merge({
             'execution': {
                 'scenario': {
                     "requests": [
                         {
-                            "foreach": "coll",
-                            "loop-variable": "item",
+                            "foreach": "item in coll",
                             "do": [
                                 {
                                     "url": "http://${item}.blazemeter.com/",

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1262,8 +1262,8 @@ class TestJMeterExecutor(BZTestCase):
                     ],
                 }
             },
-            "provisioning": "local",
         })
+        self.obj.engine.config.merge({"provisioning": "local"})
         self.obj.execution = self.obj.engine.config['execution']
         res_files = self.obj.resource_files()
         self.assertEqual(len(res_files), 1)

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1262,6 +1262,7 @@ class TestJMeterExecutor(BZTestCase):
                     ],
                 }
             },
+            "provisioning": "local",
         })
         self.obj.execution = self.obj.engine.config['execution']
         res_files = self.obj.resource_files()

--- a/tests/yaml/converter/controllers.jmx
+++ b/tests/yaml/converter/controllers.jmx
@@ -105,9 +105,11 @@
           <hashTree/>
         </hashTree>
         <ForeachController guiclass="ForeachControlPanel" testclass="ForeachController" testname="ForEach Controller" enabled="true">
-          <stringProp name="ForeachController.inputVal"></stringProp>
-          <stringProp name="ForeachController.returnVal"></stringProp>
+          <stringProp name="ForeachController.inputVal">input</stringProp>
+          <stringProp name="ForeachController.returnVal">output</stringProp>
           <boolProp name="ForeachController.useSeparator">true</boolProp>
+          <stringProp name="ForeachController.startIndex">1</stringProp>
+          <stringProp name="ForeachController.endIndex">10</stringProp>
         </ForeachController>
         <hashTree>
           <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="demo/BM" enabled="true">

--- a/tests/yaml/converter/controllers.yml
+++ b/tests/yaml/converter/controllers.yml
@@ -23,13 +23,12 @@ scenarios:
         method: GET
         url: http://example.com/
       loop: 42
-    - foreach: input
-      loop-variable: output
-      range: 1 to 10
-      requests:
+    - do:
       - label: demo/BM
         method: GET
         url: http://demo.blazemeter.com/
+      foreach: input
+      loop-variable: output
     - label: example.com/1
       method: GET
       url: http://example.com/1

--- a/tests/yaml/converter/controllers.yml
+++ b/tests/yaml/converter/controllers.yml
@@ -27,8 +27,7 @@ scenarios:
       - label: demo/BM
         method: GET
         url: http://demo.blazemeter.com/
-      foreach: input
-      loop-variable: output
+      foreach: output in input
     - label: example.com/1
       method: GET
       url: http://example.com/1

--- a/tests/yaml/converter/controllers.yml
+++ b/tests/yaml/converter/controllers.yml
@@ -23,9 +23,13 @@ scenarios:
         method: GET
         url: http://example.com/
       loop: 42
-    - label: demo/BM
-      method: GET
-      url: http://demo.blazemeter.com/
+    - foreach: input
+      loop-variable: output
+      range: 1 to 10
+      requests:
+      - label: demo/BM
+        method: GET
+        url: http://demo.blazemeter.com/
     - label: example.com/1
       method: GET
       url: http://example.com/1


### PR DESCRIPTION
This PR adds `foreach` blocks into JMeter requests. They allow to iterate over a collection of variables.

Example:
```yaml
scenario:
  requests:
  - url: https://api.instagram.com/v1/media/search
    body:
      access_token: shiny_new_token
      lat: 48.858844
      lng: 2.294351
    extract-jsonpath:
      status_code: $.meta.code
      usernames: $.data.[*].user.username
  - if: '"${status_code)" == "200"'
    then:
    - foreach: currentUser in usernames
      do:
        - http://instagram.com/${currentUser}
```


TODO
- [x] parse `foreach` blocks
- [x] compile `foreach` blocks to Foreach Controlers
- [x] jmx2yaml extractor
- [x] docs