### PR TITLE
Rely on Gatling simulation auto-detection mechanism when `simulation` is not set

### DIFF
--- a/bzt/modules/gatling.py
+++ b/bzt/modules/gatling.py
@@ -209,11 +209,7 @@ class GatlingExecutor(ScenarioExecutor, WidgetProvider, FileLister):
         Should start the tool as fast as possible.
         """
 
-        simulation = self.get_scenario().get("simulation", "")
-        if not simulation:
-            # TODO: guess simulation from script file
-            raise ValueError("No simulation set")
-
+        simulation = self.get_scenario().get("simulation")
         datadir = os.path.realpath(self.engine.artifacts_dir)
 
         if os.path.isfile(self.script):
@@ -223,7 +219,9 @@ class GatlingExecutor(ScenarioExecutor, WidgetProvider, FileLister):
 
         cmdline = [self.settings["path"]]
         cmdline += ["-sf", script_path, "-df", datadir, "-rf ", datadir]
-        cmdline += ["-on", self.dir_prefix, "-m", "-s", simulation]
+        cmdline += ["-on", self.dir_prefix, "-m"]
+        if simulation:
+            cmdline += ["-s", simulation]
 
         self.start_time = time.time()
         out = self.engine.create_artifact("gatling-stdout", ".log")

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.4 (next)
+ - rely on Gatling simulation auto-detection mechanism when `simulation` field is not set
+
 ## 1.6.3 <sup>17 jun 2016</sup>
  - fix percentile value handling in passfail criteria
  - add setting up of CWD on server side

--- a/tests/modules/test_Gatling.py
+++ b/tests/modules/test_Gatling.py
@@ -190,7 +190,12 @@ class TestGatlingExecutor(BZTestCase):
         obj = self.getGatling()
         obj.execution.merge({"scenario": {"script": __dir__() + "/../gatling/bs/BasicSimulation.scala"}})
         obj.prepare()
-        self.assertRaises(ValueError, obj.startup)
+        try:
+            obj.startup()
+            while not obj.check():
+                time.sleep(obj.engine.check_interval)
+        finally:
+            obj.shutdown()
 
     def test_full_Gatling(self):
         obj = self.getGatling()


### PR DESCRIPTION
There's really no point in throwing an exception when 'simulation' is not set.

Gatling can autodetect the simulation without prompting user when given "-m" option. And if there's more than one simulation found - Gatling will print a warning urging user to set simulation name and Taurus will pass that warning to user.