### PR TITLE
Automatically rename Selenium Python script if it has undiscoverable name

### DIFF
--- a/bzt/modules/selenium.py
+++ b/bzt/modules/selenium.py
@@ -165,7 +165,16 @@ class SeleniumExecutor(ScenarioExecutor, WidgetProvider, FileLister):
             if self.self_generated_script:
                 shutil.move(script, runner_working_dir)
             else:
-                shutil.copy2(script, runner_working_dir)
+                script_type = self.detect_script_type(script)
+                script_name = os.path.basename(script)
+                if script_type == ".py" and not script_name.lower().startswith('test'):
+                    target_name = 'test_' + script_name
+                    msg = "Script '%s' won't be discovered by nosetests, renaming script to %s"
+                    self.log.warning(msg, script_name, target_name)
+                else:
+                    target_name = script_name
+                target_path = os.path.join(runner_working_dir, target_name)
+                shutil.copy2(script, target_path)
 
     @staticmethod
     def detect_script_type(script_path):

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -6,6 +6,7 @@
  - fix config cleanup in cloud provisioning
  - fix Selenium crash when used in multi-execution with a shared scenario
  - add `default-address` scenario option to Selenium
+ - automatically rename Selenium Python script if it has undiscoverable name
 
 ## 1.6.3 <sup>17 jun 2016</sup>
  - fix percentile value handling in passfail criteria

--- a/tests/modules/test_SeleniumExecutor.py
+++ b/tests/modules/test_SeleniumExecutor.py
@@ -449,6 +449,7 @@ class TestSeleniumNoseRunner(SeleniumTestCase):
         while not self.obj.check():
             time.sleep(self.obj.engine.check_interval)
         self.obj.shutdown()
+        self.assertTrue(os.path.exists(os.path.join(self.obj.runner_working_dir, "test_bad_name.py")))
 
 
 class TestSeleniumStuff(SeleniumTestCase):

--- a/tests/modules/test_SeleniumExecutor.py
+++ b/tests/modules/test_SeleniumExecutor.py
@@ -346,7 +346,7 @@ class TestSeleniumNoseRunner(SeleniumTestCase):
         self.obj.execution.merge({"scenario": {"script": __dir__() + "/../selenium/python/"}})
         self.obj.prepare()
         python_scripts = os.listdir(self.obj.runner.working_dir)
-        self.assertEqual(len(python_scripts), 2)
+        self.assertEqual(len(python_scripts), 3)
 
     def test_selenium_startup_shutdown_python_single(self):
         """
@@ -401,7 +401,7 @@ class TestSeleniumNoseRunner(SeleniumTestCase):
         self.obj.shutdown()
         prepared_files = os.listdir(self.obj.runner.working_dir)
         python_files = [fname for fname in prepared_files if fname.endswith(".py")]
-        self.assertEqual(2, len(python_files))
+        self.assertEqual(3, len(python_files))
         self.assertTrue(os.path.exists(self.obj.runner.settings.get("report-file")))
 
     def runner_fail_no_test_found(self):

--- a/tests/modules/test_SeleniumExecutor.py
+++ b/tests/modules/test_SeleniumExecutor.py
@@ -432,6 +432,24 @@ class TestSeleniumNoseRunner(SeleniumTestCase):
 
         self.assertEqual(len(self.obj.resource_files()), 1)
 
+    def test_script_renaming(self):
+        """
+        Check that if script does't start with 'test' -
+        it gets renamed to 'test_xxx'
+        """
+        self.obj.engine.config.merge({
+            ScenarioExecutor.EXEC: {
+                "executor": "selenium",
+                "scenario": {"script": __dir__() + "/../selenium/python/bad_name.py"}
+            }
+        })
+        self.obj.execution = self.obj.engine.config['execution']
+        self.obj.prepare()
+        self.obj.startup()
+        while not self.obj.check():
+            time.sleep(self.obj.engine.check_interval)
+        self.obj.shutdown()
+
 
 class TestSeleniumStuff(SeleniumTestCase):
     def test_empty_scenario(self):

--- a/tests/selenium/python/bad_name.py
+++ b/tests/selenium/python/bad_name.py
@@ -1,0 +1,16 @@
+import unittest
+
+
+class TestBrowser(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_something(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Nose only considers modules that are named '[Tt]est* to be tests. So it might be a good idea to rename Python script to make it discoverable by nose.