### PR TITLE
Optimize aggregator by removing excessive calls to BetterDict.get

### DIFF
--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## 1.6.6 (next)
+ - optimize aggregator by removing excessive calls to `BetterDict.get()`
+
 ## 1.6.5 <sup>12 jul 2016</sup>
  - fix master_id choosing for cloud reporting 
  - fix non-graceful shutdown on GUI window close


### PR DESCRIPTION
Taurus config used for profiling generates exactly 500k samples in about 30 seconds.

## Baseline

* 9 million calls to `BetterDict.get()`
* 3 million calls to `BetterDict.__init__()`
* `time.sleep()` was occupying only 10% of running time, while ideally it should be close to 99%
* Engine utilization (engine-loop metric) was often exceeding 1.0  
 
![aggregator-noop](https://cloud.githubusercontent.com/assets/668589/16763756/18d25908-4833-11e6-8c31-c2e3a6ba76a7.png)

## Optimized

* Number of calls to `BetterDict.get()` is reduced to only 9000 (!)
* Number of calls to `BetterDict.__init__()` is reduced to 4000
* `time.sleep()` occupies 53% of run time, which is much better
* Engine utilization stays at 0.5-0.6, which is not perfect, but better

![aggregator-optimized](https://cloud.githubusercontent.com/assets/668589/16763817/5e6e3022-4833-11e6-9be6-12746029cf7d.png)

## Optimizations

- Remove excessive calls to `BetterDict.get()` where simple `__getitem__` call is sufficient.
- Do not create a KPISet for every sample in `ResultsReader.__aggregate_current()`