### PR TITLE
Add `upload-files` option to JMeter requests to allow multipart/form-data uploads

### DIFF
--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -261,7 +261,7 @@ class JMX(object):
                              guiclass="ArgumentsPanel", testclass="Arguments")
 
     @staticmethod
-    def _get_http_request(url, label, method, timeout, body, keepalive, multipart, files):
+    def _get_http_request(url, label, method, timeout, body, keepalive, files=None):
         """
         Generates HTTP request
         :type method: str
@@ -293,14 +293,14 @@ class JMX(object):
         proxy.append(JMX._bool_prop("HTTPSampler.use_keepalive", keepalive))
         proxy.append(JMX._bool_prop("HTTPSampler.follow_redirects", True))
 
-        proxy.append(JMX._bool_prop("HTTPSampler.DO_MULTIPART_POST", multipart))
-        proxy.append(JMX._bool_prop("HTTPSampler.BROWSER_COMPATIBLE_MULTIPART", multipart))
-
         if timeout is not None:
             proxy.append(JMX._string_prop("HTTPSampler.connect_timeout", timeout))
             proxy.append(JMX._string_prop("HTTPSampler.response_timeout", timeout))
 
         if files:
+            proxy.append(JMX._bool_prop("HTTPSampler.DO_MULTIPART_POST", True))
+            proxy.append(JMX._bool_prop("HTTPSampler.BROWSER_COMPATIBLE_MULTIPART", True))
+
             files_prop = JMX._element_prop("HTTPsampler.Files", "HTTPFileArgs")
             files_coll = JMX._collection_prop("HTTPFileArgs.files")
             for file_dict in files:

--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -261,7 +261,7 @@ class JMX(object):
                              guiclass="ArgumentsPanel", testclass="Arguments")
 
     @staticmethod
-    def _get_http_request(url, label, method, timeout, body, keepalive):
+    def _get_http_request(url, label, method, timeout, body, keepalive, multipart, files):
         """
         Generates HTTP request
         :type method: str
@@ -293,9 +293,25 @@ class JMX(object):
         proxy.append(JMX._bool_prop("HTTPSampler.use_keepalive", keepalive))
         proxy.append(JMX._bool_prop("HTTPSampler.follow_redirects", True))
 
+        proxy.append(JMX._bool_prop("HTTPSampler.DO_MULTIPART_POST", multipart))
+        proxy.append(JMX._bool_prop("HTTPSampler.BROWSER_COMPATIBLE_MULTIPART", multipart))
+
         if timeout is not None:
             proxy.append(JMX._string_prop("HTTPSampler.connect_timeout", timeout))
             proxy.append(JMX._string_prop("HTTPSampler.response_timeout", timeout))
+
+        if files:
+            files_prop = JMX._element_prop("HTTPsampler.Files", "HTTPFileArgs")
+            files_coll = JMX._collection_prop("HTTPFileArgs.files")
+            for file_dict in files:
+                file_elem = JMX._element_prop(file_dict['path'], "HTTPFileArg")
+                file_elem.append(JMX._string_prop("File.path", file_dict['path']))
+                file_elem.append(JMX._string_prop("File.paramname", file_dict["param"]))
+                file_elem.append(JMX._string_prop("File.mimetype", file_dict['mime-type']))
+                files_coll.append(file_elem)
+            files_prop.append(files_coll)
+            proxy.append(files_prop)
+
         return proxy
 
     @staticmethod

--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -261,7 +261,7 @@ class JMX(object):
                              guiclass="ArgumentsPanel", testclass="Arguments")
 
     @staticmethod
