### PR TITLE
Fix passfail crash regression

### DIFF
--- a/bzt/modules/passfail.py
+++ b/bzt/modules/passfail.py
@@ -45,7 +45,7 @@ class PassFailStatus(Reporter, Service, AggregatorListener, WidgetProvider):
         super(PassFailStatus, self).prepare()
 
         # TODO: remove "criterias" support in three months
-        criterias = self.parameters.get("criterias", self.criteria)
+        criterias = self.parameters.get("criterias", [])
         if criterias:
             self.log.warning('"criterias" section name is deprecated, use "criteria" instead')
         criteria = self.parameters.get("criteria", criterias)

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.2 (next)
+ - fix passfail-related regression crash
+
 ## 1.6.1 <sup>1 jun 2016</sup>
  - add `run-at` option for unpacker module
 

--- a/tests/modules/test_passFailStatus.py
+++ b/tests/modules/test_passFailStatus.py
@@ -5,6 +5,7 @@ import time
 from bzt import AutomatedShutdown
 from bzt.modules.aggregator import DataPoint, KPISet
 from bzt.modules.passfail import PassFailStatus, DataCriterion
+from bzt.utils import BetterDict
 from tests import BZTestCase, __dir__, random_datapoint
 from tests.mocks import EngineEmul
 
@@ -183,5 +184,22 @@ class TestPassFailStatus(BZTestCase):
         obj.aggregated_second(point)
         self.assertRaises(AutomatedShutdown, obj.post_process)
 
+    def test_passfail_crash(self):
+        passfail = BetterDict()
+        passfail.merge({
+            "module": "passfail",
+            "criteria": [
+                "fail>10% within 5s",
+            ]
+        })
+        obj = PassFailStatus()
+        obj.engine = EngineEmul()
+        obj.parameters = passfail
+        obj.engine.config.merge({
+            "services": [passfail],
+        })
+        obj.prepare()
+        self.assertTrue(all(isinstance(obj, dict) for obj in passfail["criteria"]))
+        self.assertTrue(all(isinstance(obj, dict) for obj in passfail["criterias"]))
 
 


### PR DESCRIPTION
It was caused by placing a link to criteria list into engine config, that was later populated with FailCriteria objects (that obviously are not serializable).

When Engine is trying to dump configuration to artifacts at the end of `prepare()` stage — it can't serialize these objects and fails with an pretty obscure message.