### PR TITLE
Update Gatling script example

### DIFF
--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -4,6 +4,7 @@
  - fix non-graceful shutdown on GUI window close
  - restructure reporting and services docs
  - do not crash when attempting to open browser in browserless env
+ - update Gatling script sample in docs
 
 ## 1.6.4 <sup>05 jul 2016</sup>
  - add short script syntax (`<scenario>: \<script>`)

--- a/site/dat/docs/Gatling.md
+++ b/site/dat/docs/Gatling.md
@@ -1,8 +1,8 @@
 # Gatling Executor
 
 Gatling is load testing tool which most famous as choice for testing of HTTP servers.
- 
-In Taurus you have two way for run it: with native gatling script or with usual Taurus features: `requests`, `iterations`, etc. In last case scala script will be generated automatically.  
+
+In Taurus you have two way for run it: with native gatling script or with usual Taurus features: `requests`, `iterations`, etc. In last case scala script will be generated automatically.
 
 ## Run Gatling Tool
 
@@ -11,7 +11,7 @@ In Taurus you have two way for run it: with native gatling script or with usual 
 execution:
 - executor: gatling
   scenario: sample
-  
+
 scenarios:
   sample:
     script: tests/gatling/BasicSimulation.scala
@@ -22,39 +22,49 @@ The `simulation` option is canonical class name for main simulation class. It wi
 
 ## Load Configuration
 
- Taurus supports possibility to send values of execution options `concurrency`, `iterations`, `ramp-up` and `hold-for` to Gatling test script. Below you can see example of usage these parameters on the Gatling side:
- 
-```
- package mytest
+Taurus supports possibility to send values of execution options `concurrency`, `iterations`, `ramp-up` and `hold-for` to Gatling test script. Below you can see how you can use these parameters on the Gatling side to set up your test:
+
+```scala
+package tests.gatling
 
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 import scala.concurrent.duration._
 
 class BasicSimulation extends Simulation {
+  // parse load profile from Taurus
+  val iterations = Integer.getInteger("iterations", 100).toInt
+  val concurrency = Integer.getInteger("concurrency", 10).toInt
+  val rampUp = Integer.getInteger("ramp-up", 1).toInt
+  val holdFor = Integer.getInteger("hold-for", 60).toInt
+  val httpConf = http.baseURL("http://blazedemo.com/")
 
-  val httpConf = http
-    .baseURL("http://blazedemo.com/")
+  // 'forever' means each thread will execute scenario until
+  // duration limit is reached
+  val loopScenario = scenario("Loop Scenario").forever() {
+    exec(http("index").get("/"))
+  }
 
-  val scn = scenario("Extra").exec(
-          http("request_1").get("/")
-      )
+  // if you want to set an iteration limit (instead of using duration limit),
+  // you can use the following scenario
+  val iterationScenario = scenario("Iteration Scenario").repeat(iterations) {
+    exec(http("index").get("/"))
+  }
 
-  val t_concurrency = Integer.getInteger("concurrency", 10).toInt
-  val t_ramp_up = Integer.getInteger("hold-for", 1).toInt
-  val t_hold_for = Integer.getInteger("ramp-up", 1).toInt
+  val execution = loopScenario
+    .inject(rampUsers(concurrency) over rampUp)
+    .protocols(httpConf)
 
-  setUp(scn.inject(rampUsers(t_concurrency) over (t_ramp_up))
-    .protocols(httpConf)).maxDuration(t_ramp_up + t_hold_for)
+  setUp(execution).maxDuration(rampUp + holdFor)
 }
 ```
 
 ## Building Test Script from Config
 
- If your scenario don't contains `script` parameter and contains at least one element of `requests` Taurus will build scala script for test. This script will be placed in `[artifact-dir](ConfigSyntax/#Top-Level-Settings)`: you can modify it and use with Gatling later. 
- 
- Following abilities are supported: `default-address`, `requests`, `headers` on scenario and request levels, `body` of request, `think-time` and params that described in `[Load Configuration](#Load Configuration)`. 
- Some asserts can be added to request. Assert describes templates and area for search (`contains` and `subject` accordingly), regexp and inverse marks. You can look for particular response code in `http-code` part or for string and regular expression in `body` of request.
+If your scenario don't contains `script` parameter and contains at least one element of `requests` Taurus will build scala script for test. This script will be placed in `[artifact-dir](ConfigSyntax/#Top-Level-Settings)`: you can modify it and use with Gatling later.
+
+Following features are supported: `default-address`, `requests`, `headers` on scenario and request levels, `body` of request, `think-time` and params that described in `[Load Configuration](#Load Configuration)`.
+Some asserts can be added to request. Assert describes templates and area for search (`contains` and `subject` accordingly), regexp and inverse marks. You can look for particular response code in `http-code` part or for string and regular expression in `body` of request.
  Next yaml example shows the way these features can be used and ready to conversion to scala automatically:
 
 ```yaml
@@ -66,7 +76,7 @@ execution:
   ramp-up: 2
   hold-for: 10
   scenario: complex_sample
-  
+
 scenarios:
   complex_sample:
     default-address: blazedemo.com
@@ -80,18 +90,19 @@ scenarios:
         - .+sometext.+  # expression for assertion (mandatory)
           subject: body # subject for search (defalut: body)
           regexp: true  # whether expression is regular (default: false)
-          not: true     # invert condition (default: false)          
+          not: true     # invert condition (default: false)
       body: 'Some Body Data'
       headers:
         HEADER_11: VALUE_11
     - url: /reserve.php
       think-time: 2s
       assert:
-      - contains: 
+      - contains:
         - 200
         subject: http-code
         not: true
 ```
+
 ## Configuration Options
 
  Similar to other modules there is possibility of global configuration Gatling Executor by write some lines in `gatling` branch of modules setting. Next options can be set:
@@ -99,28 +110,30 @@ scenarios:
     Path to Gatling executable.
     If no Gatling executable found, it will be automatically downloaded and installed in "path".
     By default "~/.bzt/gatling-taurus/bin/gatling.sh".
-    
+
  - `java-opts`: string with some java options for Gatling
-     
+
  - `download-link`:"http://somehost/gatling-charts-highcharts-bundle-{version}-bundle.zip"
     Link to download Gatling.
     By default: "https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/{version}/gatling-charts-highcharts-bundle-{version}-bundle.zip"
-    
+
  -  `version`: "2.1.7"
     Gatling version, 2.1.7 by default
 
  - `properties`: dictionary for tuning of gatling tool behaviour (see list of available parameters in gatling documentation). Following example shows setting output buffer size:
-        
+
 ```yaml
 ---
 modules:
   gatling:
     properties:
-      gatling.data.file.bufferSize: 512  # output buffer size, 256 bytes by default      
+      gatling.data.file.bufferSize: 512  # output buffer size, 256 bytes by default
 ```
+
 ## External Java Libraries Usage
 
 Thanks to Taurus you can use additional Java classes in your scala code. For this add required jar files or contained dir to `files` list:
+
 ```yaml
 ---
 execution:
@@ -128,14 +141,15 @@ execution:
   concurrency: 10
   hold-for: 1h
   scenario: example
-  files: 
+  files:
   - first.jar
   - second.jar
   - folder_with_jars
-scenarios: 
+scenarios:
   example:
     script: my_file.scala
-    
+```
+
 ## Gatling 2.2.0 Support
 
 Taurus works with Gatling 2.2.0. However, with Gatling 2.2.0 it's not possible to extract such network stats


### PR DESCRIPTION
Make it show usage of `forever` and `repeat` constructs that allow to control test execution specifics.

(Also, remove trailing whitespace).