### PR TITLE
fix first executor delay trouble

### DIFF
--- a/bzt/modules/provisioning.py
+++ b/bzt/modules/provisioning.py
@@ -87,9 +87,10 @@ class Local(Provisioning):
 
         self._start_modules()
         for executor in self.executors:
-            if executor in self.engine.started and executor not in self.finished_modules:
-                if executor.check():
-                    self.finished_modules.append(executor)
+            if executor not in self.finished_modules:
+                if executor in self.engine.started:
+                    if executor.check():
+                        self.finished_modules.append(executor)
                 else:
                     finished = False
 

--- a/bzt/modules/provisioning.py
+++ b/bzt/modules/provisioning.py
@@ -87,12 +87,17 @@ class Local(Provisioning):
 
         self._start_modules()
         for executor in self.executors:
-            if executor not in self.finished_modules:
-                if executor in self.engine.started:
-                    if executor.check():
-                        self.finished_modules.append(executor)
-                else:
-                    finished = False
+            if executor in self.finished_modules:
+                continue
+
+            if executor not in self.engine.started:
+                finished = False
+                continue
+
+            if executor.check():
+                self.finished_modules.append(executor)
+            else:
+                finished = False
 
         return finished
 

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -2,6 +2,7 @@
 ## 1.6.7 (next)
  - add worker id to cloud log file names
  - add `cloud` and `local` aliases 
+ - fix delay trouble in provisioning
 
 ## 1.6.6 <sup>08 aug 2016</sup>
  - optimize aggregator by removing excessive calls to `BetterDict.get()`


### PR DESCRIPTION
If the first executor is delayed (not started) check() will return True and Taurus will stop