### PR TITLE
Terminate test execution when CSV is exhausted and data-source `loop` is set to false

### DIFF
--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -879,7 +879,7 @@ class JMX(object):
         return element
 
     @staticmethod
-    def _get_csv_config(path, delimiter, is_quoted, on_eof):
+    def _get_csv_config(path, delimiter, is_quoted, loop):
         """
 
         :type path: str
@@ -890,20 +890,11 @@ class JMX(object):
         """
         element = etree.Element("CSVDataSet", guiclass="TestBeanGUI",
                                 testclass="CSVDataSet", testname="CSV %s" % os.path.basename(path))
-        if on_eof == "loop":
-            recycle = True
-            stop = False
-        elif on_eof == "stop":
-            recycle = False
-            stop = True
-        else:
-            recycle = False
-            stop = False
         element.append(JMX._string_prop("filename", path))
         element.append(JMX._string_prop("delimiter", delimiter))
         element.append(JMX._bool_prop("quotedData", is_quoted))
-        element.append(JMX._bool_prop("recycle", recycle))
-        element.append(JMX._bool_prop("stopThread", stop))
+        element.append(JMX._bool_prop("recycle", loop))
+        element.append(JMX._bool_prop("stopThread", not loop))
 
         return element
 

--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -879,7 +879,7 @@ class JMX(object):
         return element
 
     @staticmethod
-    def _get_csv_config(path, delimiter, is_quoted, is_recycle, stop_on_eof):
+    def _get_csv_config(path, delimiter, is_quoted, on_eof):
         """
 
         :type path: str
@@ -890,11 +890,20 @@ class JMX(object):
         """
         element = etree.Element("CSVDataSet", guiclass="TestBeanGUI",
                                 testclass="CSVDataSet", testname="CSV %s" % os.path.basename(path))
+        if on_eof == "loop":
+            recycle = True
+            stop = False
+        elif on_eof == "stop":
+            recycle = False
+            stop = True
+        else:
+            recycle = False
+            stop = False
         element.append(JMX._string_prop("filename", path))
         element.append(JMX._string_prop("delimiter", delimiter))
         element.append(JMX._bool_prop("quotedData", is_quoted))
-        element.append(JMX._bool_prop("recycle", is_recycle))
-        element.append(JMX._bool_prop("stopThread", stop_on_eof))
+        element.append(JMX._bool_prop("recycle", recycle))
+        element.append(JMX._bool_prop("stopThread", stop))
 
         return element
 

--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -879,7 +879,7 @@ class JMX(object):
         return element
 
     @staticmethod
