### PR TITLE
Apply repr() to webdriver log path before writing it to Selenium script

### DIFF
--- a/bzt/modules/selenium.py
+++ b/bzt/modules/selenium.py
@@ -771,7 +771,7 @@ class SeleniumScriptBuilder(NoseTest):
 
         if browser == 'Firefox':
             setup_method_def.append(self.gen_method_statement("profile = webdriver.FirefoxProfile()"))
-            log_set = self.gen_method_statement("profile.set_preference('webdriver.log.file', r'%s')" % self.wdlog)
+            log_set = self.gen_method_statement("profile.set_preference('webdriver.log.file', %s)" % repr(self.wdlog))
             setup_method_def.append(log_set)
             setup_method_def.append(self.gen_method_statement("self.driver = webdriver.Firefox(profile)"))
         else:

--- a/bzt/modules/selenium.py
+++ b/bzt/modules/selenium.py
@@ -770,12 +770,12 @@ class SeleniumScriptBuilder(NoseTest):
         setup_method_def = self.gen_method_definition("setUp", ["self"])
 
         if browser == 'Firefox':
-            setup_method_def.append(self.gen_method_statement("profile = webdriver.%sProfile();" % browser))
-            log_set = self.gen_method_statement("profile.set_preference('webdriver.log.file', '%s');" % self.wdlog)
+            setup_method_def.append(self.gen_method_statement("profile = webdriver.FirefoxProfile()"))
+            log_set = self.gen_method_statement("profile.set_preference('webdriver.log.file', r'%s')" % self.wdlog)
             setup_method_def.append(log_set)
-            setup_method_def.append(self.gen_method_statement("self.driver=webdriver.%s(profile)" % browser))
+            setup_method_def.append(self.gen_method_statement("self.driver = webdriver.Firefox(profile)"))
         else:
-            setup_method_def.append(self.gen_method_statement("self.driver=webdriver.%s()" % browser))
+            setup_method_def.append(self.gen_method_statement("self.driver = webdriver.%s()" % browser))
 
         scenario_timeout = self.scenario.get("timeout", 30)
         setup_method_def.append(self.gen_impl_wait(scenario_timeout))


### PR DESCRIPTION
Because Windows paths do not play nicely with Python string escape characters. 