### PR TITLE
Fix percentiles handling in passfail service

### DIFF
--- a/bzt/modules/passfail.py
+++ b/bzt/modules/passfail.py
@@ -309,7 +309,7 @@ class DataCriterion(FailCriterion):
         elif subject.startswith('p'):
             if percentage:
                 raise ValueError("Percentage threshold is not applicable for %s" % subject)
-            level = float(subject[1:])
+            level = str(float(subject[1:]))
             return lambda x: x[KPISet.PERCENTILES][level] if level in x[KPISet.PERCENTILES] else 0
         elif subject.startswith('rc'):
             count = lambda x: sum([fnmatch.fnmatch(y, subject[2:]) for y in x[KPISet.RESP_CODES].keys()])

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.3 (next)
+ - fix percentile value handling in passfail criteria
+
 ## 1.6.2 <sup>8 jun 2016</sup>
  - fix passfail-related regression crash
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -59,12 +59,12 @@ def random_datapoint(n):
     overall[KPISet.SAMPLE_COUNT] = int(100 * r(1000)) + 1
     overall[KPISet.SUCCESSES] = int(overall[KPISet.SAMPLE_COUNT] * random())
     overall[KPISet.FAILURES] = overall[KPISet.SAMPLE_COUNT] - overall[KPISet.SUCCESSES]
-    overall[KPISet.PERCENTILES]['25'] = r(10)
-    overall[KPISet.PERCENTILES]['50'] = r(20)
-    overall[KPISet.PERCENTILES]['75'] = r(30)
-    overall[KPISet.PERCENTILES]['90'] = r(40)
-    overall[KPISet.PERCENTILES]['99'] = r(50)
-    overall[KPISet.PERCENTILES]['100'] = r(100)
+    overall[KPISet.PERCENTILES]['25.0'] = r(10)
+    overall[KPISet.PERCENTILES]['50.0'] = r(20)
+    overall[KPISet.PERCENTILES]['75.0'] = r(30)
+    overall[KPISet.PERCENTILES]['90.0'] = r(40)
+    overall[KPISet.PERCENTILES]['99.0'] = r(50)
+    overall[KPISet.PERCENTILES]['100.0'] = r(100)
     overall[KPISet.RESP_CODES][rc()] = 1
 
     overall[KPISet.AVG_RESP_TIME] = r(100)

--- a/tests/modules/test_passFailStatus.py
+++ b/tests/modules/test_passFailStatus.py
@@ -202,4 +202,22 @@ class TestPassFailStatus(BZTestCase):
         self.assertTrue(all(isinstance(obj, dict) for obj in passfail["criteria"]))
         self.assertTrue(all(isinstance(obj, dict) for obj in passfail["criterias"]))
 
+    def test_percentiles_track(self):
+        obj = PassFailStatus()
+        obj.engine = EngineEmul()
+        obj.parameters = {"criteria": ["p90>0ms"]}
+        obj.prepare()
+        self.assertGreater(len(obj.criteria), 0)
+
+        for n in range(0, 10):
+            point = random_datapoint(n)
+            obj.aggregated_second(point)
+            obj.check()
+
+        obj.shutdown()
+        try:
+            obj.post_process()
+            self.fail()
+        except AutomatedShutdown:
+            pass
 


### PR DESCRIPTION
For example, `p99>1s, continue as failed` criterion wasn't working because string percentiles from DataPoint were compared to float value from DataCriteria object.