### PR TITLE
Add 'include-scenario' block to JMeter

### DIFF
--- a/bzt/engine.py
+++ b/bzt/engine.py
@@ -830,6 +830,13 @@ class ScenarioExecutor(EngineModule):
 
         return self.__scenario
 
+    def get_scenario_by_name(self, name):
+        scenarios = self.engine.config.get("scenarios")
+        if name not in scenarios:
+            raise ValueError("Scenario not found in scenarios: %s" % name)
+        scenario = scenarios.get(name)
+        return Scenario(self.engine, scenario)
+
     def get_load(self):
         """
         Helper method to read load specification

--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -959,9 +959,3 @@ class JMX(object):
                                    testclass="TransactionController", testname=transaction_name)
         controller.append(JMX._bool_prop("TransactionController.parent", True))
         return controller
-
-    @staticmethod
-    def _get_simple_controller(name):
-        return etree.Element("GenericController", guiclass="LogicControllerGui",
-                             testclass="GenericController", testname=name)
-

--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -909,6 +909,13 @@ class JMX(object):
         self.append(self.TEST_PLAN_SEL, dbg_tree)
         self.append(self.TEST_PLAN_SEL, etree.Element("hashTree"))
 
+    def _get_results_tree(self):
+        dbg_tree = etree.Element("ResultCollector",
+                                 testname="View Results Tree",
+                                 testclass="ResultCollector",
+                                 guiclass="ViewResultsFullVisualizer")
+        return dbg_tree
+
     @staticmethod
     def _get_if_controller(condition):
         controller = etree.Element("IfController", guiclass="IfControllerPanel", testclass="IfController",
@@ -952,3 +959,9 @@ class JMX(object):
                                    testclass="TransactionController", testname=transaction_name)
         controller.append(JMX._bool_prop("TransactionController.parent", True))
         return controller
+
+    @staticmethod
+    def _get_simple_controller(name):
+        return etree.Element("GenericController", guiclass="LogicControllerGui",
+                             testclass="GenericController", testname=name)
+

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -397,6 +397,7 @@ Taurus allows to control execution flow with the following constructs:
 - `while` blocks
 - `foreach` blocks
 - `transaction` blocks
+- `include-scenario` blocks
 
 ##### If Blocks
 
@@ -533,6 +534,37 @@ scenario:
     - http://example.com/card
     - http://example.com/checkout
 ```
+
+##### Include Scenario blocks
+`include-scenario` blocks allows you to include scenario in another one. You can use it to split your test plan into
+a few of independent scenarios that can be reused.
+
+Example:
+```yaml
+scenarios:
+  login:
+    data-sources:
+    - logins.csv
+    requests:
+    - url: http://example.com/login
+      method: POST
+      body:
+        user: ${username}
+        password: ${password}
+  logout:
+    requests:
+    - url: http://example.com/logout
+      method: POST
+   shop-session:
+     requests:
+     - include-scenario: login
+     - http://example.com/shop/items/1
+     - http://example.com/checkout
+     - include-scenario: logout
+```
+
+Taurus translates each `include-scenario` block to a JMeter's `Simple Controller` and puts all scenario-level
+settings and requests there.
 
 ## JMeter Test Log
 You can tune JTL file verbosity with option `write-xml-jtl`. Possible values are 'error' (default), 'full', or any other value for 'none'. Keep in mind: max verbosity can seriously load your system.

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1524,6 +1524,51 @@ class TestJMeterExecutor(BZTestCase):
         filename = scenario_dataset.find('stringProp[@name="filename"]')
         self.assertEqual(filename.text, get_full_path(__dir__() + "/../data/test2.csv"))
 
+    def test_include_recursion(self):
+        self.obj.engine.config.merge({
+            'scenarios': {
+                'a': {
+                    'requests': [{
+                        "include-scenario": "b",
+                    }],
+                },
+                'b': {
+                    'requests': [{
+                        "include-scenario": "a",
+                    }],
+                }
+            },
+            'execution': {
+                'scenario': 'a',
+            },
+            "provisioning": "local",
+        })
+        self.obj.execution = self.obj.engine.config['execution']
+        self.assertRaises(ValueError, self.obj.prepare)
+
+    def test_include_sources_recursion(self):
+        self.obj.engine.config.merge({
+            'scenarios': {
+                'a': {
+                    'requests': [{
+                        "include-scenario": "b",
+                    }],
+                },
+                'b': {
+                    'requests': [{
+                        "include-scenario": "a",
+                    }],
+                }
+            },
+            'execution': {
+                'scenario': 'a',
+            },
+            "provisioning": "local",
+        })
+        self.obj.execution = self.obj.engine.config['execution']
+        self.assertRaises(ValueError, self.obj.resource_files)
+
+
 
 class TestJMX(BZTestCase):
     def test_jmx_unicode_checkmark(self):


### PR DESCRIPTION
It works by wrapping all scenario subblocks (data-sources, config, requests) in a SimpleController.

TODO:
- [x] parse `included-scenario` block
- [x] compile to JMX
- [x] docs
- [x] prevent infinite recursion with mutual scenario inclusion
