### PR TITLE
Fix Selenium crash when used in multi-execution setup with a shared scenario

### DIFF
--- a/bzt/modules/selenium.py
+++ b/bzt/modules/selenium.py
@@ -150,7 +150,7 @@ class SeleniumExecutor(ScenarioExecutor, WidgetProvider, FileLister):
             self.script = self.__tests_from_requests()
             self.self_generated_script = True
         else:
-            raise RuntimeError("Nothing to test, no requests were provided in scenario")
+            raise ValueError("Nothing to test, no requests were provided in scenario")
 
     def _cp_resource_files(self, runner_working_dir):
         script = self._get_script_path()

--- a/bzt/modules/selenium.py
+++ b/bzt/modules/selenium.py
@@ -72,6 +72,7 @@ class SeleniumExecutor(ScenarioExecutor, WidgetProvider, FileLister):
         self.err_jtl = None
         self.runner_working_dir = None
         self.scenario = None
+        self.script = None
         self.self_generated_script = False
 
     def set_virtual_display(self):
@@ -98,10 +99,7 @@ class SeleniumExecutor(ScenarioExecutor, WidgetProvider, FileLister):
             del SeleniumExecutor.SHARED_VIRTUAL_DISPLAY[self.engine]
 
     def _get_script_path(self):
-        script = self.scenario.get(Scenario.SCRIPT)
-        if not script:
-            return None
-        return self.engine.find_file(script)
+        return self.engine.find_file(self.script)
 
     def _create_runner(self, working_dir, kpi_file, err_file):
         script_path = self._get_script_path()
@@ -146,12 +144,13 @@ class SeleniumExecutor(ScenarioExecutor, WidgetProvider, FileLister):
             self.engine.aggregator.add_underling(self.reader)
 
     def _verify_script(self):
-        if not self.scenario.get(Scenario.SCRIPT):
-            if self.scenario.get("requests"):
-                self.scenario[Scenario.SCRIPT] = self.__tests_from_requests()
-                self.self_generated_script = True
-            else:
-                raise RuntimeError("Nothing to test, no requests were provided in scenario")
+        if Scenario.SCRIPT in self.scenario:
+            self.script = self.scenario.get(Scenario.SCRIPT)
+        elif "requests" in self.scenario:
+            self.script = self.__tests_from_requests()
+            self.self_generated_script = True
+        else:
+            raise RuntimeError("Nothing to test, no requests were provided in scenario")
 
     def _cp_resource_files(self, runner_working_dir):
         script = self._get_script_path()
@@ -242,16 +241,17 @@ class SeleniumExecutor(ScenarioExecutor, WidgetProvider, FileLister):
 
     def get_widget(self):
         if not self.widget:
-            self.widget = SeleniumWidget(self.scenario.get(Scenario.SCRIPT), self.runner.settings.get("stdout"))
+            self.widget = SeleniumWidget(self.script, self.runner.settings.get("stdout"))
         return self.widget
 
     def resource_files(self):
         self.scenario = self.get_scenario()
-
-        if Scenario.SCRIPT in self.scenario:
-            return [self._get_script_path()]
-        else:
-            return []
+        self._verify_script()
+        script_path = self._get_script_path()
+        resources = []
+        if script_path is not None:
+            resources.append(script_path)
+        return resources
 
     def __tests_from_requests(self):
         filename = self.engine.create_artifact("test_requests", ".py")

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -2,6 +2,7 @@
 
 ## 1.6.4 (next)
  - rely on Gatling simulation auto-detection mechanism when `simulation` field is not set
+ - fix Selenium crash when used in multi-execution with a shared scenario
 
 ## 1.6.3 <sup>17 jun 2016</sup>
  - fix percentile value handling in passfail criteria

--- a/tests/modules/test_SeleniumExecutor.py
+++ b/tests/modules/test_SeleniumExecutor.py
@@ -643,3 +643,14 @@ class TestSeleniumStuff(SeleniumTestCase):
             }
         })
         obj.prepare()
+
+    def test_do_not_modify_scenario_script(self):
+        obj = SeleniumExecutor()
+        obj.engine = EngineEmul()
+        obj.execution.merge({
+            "scenario": {
+                "requests": ["address"],
+            }
+        })
+        obj.prepare()
+        self.assertNotIn("script", obj.get_scenario())


### PR DESCRIPTION
Selenium executor was modifying scenario's `script` field, putting there a path to generated script. This shouldn't be the case, as scenario may be used by another executor.