### PR TITLE
Refactor imports in console module to fix Scrutinizer tests

### DIFF
--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -853,9 +853,9 @@ class DummyScreen(BaseScreen):
     Null-object for Screen on non-tty output
     """
 
-    def __init__(self):
+    def __init__(self, rows=120, cols=40):
         super(DummyScreen, self).__init__()
-        self.size = (120, 40)
+        self.size = (rows, cols)
         self.ansi_escape = re.compile(r'\x1b[^m]*m')
 
     def get_cols_rows(self):

--- a/tests/modules/test_consoleStatusReporter.py
+++ b/tests/modules/test_consoleStatusReporter.py
@@ -120,23 +120,21 @@ class TestConsoleStatusReporter(BZTestCase):
         obj.post_process()
 
     def test_screen(self):
-        isatty = sys.stdout.isatty
-        sys.stdout.isatty = lambda: True
         obj = ConsoleStatusReporter()
         obj.settings["screen"] = "console"
-        if not is_windows():
-            self.assertIsInstance(obj._get_screen(), ConsoleScreen)
+        if not sys.stdout.isatty():
+            self.assertEqual(obj._get_screen_type(), "dummy")
+        elif is_windows():
+            self.assertEqual(obj._get_screen(), "gui")
         else:
-            self.assertIsInstance(obj._get_screen(), GUIScreen)
-        sys.stdout.isatty = isatty
+            self.assertEqual(obj._get_screen_type(), "console")
 
     def test_screen_invalid(self):
-        isatty = sys.stdout.isatty
-        sys.stdout.isatty = lambda: True
         obj = ConsoleStatusReporter()
         obj.settings["screen"] = "invalid"
-        if not is_windows():
-            self.assertIsInstance(obj._get_screen(), ConsoleScreen)
+        if not sys.stdout.isatty():
+            self.assertEqual(obj._get_screen_type(), "dummy")
+        elif is_windows():
+            self.assertEqual(obj._get_screen(), "gui")
         else:
-            self.assertIsInstance(obj._get_screen(), GUIScreen)
-        sys.stdout.isatty = isatty
+            self.assertEqual(obj._get_screen_type(), "console")


### PR DESCRIPTION
Also,
* Get rid of duplicated `DummyScreen`
* Handle absent `curses` in console tests.