### PR TITLE
Remove default heap size calculation for JMeter

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -29,7 +29,6 @@ from collections import Counter, namedtuple
 from distutils.version import LooseVersion
 from math import ceil
 
-import psutil
 from cssselect import GenericTranslator
 
 from bzt.engine import ScenarioExecutor, Scenario, FileLister

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -125,18 +125,11 @@ class JMeterExecutor(ScenarioExecutor, WidgetProvider, FileLister):
             JMeterExecutor.__write_props_to_file(sys_props_file, sys_props)
             self.sys_properties_file = sys_props_file
 
-    @staticmethod
-    def __calculate_default_heap_size():
-        memory = psutil.virtual_memory()
-        memory_mb = round(float(memory.total) / 1024 / 1024)
-        memory_limit = int(memory_mb * 0.5)
-        return "%dM" % memory_limit
-
     def __set_jvm_properties(self):
-        def_heap_size = JMeterExecutor.__calculate_default_heap_size()
-        heap_size = self.settings.get("memory-xmx", def_heap_size)
-        self.log.debug("Setting JVM heap size to %s", heap_size)
-        self._env["JVM_ARGS"] = "-Xmx%s" % heap_size
+        heap_size = self.settings.get("memory-xmx", None)
+        if heap_size is not None:
+            self.log.debug("Setting JVM heap size to %s", heap_size)
+            self._env["JVM_ARGS"] = "-Xmx%s" % heap_size
 
     def __set_jmeter_properties(self, scenario):
         props = self.settings.get("properties")

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -7,7 +7,7 @@
  - fix reading piped config from stdin
  - don't trap KeyboardInterrupt in tool install
  - add [logic blocks](JMeter.md#Logic-Blocks) to `scenario.requests` syntax for JMeter
- - remove default heap size calculation for JMeter
+ - remove default xmx set for JMeter
 
 ## 1.5.0 <sup>4 may 2016</sup>
  - add [Tsung](Tsung.md) executor

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -7,6 +7,7 @@
  - fix reading piped config from stdin
  - don't trap KeyboardInterrupt in tool install
  - add [logic blocks](JMeter.md#Logic-Blocks) to `scenario.requests` syntax for JMeter
+ - remove default heap size calculation for JMeter
 
 ## 1.5.0 <sup>4 may 2016</sup>
  - add [Tsung](Tsung.md) executor

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -547,8 +547,8 @@ execution
 
 ## JMeter JVM Memory Limit
 
-By default Taurus will allow JMeter to use up to 50% of your RAM. You can tweak JMeter's memory limit with `memory-xmx`
-option. Use `K`, `M` or `G` suffixes to specify memory limit in kilobytes, megabytes or gigabytes.
+You can tweak JMeter's memory limit (aka, `-Xmx` JVM option) with `memory-xmx` setting.
+Use `K`, `M` or `G` suffixes to specify memory limit in kilobytes, megabytes or gigabytes.
 
 Example:
 ```yaml

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -966,20 +966,6 @@ class TestJMeterExecutor(BZTestCase):
         self.obj.post_process()
         self.assertIn("-Xmx2G", str(stdout))
 
-    def test_jvm_heap_default_value(self):
-        self.obj.engine.config.merge({'execution': {'iterations': 1,
-                                               'scenario': {'script': __dir__() + '/../jmeter/jmx/http.jmx'}}})
-        self.obj.engine.config.merge({"provisioning": "local"})
-        self.obj.execution = self.obj.engine.config['execution']
-        self.obj.settings.merge(self.obj.engine.config.get("modules").get("jmeter"))
-        self.obj.prepare()
-        self.obj._env['TEST_MODE'] = 'heap'
-        self.obj.startup()
-        stdout, _ = self.obj.process.communicate()
-        self.obj.shutdown()
-        self.obj.post_process()
-        self.assertIn("-Xmx", str(stdout))
-
     def test_data_sources_in_artifacts(self):
         self.obj.engine.config.merge({'execution': {'iterations': 1,
                                                'scenario': {'data-sources': ['test1.csv'],


### PR DESCRIPTION
It was failing when 32-bit JVM was installed on a 64-bit OS.