### PR TITLE
Optimize stats reader in JMeter executor

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -884,6 +884,7 @@ class IncrementalCSVReader(object):
         self.offset = 0
         self.filename = filename
         self.fds = None
+        self.read_speed = 1024 * 1024
 
     def read(self, last_pass=False):
         """
@@ -901,11 +902,14 @@ class IncrementalCSVReader(object):
         if last_pass:
             lines = self.fds.readlines()  # unlimited
         else:
-            lines = self.fds.readlines(1024 * 1024)  # 1MB limit to read
-
+            lines = self.fds.readlines(int(self.read_speed))
         self.offset = self.fds.tell()
-
-        self.log.debug("Read lines: %s / %s bytes", len(lines), len(''.join(lines)))
+        bytes_read = sum(len(line) for line in lines)
+        self.log.debug("Read lines: %s / %s bytes (at speed %s)", len(lines), bytes_read, self.read_speed)
+        if sum(len(line) for line in lines) >= self.read_speed:
+            self.read_speed *= 2
+        elif bytes_read < self.read_speed / 2:
+            self.read_speed = max(self.read_speed / 2, 1024 * 1024)
 
         for line in lines:
             if not line.endswith("\n"):

--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -147,7 +147,6 @@ class BetterDict(defaultdict):
 
     def __init__(self, **kwargs):
         super(BetterDict, self).__init__(**kwargs)
-        self.log = logging.getLogger(self.__class__.__name__)
 
     def get(self, key, default=defaultdict):
         """
@@ -187,15 +186,11 @@ class BetterDict(defaultdict):
                 if key[1:] in self:
                     self.pop(key[1:])
                 key = key[1:]
-                self.log.debug("Overridden key: %s", key)
 
             if len(key) and key[0] == '^':  # eliminate flag
                 # TODO: improve logic - use val contents to see what to eliminate
                 if key[1:] in self:
                     self.pop(key[1:])
-                    self.log.debug("Removed key: %s", key)
-                else:
-                    self.log.debug("No key to remove: %s", key)
                 continue
 
             if isinstance(val, dict):
@@ -207,7 +202,6 @@ class BetterDict(defaultdict):
                 elif isinstance(dst, dict):
                     raise ValueError("Mix of DictOfDict and dict is forbidden")
                 else:
-                    self.log.warning("Overwritten key: %s", key)
                     self[key] = val
             elif isinstance(val, list):
                 self.__ensure_list_type(val)
@@ -216,7 +210,6 @@ class BetterDict(defaultdict):
                 if isinstance(self[key], list):
                     self[key].extend(val)
                 else:
-                    self.log.warning("Overridden key: %s", key)
                     self[key] = val
             else:
                 self[key] = val

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -5,6 +5,7 @@
  - restructure reporting and services docs
  - do not crash when attempting to open browser in browserless env
  - update Gatling script sample in docs
+ - solve slow post-processing by making reading speed of kpi.jtl adaptive
 
 ## 1.6.4 <sup>05 jul 2016</sup>
  - add short script syntax (`<scenario>: \<script>`)


### PR DESCRIPTION
This PR has the following changes:
1. Makes kpi.jtl reading speed adaptive;
2. Removes logging from BetterDict.

1. Reading speed from kpi.jtl was capped at 1 MB per second, which was causing post-processing phase to be quite slow when kpi.jtl is large. Dynamically adapting reading speed solves that, but only partially. Ultimately, user may need to increase `check-interval` to make overall performance bearable. 

2. Profiling with cProfile while running Taurus with simple config (config that makes JMeter generate ~10k HTTP errors per second) shows that ~15% of run time is spent in `logging.getLogger()` call inside `BetterDict.__init__()` method, which is a bit unexpected. It also shows, that `BetterDict.__init__()` is called ~6 million times per minute, which is a *lot*. So it makes sense to not have logging inside such hot code. And indeed, removing logger from BetterDict shows a ~15% improvement in run time.