-    def _get_http_request(url, label, method, timeout, body, keepalive, files=None):
+    def _get_http_request(url, label, method, timeout, body, keepalive, files=()):
         """
         Generates HTTP request
         :type method: str

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1785,7 +1785,7 @@ class RequestsParser(object):
                 path = file_dict.get('path', ValueError("Items from upload-files must specify path to file"))
                 mime = file_dict.get('mime-type', guess_mime(path))
                 if mime is None:
-                    raise ValueError("Taurus can't detect MIME type for file %s, please specify it manually", path)
+                    raise ValueError("Taurus can't detect MIME type for file %s, please specify it manually" % path)
 
             return HTTPRequest(url, label, method, headers, timeout, think_time, body, upload_files, req)
 

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1784,9 +1784,8 @@ class RequestsParser(object):
             for file_dict in upload_files:
                 file_dict.get("param", ValueError("Items from upload-files must specify parameter name"))
                 path = file_dict.get('path', ValueError("Items from upload-files must specify path to file"))
-                mime = file_dict.get('mime-type', mimetypes.guess_type(path)[0])
-                if mime is None:
-                    raise ValueError("Taurus can't detect MIME type for file %s, please specify it manually" % path)
+                mime = mimetypes.guess_type(path)[0] or "application/octet-stream"
+                file_dict.get('mime-type', mime)
 
             return HTTPRequest(url, label, method, headers, timeout, think_time, body, upload_files, req)
 

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -18,6 +18,7 @@ limitations under the License.
 import csv
 import fnmatch
 import json
+import mimetypes
 import os
 import re
 import socket
@@ -38,7 +39,7 @@ from bzt.modules.console import WidgetProvider, SidebarWidget
 from bzt.modules.provisioning import Local
 from bzt.six import iteritems, string_types, StringIO, etree, binary_type
 from bzt.six import request as http_request
-from bzt.utils import get_full_path, EXE_SUFFIX, MirrorsManager, guess_mime
+from bzt.utils import get_full_path, EXE_SUFFIX, MirrorsManager
 from bzt.utils import shell_exec, ensure_is_dict, dehumanize_time, BetterDict, guess_csv_dialect
 from bzt.utils import unzip, RequiredTool, JavaVM, shutdown_process, ProgressBarContext, TclLibrary
 
@@ -1783,7 +1784,7 @@ class RequestsParser(object):
             for file_dict in upload_files:
                 file_dict.get("param", ValueError("Items from upload-files must specify parameter name"))
                 path = file_dict.get('path', ValueError("Items from upload-files must specify path to file"))
-                mime = file_dict.get('mime-type', guess_mime(path))
+                mime = file_dict.get('mime-type', mimetypes.guess_type(path)[0])
                 if mime is None:
                     raise ValueError("Taurus can't detect MIME type for file %s, please specify it manually" % path)
 

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1333,7 +1333,7 @@ class JMeterScenarioBuilder(JMX):
             body = request.body
 
         http = JMX._get_http_request(request.url, request.label, request.method, timeout, body, global_keepalive,
-                                     request.multipart_form, request.upload_files)
+                                     request.upload_files)
 
         children = etree.Element("hashTree")
 
@@ -1642,7 +1642,7 @@ class Request(object):
 
 
 class HTTPRequest(Request):
-    def __init__(self, url, label, method, headers, timeout, think_time, body, multipart, upload_files, config):
+    def __init__(self, url, label, method, headers, timeout, think_time, body, upload_files, config):
         super(HTTPRequest, self).__init__(config)
         self.url = url
         self.label = label
@@ -1651,7 +1651,6 @@ class HTTPRequest(Request):
         self.timeout = timeout
         self.think_time = think_time
         self.body = body
-        self.multipart_form = multipart
         self.upload_files = upload_files
 
     def __repr__(self):
@@ -1780,9 +1779,7 @@ class RequestsParser(object):
                     body = fhd.read()
             body = req.get("body", body)
 
-            multipart = req.get("multipart-form", False)
             upload_files = req.get("upload-files", [])
-
             for file_dict in upload_files:
                 file_dict.get("param", ValueError("Items from upload-files must specify parameter name"))
                 path = file_dict.get('path', ValueError("Items from upload-files must specify path to file"))
@@ -1790,7 +1787,7 @@ class RequestsParser(object):
                 if mime is None:
                     raise ValueError("Taurus can't detect MIME type for file %s, please specify it manually", path)
 
-            return HTTPRequest(url, label, method, headers, timeout, think_time, body, multipart, upload_files, req)
+            return HTTPRequest(url, label, method, headers, timeout, think_time, body, upload_files, req)
 
     def __parse_requests(self, raw_requests):
         requests = []

--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -900,3 +900,7 @@ def is_piped(file_obj):
     "check if file-object is a pipe or a file redirect"
     mode = os.fstat(file_obj.fileno()).st_mode
     return stat.S_ISFIFO(mode) or stat.S_ISREG(mode)
+
+
+def guess_mime(file_path):
+    return mimetypes.guess_type(file_path)[0]

--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -900,7 +900,3 @@ def is_piped(file_obj):
     "check if file-object is a pipe or a file redirect"
     mode = os.fstat(file_obj.fileno()).st_mode
     return stat.S_ISFIFO(mode) or stat.S_ISREG(mode)
-
-
-def guess_mime(file_path):
-    return mimetypes.guess_type(file_path)[0]

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -10,6 +10,7 @@
  - fix gatling path fail on Windows
  - automatically rename Selenium Python script if it has undiscoverable name
  - fix null global headers failure
+ - add `multipart-form` and `upload-files` options to JMeter requests
 
 ## 1.6.3 <sup>17 jun 2016</sup>
  - fix percentile value handling in passfail criteria

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -10,7 +10,7 @@
  - fix gatling path fail on Windows
  - automatically rename Selenium Python script if it has undiscoverable name
  - fix null global headers failure
- - add `multipart-form` and `upload-files` options to JMeter requests
+ - add `upload-files` option to JMeter requests for multipart/form-data uploads
 
 ## 1.6.3 <sup>17 jun 2016</sup>
  - fix percentile value handling in passfail criteria

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -208,7 +208,7 @@ scenarios:
       upload-files:  # attach files to form (and enable multipart/form-data)
       - param: summaryReport  # form parameter name
         path: report.pdf  # path to file
-        mime-type: application/pdf  # Taurus will guess MIME type automatically
+        mime-type: application/pdf  # optional, Taurus will attempt to guess it automatically
 
       headers:  # local headers that override global
         Authentication: Token 1234567890

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -205,6 +205,13 @@ scenarios:
         param2: value2
       body-file: path/to/file.txt  # this file contents will be used as post body
 
+      multipart-form: false  # use multipart/form-data for POST
+
+      upload-files:  # attach files to multipart form
+      - param: summaryReport  # form parameter name
+        path: report.pdf  # path to file
+        mime-type: application/pdf  # Taurus will guess MIME type automatically
+
       headers:  # local headers that override global
         Authentication: Token 1234567890
         Referer: http://taurus.blazemeter/docs

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -205,9 +205,7 @@ scenarios:
         param2: value2
       body-file: path/to/file.txt  # this file contents will be used as post body
 
-      multipart-form: false  # use multipart/form-data for POST
-
-      upload-files:  # attach files to multipart form
+      upload-files:  # attach files to form (and enable multipart/form-data)
       - param: summaryReport  # form parameter name
         path: report.pdf  # path to file
         mime-type: application/pdf  # Taurus will guess MIME type automatically

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1690,7 +1690,7 @@ class TestJMeterExecutor(BZTestCase):
                             "url": "http://blazedemo.com/",
                             "method": "POST",
                             "upload-files": [{
-                                "path": "stats.csv",
+                                "path": "sound.mp3",
                                 "param": "stats",
                             }, {
                                 "path": "report.pdf",
@@ -1710,7 +1710,7 @@ class TestJMeterExecutor(BZTestCase):
         file_query = 'elementProp[@name="HTTPsampler.Files"]/collectionProp[@name="HTTPFileArgs.files"]/elementProp'
         files = request.findall(file_query)
         self.assertEqual(len(files), 2)
-        self.assertEqual(files[0].find('stringProp[@name="File.mimetype"]').text, "text/csv")
+        self.assertEqual(files[0].find('stringProp[@name="File.mimetype"]').text, "audio/mpeg")
         self.assertEqual(files[1].find('stringProp[@name="File.mimetype"]').text, "application/pdf")
 
     def test_upload_files_mime_autodetect_fail(self):

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -268,7 +268,7 @@ class TestJMeterExecutor(BZTestCase):
         xml_tree = etree.fromstring(open(self.obj.modified_jmx, "rb").read())
         sampler_element = xml_tree.findall(".//HTTPSamplerProxy[@testname='With body params']")
         arguments_element_prop = sampler_element[0][0]
-        self.assertEqual(10, len(sampler_element[0].getchildren()))
+        self.assertEqual(12, len(sampler_element[0].getchildren()))
         self.assertEqual(1, len(arguments_element_prop.getchildren()))
         self.assertEqual(2, len(arguments_element_prop[0].getchildren()))
         self.assertEqual(1, len(arguments_element_prop[0].findall(".//elementProp[@name='param1']")))
@@ -1735,21 +1735,21 @@ class TestJMeterExecutor(BZTestCase):
 class TestJMX(BZTestCase):
     def test_jmx_unicode_checkmark(self):
         obj = JMX()
-        res = obj._get_http_request("url", "label", "method", 0, {"param": u"✓"}, True)
+        res = obj._get_http_request("url", "label", "method", 0, {"param": u"✓"}, True, False, [])
         prop = res.find(".//stringProp[@name='Argument.value']")
         self.assertNotEqual("BINARY", prop.text)
         self.assertEqual(u"✓", prop.text)
 
     def test_variable_hostname(self):
         obj = JMX()
-        res = obj._get_http_request("http://${hostName}:${Port}/${Path}", "label", "method", 0, {}, True)
+        res = obj._get_http_request("http://${hostName}:${Port}/${Path}", "label", "method", 0, {}, True, False, [])
         self.assertEqual("/${Path}", res.find(".//stringProp[@name='HTTPSampler.path']").text)
         self.assertEqual("${hostName}", res.find(".//stringProp[@name='HTTPSampler.domain']").text)
         self.assertEqual("${Port}", res.find(".//stringProp[@name='HTTPSampler.port']").text)
 
     def test_no_port(self):
         obj = JMX()
-        res = obj._get_http_request("http://hostname", "label", "method", 0, {}, True)
+        res = obj._get_http_request("http://hostname", "label", "method", 0, {}, True, False, [])
         self.assertEqual("", res.find(".//stringProp[@name='HTTPSampler.path']").text)
         self.assertEqual("hostname", res.find(".//stringProp[@name='HTTPSampler.domain']").text)
         self.assertEqual("", res.find(".//stringProp[@name='HTTPSampler.port']").text)

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1695,6 +1695,9 @@ class TestJMeterExecutor(BZTestCase):
                             }, {
                                 "path": "report.pdf",
                                 "param": "report",
+                            }, {
+                                "path": "unknown.file",
+                                "param": "stuff",
                             }]
                         }
                     ],
@@ -1709,29 +1712,10 @@ class TestJMeterExecutor(BZTestCase):
         self.assertIsNotNone(request)
         file_query = 'elementProp[@name="HTTPsampler.Files"]/collectionProp[@name="HTTPFileArgs.files"]/elementProp'
         files = request.findall(file_query)
-        self.assertEqual(len(files), 2)
+        self.assertEqual(len(files), 3)
         self.assertEqual(files[0].find('stringProp[@name="File.mimetype"]').text, "audio/mpeg")
         self.assertEqual(files[1].find('stringProp[@name="File.mimetype"]').text, "application/pdf")
-
-    def test_upload_files_mime_autodetect_fail(self):
-        self.obj.engine.config.merge({
-            'execution': {
-                'scenario': {
-                    "requests": [
-                        {
-                            "url": "http://blazedemo.com/",
-                            "upload-files": [{
-                                "path": "unknown",
-                                "param": "stats",
-                            }]
-                        }
-                    ],
-                }
-            },
-            "provisioning": "local",
-        })
-        self.obj.execution = self.obj.engine.config['execution']
-        self.assertRaises(ValueError, self.obj.prepare)
+        self.assertEqual(files[2].find('stringProp[@name="File.mimetype"]').text, "application/octet-stream")
 
 
 class TestJMX(BZTestCase):

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -268,7 +268,7 @@ class TestJMeterExecutor(BZTestCase):
         xml_tree = etree.fromstring(open(self.obj.modified_jmx, "rb").read())
         sampler_element = xml_tree.findall(".//HTTPSamplerProxy[@testname='With body params']")
         arguments_element_prop = sampler_element[0][0]
-        self.assertEqual(12, len(sampler_element[0].getchildren()))
+        self.assertEqual(10, len(sampler_element[0].getchildren()))
         self.assertEqual(1, len(arguments_element_prop.getchildren()))
         self.assertEqual(2, len(arguments_element_prop[0].getchildren()))
         self.assertEqual(1, len(arguments_element_prop[0].findall(".//elementProp[@name='param1']")))
@@ -1667,6 +1667,8 @@ class TestJMeterExecutor(BZTestCase):
         xml_tree = etree.fromstring(open(self.obj.original_jmx, "rb").read())
         request = xml_tree.find('.//HTTPSamplerProxy')
         self.assertIsNotNone(request)
+        self.assertEqual(request.find('boolProp[@name="HTTPSampler.DO_MULTIPART_POST"]').text, 'true')
+        self.assertEqual(request.find('boolProp[@name="HTTPSampler.BROWSER_COMPATIBLE_MULTIPART"]').text, 'true')
         file_query = 'elementProp[@name="HTTPsampler.Files"]/collectionProp[@name="HTTPFileArgs.files"]/elementProp'
         files = request.findall(file_query)
         self.assertEqual(len(files), 2)
@@ -1735,21 +1737,21 @@ class TestJMeterExecutor(BZTestCase):
 class TestJMX(BZTestCase):
     def test_jmx_unicode_checkmark(self):
         obj = JMX()
-        res = obj._get_http_request("url", "label", "method", 0, {"param": u"✓"}, True, False, [])
+        res = obj._get_http_request("url", "label", "method", 0, {"param": u"✓"}, True)
         prop = res.find(".//stringProp[@name='Argument.value']")
         self.assertNotEqual("BINARY", prop.text)
         self.assertEqual(u"✓", prop.text)
 
     def test_variable_hostname(self):
         obj = JMX()
-        res = obj._get_http_request("http://${hostName}:${Port}/${Path}", "label", "method", 0, {}, True, False, [])
+        res = obj._get_http_request("http://${hostName}:${Port}/${Path}", "label", "method", 0, {}, True)
         self.assertEqual("/${Path}", res.find(".//stringProp[@name='HTTPSampler.path']").text)
         self.assertEqual("${hostName}", res.find(".//stringProp[@name='HTTPSampler.domain']").text)
         self.assertEqual("${Port}", res.find(".//stringProp[@name='HTTPSampler.port']").text)
 
     def test_no_port(self):
         obj = JMX()
-        res = obj._get_http_request("http://hostname", "label", "method", 0, {}, True, False, [])
+        res = obj._get_http_request("http://hostname", "label", "method", 0, {}, True)
         self.assertEqual("", res.find(".//stringProp[@name='HTTPSampler.path']").text)
         self.assertEqual("hostname", res.find(".//stringProp[@name='HTTPSampler.domain']").text)
         self.assertEqual("", res.find(".//stringProp[@name='HTTPSampler.port']").text)

--- a/tests/yaml/converter/disabled.jmx
+++ b/tests/yaml/converter/disabled.jmx
@@ -239,6 +239,36 @@
           </collectionProp>
         </HeaderManager>
         <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="request with files" enabled="true">
+          <elementProp name="HTTPsampler.Files" elementType="HTTPFileArgs">
+            <collectionProp name="HTTPFileArgs.files">
+              <elementProp name="file.txt" elementType="HTTPFileArg">
+                <stringProp name="File.path">file.txt</stringProp>
+                <stringProp name="File.paramname">attachment</stringProp>
+                <stringProp name="File.mimetype">text/plain</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">blazedemo.com</stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/</stringProp>
+          <stringProp name="HTTPSampler.method">POST</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">true</boolProp>
+          <boolProp name="HTTPSampler.BROWSER_COMPATIBLE_MULTIPART">true</boolProp>
+          <boolProp name="HTTPSampler.monitor">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
       </hashTree>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Second Thread Group" enabled="true">
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>

--- a/tests/yaml/converter/disabled.yml
+++ b/tests/yaml/converter/disabled.yml
@@ -82,6 +82,13 @@ scenarios:
       think-time: 500ms
       timeout: 200ms
       url: http://192.168.0.1/
+    - url: http://blazedemo.com/
+      label: request with files
+      method: POST
+      upload-files:
+      - param: attachment
+        path: file.txt
+        mime-type: text/plain
     store-cache: false
     store-cookie: false
     use-dns-cache-mgr: true


### PR DESCRIPTION
They can be used to POST a multipart/form-data with files.