### PR TITLE
Update Taurus Windows installation guide

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     docs_url='http://gettaurus.org/',
 
     install_requires=[
-        'pyyaml', 'psutil > 3', 'colorlog', 'colorama', 'lxml >= 3.4.2',
+        'pyyaml', 'psutil > 3', 'colorlog', 'colorama', 'lxml >= 3.6.0',
         'cssselect', 'urwid', 'six', 'nose',
         'selenium', 'progressbar33', 'pyvirtualdisplay', ],
     packages=['bzt', 'bzt.six', 'bzt.modules', 'bzt.resources'],

--- a/site/dat/docs/Installation.md
+++ b/site/dat/docs/Installation.md
@@ -2,18 +2,46 @@
 
 ## Windows
 
-Tried on Windows 7 and Windows XP:
+The installation process was tried on Windows 7 and Windows XP.
 
-  1. Get Python 2.7 from [http://www.python.org/downloads](http://www.python.org/downloads) and install it, don't forget to enable "Add python.exe to Path" checkbox.
-  1. Get latest Java from [https://www.java.com/download/](https://www.java.com/download/) and install it.
-  1. Download `lxml-3.6.0-cp27-cp27m-win32.whl` package from [http://www.lfd.uci.edu/](http://www.lfd.uci.edu/~gohlke/pythonlibs/#lxml).
-  1. Open Command Prompt with administrative privileges (find `Command Prompt` in main menu and chose `Run as administrator` from context menu) and type these commands:
+###  Install Taurus system dependencies
+
+1. Get Python 2.7 from [http://www.python.org/downloads](http://www.python.org/downloads) and install it, don't forget to enable "Add python.exe to Path" checkbox.
+1. Get latest Java from [https://www.java.com/download/](https://www.java.com/download/) and install it.
+
+### Install Taurus Python dependencies: 
+
+Open Command Prompt with administrative privileges (find `Command Prompt` in main menu and chose `Run as administrator`
+from context menu). Then run the following commands:
+
+#### Install `lxml` package
+
 ```
-  pip install lxml-3.6.0-cp27-cp27m-win32.whl
-  pip install --upgrade setuptools
-  pip install bzt
+pip install lxml
 ```
-To upgrade Taurus, open Command Prompt the same way and hit
+
+If this command fails, `lxml` provides Windows installers at its [PyPI page](https://pypi.python.org/pypi/lxml/3.6.0).
+Download `lxml-3.6.0.win32-py2.7.exe` installer (or `lxml-3.6.0.win-amd64-py2.7.exe`, if you've installed 64-bit
+Python) and run it.
+
+#### Install `psutil` package
+
+```
+pip install psutil
+```
+
+If this doesn't work for you, `psutil` provides Windows installers at its [PyPI page](https://pypi.python.org/pypi/psutil).
+Download `psutil-4.2.0.win32-py2.7.exe` (or `psutil-4.2.0.win-amd64-py2.7.exe` for 64-bit installations) and install it.
+
+### Install Taurus
+
+```
+pip install bzt
+```
+
+### Upgrading Taurus
+
+To upgrade Taurus, open Command Prompt as administrator and run
 ``` 
  pip install --upgrade bzt
 ```

--- a/site/dat/docs/Installation.md
+++ b/site/dat/docs/Installation.md
@@ -4,12 +4,12 @@
 
 Tried on Windows 7 and Windows XP:
 
-  1. Get python 2.7 from [http://www.python.org/downloads](http://www.python.org/downloads) and install it, don't forget to enable "Add python.exe to Path".
+  1. Get Python 2.7 from [http://www.python.org/downloads](http://www.python.org/downloads) and install it, don't forget to enable "Add python.exe to Path" checkbox.
   1. Get latest Java from [https://www.java.com/download/](https://www.java.com/download/) and install it.
-  1. Download `lxml-3.5.0-cp27-none-win32.whl` package from [http://www.lfd.uci.edu/](http://www.lfd.uci.edu/~gohlke/pythonlibs/#lxml).
+  1. Download `lxml-3.6.0-cp27-cp27m-win32.whl` package from [http://www.lfd.uci.edu/](http://www.lfd.uci.edu/~gohlke/pythonlibs/#lxml).
   1. Open Command Prompt with administrative privileges (find `Command Prompt` in main menu and chose `Run as administrator` from context menu) and type these commands:
 ```
-  pip install lxml-3.5.0-cp27-none-win32.whl
+  pip install lxml-3.6.0-cp27-cp27m-win32.whl
   pip install --upgrade setuptools
   pip install bzt
 ```

--- a/site/dat/docs/Installation.md
+++ b/site/dat/docs/Installation.md
@@ -23,9 +23,9 @@ python -m pip install --upgrade pip
 pip install lxml
 ```
 
-If this command fails, `lxml` provides Windows installers at its [PyPI page](https://pypi.python.org/pypi/lxml/3.6.0).
-Download `lxml-3.6.0.win32-py2.7.exe` installer (or `lxml-3.6.0.win-amd64-py2.7.exe`, if you've installed 64-bit
-Python) and run it.
+If this command fails, you can install `lxml` with Windows installer provided at project's
+[PyPI page](https://pypi.python.org/pypi/lxml/3.6.0). Just download `lxml-3.6.0.win32-py2.7.exe` installer (or
+`lxml-3.6.0.win-amd64-py2.7.exe`, if you've installed 64-bit Python) and run it.
 
 #### Install `psutil` package
 
@@ -33,8 +33,9 @@ Python) and run it.
 pip install psutil
 ```
 
-If this doesn't work for you, `psutil` provides Windows installers at its [PyPI page](https://pypi.python.org/pypi/psutil).
-Download `psutil-4.2.0.win32-py2.7.exe` (or `psutil-4.2.0.win-amd64-py2.7.exe` for 64-bit installations) and install it.
+If this command fails, you can install `psutil` with Windows installer provided at project's
+[PyPI page](https://pypi.python.org/pypi/psutil). Download `psutil-4.2.0.win32-py2.7.exe` file (or
+`psutil-4.2.0.win-amd64-py2.7.exe` for 64-bit Python) and install it.
 
 ### Install Taurus
 

--- a/site/dat/docs/Installation.md
+++ b/site/dat/docs/Installation.md
@@ -12,7 +12,10 @@ The installation process was tried on Windows 7 and Windows XP.
 ### Install Taurus Python dependencies
 
 Open Command Prompt with administrative privileges (find `Command Prompt` in main menu and chose `Run as administrator`
-from context menu). Then run the following commands:
+from context menu). Then run the following command to update Python package manager to the latest version:
+```
+python -m pip install --upgrade pip
+```
 
 #### Install `lxml` package
 

--- a/site/dat/docs/Installation.md
+++ b/site/dat/docs/Installation.md
@@ -2,7 +2,7 @@
 
 ## Windows
 
-The installation process was tried on Windows 7 and Windows XP.
+The installation process was tried on all supported Windows versions (7, 8, 10).
 
 ###  Install Taurus system dependencies
 

--- a/site/dat/docs/Installation.md
+++ b/site/dat/docs/Installation.md
@@ -9,7 +9,7 @@ The installation process was tried on Windows 7 and Windows XP.
 1. Get Python 2.7 from [http://www.python.org/downloads](http://www.python.org/downloads) and install it, don't forget to enable "Add python.exe to Path" checkbox.
 1. Get latest Java from [https://www.java.com/download/](https://www.java.com/download/) and install it.
 
-### Install Taurus Python dependencies: 
+### Install Taurus Python dependencies
 
 Open Command Prompt with administrative privileges (find `Command Prompt` in main menu and chose `Run as administrator`
 from context menu). Then run the following commands:


### PR DESCRIPTION
- packages from http://www.lfd.uci.edu/ are broken ATM, let's point users to Windows installers provided by `lxml` and `psutil` communities

- `lxml` installation should work in Windows (for example, `lxml` can be installed from pip in vanilla Win7) . However, in some cases (my Win8 setup) installation fails. The same applies for `psutil` package.