### PR TITLE
fix keepalive type cast, add keepalive into pbench and gatling docs

### DIFF
--- a/bzt/modules/gatling.py
+++ b/bzt/modules/gatling.py
@@ -291,8 +291,10 @@ class GatlingExecutor(ScenarioExecutor, WidgetProvider, FileLister):
 
         if scenario.get('timeout', None) is not None:
             params_for_scala['gatling.http.ahc.requestTimeout'] = int(dehumanize_time(scenario.get('timeout')) * 1000)
-        if scenario.get('keepalive', None) is not None:
-            params_for_scala['gatling.http.ahc.keepAlive'] = scenario.get('keepalive').lower()
+        if scenario.get('keepalive', True):
+            params_for_scala['gatling.http.ahc.keepAlive'] = 'true'
+        else:
+            params_for_scala['gatling.http.ahc.keepAlive'] = 'false'
         if load.concurrency is not None:
             params_for_scala['concurrency'] = load.concurrency
         if load.ramp_up is not None:

--- a/site/dat/docs/ApacheBenchmark.md
+++ b/site/dat/docs/ApacheBenchmark.md
@@ -8,7 +8,7 @@ Taurus supports the following features of Apache Benchmark:
  - `concurrency`: number of multiple requests to make at a time (defaults to 1).
  - `hold-for`: run load testing for specified duration
  - `headers`: headers to attach to HTTP request
- - `keepalive`: use HTTP KeepAlive feature
+ - `keepalive`: use HTTP KeepAlive feature (you can use it on two levels - global for whole scenario and local for some requests)
 
 Keep in mind the following rules when using `executor: ab`:
  - You cannot specify more than one request in `requests` section.

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -2,6 +2,7 @@
 ## 1.6.7 (next)
  - add worker id to cloud log file names
  - add `cloud` and `local` aliases 
+ - fix Gatling keepalive type cast bug
 
 ## 1.6.6 <sup>08 aug 2016</sup>
  - optimize aggregator by removing excessive calls to `BetterDict.get()`

--- a/site/dat/docs/Gatling.md
+++ b/site/dat/docs/Gatling.md
@@ -16,9 +16,11 @@ scenarios:
   sample:
     script: tests/gatling/BasicSimulation.scala
     simulation: tests.gatling.BasicSimulation
+    keepalive: true
 ```
 
 The `simulation` option is canonical class name for main simulation class. It will be passed as-is to gatling with `-s` option.
+Also you can use `keepalive` scenario attribute to set appropriate HTTP feature. 
 
 ## Load Configuration
 

--- a/site/dat/docs/PBench.md
+++ b/site/dat/docs/PBench.md
@@ -83,6 +83,7 @@ scenarios:
     default-address: http://blazedemo.com
     timeout: 10s  # important setting, affects for how long its workers are busy with request
     script: payload.src
+    keepalive: true # set HTTP connection reuse (true is default)
 ```
 
 Where `payload.src` is a file of following format:


### PR DESCRIPTION
This PR fixes bug of keepalive type casting in Gatling. Also some references about keepalive was added to docs.