-    def _get_csv_config(path, delimiter, is_quoted, is_recycle):
+    def _get_csv_config(path, delimiter, is_quoted, is_recycle, stop_on_eof):
         """
 
         :type path: str
@@ -894,6 +894,8 @@ class JMX(object):
         element.append(JMX._string_prop("delimiter", delimiter))
         element.append(JMX._bool_prop("quotedData", is_quoted))
         element.append(JMX._bool_prop("recycle", is_recycle))
+        element.append(JMX._bool_prop("stopThread", stop_on_eof))
+
         return element
 
     def set_enabled(self, sel, state):

--- a/bzt/jmx2yaml.py
+++ b/bzt/jmx2yaml.py
@@ -463,11 +463,9 @@ class JMXasDict(JMX):
                         stop_prop = False
 
                     if loop_prop:
-                        data_source_dict["on-eof"] = "loop"
-                    elif stop_prop:
-                        data_source_dict["on-eof"] = "stop"
+                        data_source_dict["loop"] = True
                     else:
-                        data_source_dict["on-eof"] = "continue"
+                        data_source_dict["loop"] = False
 
                     data_sources.append(data_source_dict)
         if data_sources:

--- a/bzt/jmx2yaml.py
+++ b/bzt/jmx2yaml.py
@@ -460,7 +460,8 @@ class JMXasDict(JMX):
                     if stop_prop is not None:
                         data_source_dict["stop-on-eof"] = stop_prop
                     else:
-                        self.log.warning("'Stop Thread on EOF' property was not set in %s, using default False", data_source.tag)
+                        self.log.warning("'Stop Thread on EOF' property was not set in %s, using default False",
+                                         data_source.tag)
                         data_source_dict["stop-on-eof"] = False
 
                     data_sources.append(data_source_dict)

--- a/bzt/jmx2yaml.py
+++ b/bzt/jmx2yaml.py
@@ -464,7 +464,7 @@ class JMXasDict(JMX):
 
                     if loop_prop:
                         data_source_dict["loop"] = True
-                    else:
+                    elif stop_prop:
                         data_source_dict["loop"] = False
 
                     data_sources.append(data_source_dict)

--- a/bzt/jmx2yaml.py
+++ b/bzt/jmx2yaml.py
@@ -450,19 +450,24 @@ class JMXasDict(JMX):
                     else:
                         self.log.warning("Quoted property was not set in %s, using default False", data_source.tag)
                         data_source_dict["quoted"] = False
+
                     loop_prop = self._get_bool_prop(data_source, 'recycle')
-                    if loop_prop is not None:
-                        data_source_dict["loop"] = loop_prop
-                    else:
+                    if loop_prop is None:
                         self.log.warning("Loop property was not set in %s, using default False", data_source.tag)
-                        data_source_dict["loop"] = False
+                        loop_prop = False
+
                     stop_prop = self._get_bool_prop(data_source, 'stopThread')
-                    if stop_prop is not None:
-                        data_source_dict["stop-on-eof"] = stop_prop
-                    else:
+                    if stop_prop is None:
                         self.log.warning("'Stop Thread on EOF' property was not set in %s, using default False",
                                          data_source.tag)
-                        data_source_dict["stop-on-eof"] = False
+                        stop_prop = False
+
+                    if loop_prop:
+                        data_source_dict["on-eof"] = "loop"
+                    elif stop_prop:
+                        data_source_dict["on-eof"] = "stop"
+                    else:
+                        data_source_dict["on-eof"] = "continue"
 
                     data_sources.append(data_source_dict)
         if data_sources:

--- a/bzt/jmx2yaml.py
+++ b/bzt/jmx2yaml.py
@@ -452,10 +452,17 @@ class JMXasDict(JMX):
                         data_source_dict["quoted"] = False
                     loop_prop = self._get_bool_prop(data_source, 'recycle')
                     if loop_prop is not None:
-                        data_source_dict["recycle"] = loop_prop
+                        data_source_dict["loop"] = loop_prop
                     else:
                         self.log.warning("Loop property was not set in %s, using default False", data_source.tag)
-                        data_source_dict["recycle"] = False
+                        data_source_dict["loop"] = False
+                    stop_prop = self._get_bool_prop(data_source, 'stopThread')
+                    if stop_prop is not None:
+                        data_source_dict["stop-on-eof"] = stop_prop
+                    else:
+                        self.log.warning("'Stop Thread on EOF' property was not set in %s, using default False", data_source.tag)
+                        data_source_dict["stop-on-eof"] = False
+
                     data_sources.append(data_source_dict)
         if data_sources:
             self.log.debug('Got %s for data_sources in %s (%s)', data_sources, element.tag, element.get("testname"))

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1486,7 +1486,7 @@ class JMeterScenarioBuilder(JMX):
             delimiter = source.get("delimiter", self.__guess_delimiter(source_path))
 
             config = JMX._get_csv_config(os.path.abspath(source_path), delimiter,
-                                         source.get("quoted", False), source.get("on-eof", "loop"))
+                                         source.get("quoted", False), source.get("loop", True))
             elements.append(config)
             elements.append(etree.Element("hashTree"))
         return elements

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1486,7 +1486,8 @@ class JMeterScenarioBuilder(JMX):
             delimiter = source.get("delimiter", self.__guess_delimiter(source_path))
 
             config = JMX._get_csv_config(os.path.abspath(source_path), delimiter,
-                                         source.get("quoted", False), source.get("loop", True))
+                                         source.get("quoted", False), source.get("loop", True),
+                                         source.get("stop-on-eof", False))
             elements.append(config)
             elements.append(etree.Element("hashTree"))
         return elements

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1486,8 +1486,7 @@ class JMeterScenarioBuilder(JMX):
             delimiter = source.get("delimiter", self.__guess_delimiter(source_path))
 
             config = JMX._get_csv_config(os.path.abspath(source_path), delimiter,
-                                         source.get("quoted", False), source.get("loop", True),
-                                         source.get("stop-on-eof", False))
+                                         source.get("quoted", False), source.get("on-eof", "loop"))
             elements.append(config)
             elements.append(etree.Element("hashTree"))
         return elements

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -11,7 +11,7 @@
  - automatically rename Selenium Python script if it has undiscoverable name
  - fix null global headers failure
  - add `upload-files` option to JMeter requests for multipart/form-data uploads
- - `loop: false` in JMeter data source now means 'stop test execution after CSV is exhausted'
+ - `loop: false` in JMeter data source now means 'stop thread after CSV is exhausted'
 
 ## 1.6.3 <sup>17 jun 2016</sup>
  - fix percentile value handling in passfail criteria

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -11,7 +11,7 @@
  - automatically rename Selenium Python script if it has undiscoverable name
  - fix null global headers failure
  - add `upload-files` option to JMeter requests for multipart/form-data uploads
- - add `on-eof` data-source option to JMeter
+ - `loop: false` in JMeter data source now means 'stop test execution after CSV is exhausted'
 
 ## 1.6.3 <sup>17 jun 2016</sup>
  - fix percentile value handling in passfail criteria

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -11,6 +11,7 @@
  - automatically rename Selenium Python script if it has undiscoverable name
  - fix null global headers failure
  - add `upload-files` option to JMeter requests for multipart/form-data uploads
+ - add `on-eof` data-source option to JMeter
 
 ## 1.6.3 <sup>17 jun 2016</sup>
  - fix percentile value handling in passfail criteria

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -166,6 +166,7 @@ scenarios:
       delimiter: ';'  # CSV delimiter, auto-detected by default
       quoted: false  # allow quoted data
       loop: true  # loop over in case of end-of-file reached
+      stop-on-eof: false  # stop test execution if end-of-file is reached (requires `loop` to be `false`)
 ```
 
 Note that `timeout` also sets duration assertion that will mark response failed if response time was more than timeout.

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -165,8 +165,11 @@ scenarios:
     - path: path/to/another.csv  # this is full form, path option is required
       delimiter: ';'  # CSV delimiter, auto-detected by default
       quoted: false  # allow quoted data
-      loop: true  # loop over in case of end-of-file reached
-      stop-on-eof: false  # stop test execution if end-of-file is reached (requires `loop` to be `false`)
+      on-eof: loop  # what to do if end-of-file is reached.
+                    # Possible values are:
+                    # - 'loop' - start CSV file from the beginning,
+                    # - 'stop' - stop execution after data source is exhausted
+                    # - 'continue' - continue the test with default values
 ```
 
 Note that `timeout` also sets duration assertion that will mark response failed if response time was more than timeout.

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -165,7 +165,7 @@ scenarios:
     - path: path/to/another.csv  # this is full form, path option is required
       delimiter: ';'  # CSV delimiter, auto-detected by default
       quoted: false  # allow quoted data
-      loop: true  # loop over in case of end-of-file reached if true, stop test execution if false
+      loop: true  # loop over in case of end-of-file reached if true, stop thread if false
 ```
 
 Note that `timeout` also sets duration assertion that will mark response failed if response time was more than timeout.

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -165,11 +165,7 @@ scenarios:
     - path: path/to/another.csv  # this is full form, path option is required
       delimiter: ';'  # CSV delimiter, auto-detected by default
       quoted: false  # allow quoted data
-      on-eof: loop  # what to do if end-of-file is reached.
-                    # Possible values are:
-                    # - 'loop' - start CSV file from the beginning,
-                    # - 'stop' - stop execution after data source is exhausted
-                    # - 'continue' - continue the test with default values
+      loop: true  # loop over in case of end-of-file reached if true, stop test execution if false
 ```
 
 Note that `timeout` also sets duration assertion that will mark response failed if response time was more than timeout.

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1725,7 +1725,7 @@ class TestJMeterExecutor(BZTestCase):
                 'scenario': {
                     "data-sources": [{
                         "path": __dir__() + "/../data/test1.csv",
-                        "on-eof": "loop"
+                        "loop": True
                     }],
                     "requests": [
                         "http://example.com/${test1}",
@@ -1752,7 +1752,7 @@ class TestJMeterExecutor(BZTestCase):
                 'scenario': {
                     "data-sources": [{
                         "path": __dir__() + "/../data/test1.csv",
-                        "on-eof": "stop"
+                        "loop": False
                     }],
                     "requests": [
                         "http://example.com/${test1}",
@@ -1772,33 +1772,6 @@ class TestJMeterExecutor(BZTestCase):
         self.assertEqual(loop.text, "false")
         stop = dataset.find('boolProp[@name="stopThread"]')
         self.assertEqual(stop.text, "true")
-
-    def test_data_sources_jmx_gen_continue(self):
-        self.obj.engine.config.merge({
-            'execution': {
-                'scenario': {
-                    "data-sources": [{
-                        "path": __dir__() + "/../data/test1.csv",
-                        "on-eof": "continue"
-                    }],
-                    "requests": [
-                        "http://example.com/${test1}",
-                    ],
-                }
-            },
-            "provisioning": "local",
-        })
-        self.obj.execution = self.obj.engine.config['execution']
-        self.obj.prepare()
-        xml_tree = etree.fromstring(open(self.obj.original_jmx, "rb").read())
-        dataset = xml_tree.find('.//hashTree[@type="tg"]/CSVDataSet')
-        self.assertIsNotNone(dataset)
-        filename = dataset.find('stringProp[@name="filename"]')
-        self.assertEqual(filename.text, get_full_path(__dir__() + "/../data/test1.csv"))
-        loop = dataset.find('boolProp[@name="recycle"]')
-        self.assertEqual(loop.text, "false")
-        stop = dataset.find('boolProp[@name="stopThread"]')
-        self.assertEqual(stop.text, "false")
 
 
 class TestJMX(BZTestCase):

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1725,8 +1725,7 @@ class TestJMeterExecutor(BZTestCase):
                 'scenario': {
                     "data-sources": [{
                         "path": __dir__() + "/../data/test1.csv",
-                        "loop": True,
-                        "stop-on-eof": False,
+                        "on-eof": "loop"
                     }],
                     "requests": [
                         "http://example.com/${test1}",

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -320,12 +320,10 @@ class TestJMeterExecutor(BZTestCase):
                         'path': csv_file,
                         'loop': False,
                         'quoted': True,
-                        'stop-on-eof': False,
                     }, {
                         'path': csv_file_uni,
                         'loop': False,
                         'quoted': True,
-                        'stop-on-eof': True,
                     }],
                 }
             }

--- a/tests/test_jmx2yaml.py
+++ b/tests/test_jmx2yaml.py
@@ -128,8 +128,7 @@ class TestConverter(BZTestCase):
         yml = yaml.load(open(yml).read())
         datasets = yml.get("scenarios").get("Thread Group one").get("data-sources")
         local_csv = [dataset for dataset in datasets if dataset.get('path') == 'local.csv'][0]
-        self.assertEqual(local_csv['loop'], False)
-        self.assertEqual(local_csv['stop-on-eof'], True)
+        self.assertEqual(local_csv['on-eof'], "stop")
         self.assertEqual(local_csv['delimiter'], ',')
         self.assertEqual(local_csv['quoted'], False)
 

--- a/tests/test_jmx2yaml.py
+++ b/tests/test_jmx2yaml.py
@@ -128,7 +128,7 @@ class TestConverter(BZTestCase):
         yml = yaml.load(open(yml).read())
         datasets = yml.get("scenarios").get("Thread Group one").get("data-sources")
         local_csv = [dataset for dataset in datasets if dataset.get('path') == 'local.csv'][0]
-        self.assertEqual(local_csv['on-eof'], "stop")
+        self.assertEqual(local_csv['loop'], False)
         self.assertEqual(local_csv['delimiter'], ',')
         self.assertEqual(local_csv['quoted'], False)
 

--- a/tests/test_jmx2yaml.py
+++ b/tests/test_jmx2yaml.py
@@ -121,6 +121,19 @@ class TestConverter(BZTestCase):
         self.assertEqual(len(local_csv_tg_one), 1)
         self.assertEqual(len(local_csv_tg_two), 0)
 
+    def test_parse_csv_dataset(self):
+        yml = self._get_tmp()
+        obj = self._get_jmx2yaml("/yaml/converter/global_copy.jmx", yml)
+        obj.process()
+        yml = yaml.load(open(yml).read())
+        datasets = yml.get("scenarios").get("Thread Group one").get("data-sources")
+        local_csv = [dataset for dataset in datasets if dataset.get('path') == 'local.csv'][0]
+        obj.log.debug(local_csv)
+        self.assertEqual(local_csv['loop'], False)
+        self.assertEqual(local_csv['stop-on-eof'], True)
+        self.assertEqual(local_csv['delimiter'], ',')
+        self.assertEqual(local_csv['quoted'], False)
+
     def test_copy_global_headers(self):
         yml = self._get_tmp()
         obj = self._get_jmx2yaml("/yaml/converter/global_copy.jmx", yml)

--- a/tests/test_jmx2yaml.py
+++ b/tests/test_jmx2yaml.py
@@ -128,7 +128,6 @@ class TestConverter(BZTestCase):
         yml = yaml.load(open(yml).read())
         datasets = yml.get("scenarios").get("Thread Group one").get("data-sources")
         local_csv = [dataset for dataset in datasets if dataset.get('path') == 'local.csv'][0]
-        obj.log.debug(local_csv)
         self.assertEqual(local_csv['loop'], False)
         self.assertEqual(local_csv['stop-on-eof'], True)
         self.assertEqual(local_csv['delimiter'], ',')

--- a/tests/yaml/converter/disabled.yml
+++ b/tests/yaml/converter/disabled.yml
@@ -16,8 +16,7 @@ scenarios:
     - delimiter: ','
       path: not_found.csv
       quoted: false
-      loop: true
-      stop-on-eof: false
+      on-eof: "loop"
     headers:
       global_header: global_value
       tg1: v1
@@ -98,8 +97,7 @@ scenarios:
     - delimiter: ','
       path: not_found.csv
       quoted: false
-      loop: true
-      stop-on-eof: false
+      on-eof: "loop"
     headers:
       global_header: global_value
     requests:

--- a/tests/yaml/converter/disabled.yml
+++ b/tests/yaml/converter/disabled.yml
@@ -16,7 +16,7 @@ scenarios:
     - delimiter: ','
       path: not_found.csv
       quoted: false
-      on-eof: "loop"
+      loop: true
     headers:
       global_header: global_value
       tg1: v1
@@ -97,7 +97,7 @@ scenarios:
     - delimiter: ','
       path: not_found.csv
       quoted: false
-      on-eof: "loop"
+      loop: true
     headers:
       global_header: global_value
     requests:

--- a/tests/yaml/converter/disabled.yml
+++ b/tests/yaml/converter/disabled.yml
@@ -16,7 +16,8 @@ scenarios:
     - delimiter: ','
       path: not_found.csv
       quoted: false
-      recycle: true
+      loop: true
+      stop-on-eof: false
     headers:
       global_header: global_value
       tg1: v1
@@ -97,7 +98,8 @@ scenarios:
     - delimiter: ','
       path: not_found.csv
       quoted: false
-      recycle: true
+      loop: true
+      stop-on-eof: false
     headers:
       global_header: global_value
     requests:

--- a/tests/yaml/converter/global_copy.jmx
+++ b/tests/yaml/converter/global_copy.jmx
@@ -62,8 +62,8 @@
           <stringProp name="variableNames"></stringProp>
           <stringProp name="delimiter">,</stringProp>
           <boolProp name="quotedData">false</boolProp>
-          <boolProp name="recycle">true</boolProp>
-          <boolProp name="stopThread">false</boolProp>
+          <boolProp name="recycle">false</boolProp>
+          <boolProp name="stopThread">true</boolProp>
           <stringProp name="shareMode">shareMode.all</stringProp>
         </CSVDataSet>
         <hashTree/>


### PR DESCRIPTION
It allows user to control execution of test when CSV data source is exhausted.

This PR:
- adds `on-eof` option to `data-source` object
- removes `loop` option, as it's covered by `on-eof`
- updates jmx2yaml to parse `on-eof` from JMXs to Taurus configs
- adds tests for jmx generator and jmx2yaml converter
- updates docs