### PR TITLE
Optimize image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ RUN apt-get -y update \
   && echo '{"settings": {"artifacts-dir": "/tmp/artifacts"}}' > /etc/bzt.d/90-artifacts-dir.json \
   && echo '{"modules": {"console": {"disable": true}}}' > /etc/bzt.d/90-no-console.json \
   && bzt -o settings.default-executor=jmeter -o execution.scenario.requests.0=http://localhost/ -o execution.iterations=1 -o execution.hold-for=1 -o execution.throughput=1 \
-  && mkdir /bzt-configs
-CMD cd /bzt-configs  && bzt -l /tmp/artifacts/bzt.log /bzt-configs/*.yml
+  && mkdir /bzt-configs \
+  && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,10 @@ RUN apt-get -y update \
   && echo '{"install-id": "Docker"}' > /etc/bzt.d/99-zinstallID.json \
   && echo '{"settings": {"artifacts-dir": "/tmp/artifacts"}}' > /etc/bzt.d/90-artifacts-dir.json \
   && echo '{"modules": {"console": {"disable": true}}}' > /etc/bzt.d/90-no-console.json \
-  && bzt -o settings.default-executor=jmeter -o execution.scenario.requests.0=http://localhost/ -o execution.iterations=1 -o execution.hold-for=1 -o execution.throughput=1 \
+  && bzt -o settings.default-executor=jmeter \
+    -o execution.scenario.requests.0=http://localhost/ \
+    -o execution.iterations=1 -o execution.hold-for=1 \
+    -o execution.throughput=1 \
   && mkdir /bzt-configs \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,6 @@ RUN apt-get -y update \
   && bzt -o settings.default-executor=jmeter -o execution.scenario.requests.0=http://localhost/ -o execution.iterations=1 -o execution.hold-for=1 -o execution.throughput=1 \
   && mkdir /bzt-configs \
   && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /bzt-configs
+CMD bzt -l /tmp/artifacts/bzt.log /bzt-configs/*.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:14.04
 RUN apt-get -y update \
-  && apt-get -y --force-yes install \
+  && apt-get -y --force-yes install --no-install-recommends \
+    gcc \
     libxslt1-dev \
     zlib1g-dev \
     python-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,18 @@
 FROM ubuntu:14.04
-RUN apt-get -y update
-RUN apt-get -y --force-yes install libxslt1-dev
-RUN apt-get -y --force-yes install zlib1g-dev
-RUN apt-get -y --force-yes install python-dev
-RUN apt-get -y --force-yes install python-pip
-RUN apt-get -y --force-yes install default-jre-headless
-RUN apt-get -y --force-yes install xvfb
-RUN apt-get -y --force-yes install libyaml-dev
-RUN apt-get -y --force-yes install siege
-RUN pip install bzt==1.6.5
-RUN echo '{"install-id": "Docker"}' > /etc/bzt.d/99-zinstallID.json
-RUN echo '{"settings": {"artifacts-dir": "/tmp/artifacts"}}' > /etc/bzt.d/90-artifacts-dir.json
-RUN echo '{"modules": {"console": {"disable": true}}}' > /etc/bzt.d/90-no-console.json
-RUN bzt -o settings.default-executor=jmeter -o execution.scenario.requests.0=http://localhost/ -o execution.iterations=1 -o execution.hold-for=1 -o execution.throughput=1
-RUN mkdir /bzt-configs
+RUN apt-get -y update \
+  && apt-get -y --force-yes install \
+    libxslt1-dev \
+    zlib1g-dev \
+    python-dev \
+    python-pip \
+    default-jre-headless \
+    xvfb \
+    libyaml-dev \
+    siege \
+  && pip install bzt==1.6.5 \
+  && echo '{"install-id": "Docker"}' > /etc/bzt.d/99-zinstallID.json \
+  && echo '{"settings": {"artifacts-dir": "/tmp/artifacts"}}' > /etc/bzt.d/90-artifacts-dir.json \
+  && echo '{"modules": {"console": {"disable": true}}}' > /etc/bzt.d/90-no-console.json \
+  && bzt -o settings.default-executor=jmeter -o execution.scenario.requests.0=http://localhost/ -o execution.iterations=1 -o execution.hold-for=1 -o execution.throughput=1 \
+  && mkdir /bzt-configs
 CMD cd /bzt-configs  && bzt -l /tmp/artifacts/bzt.log /bzt-configs/*.yml


### PR DESCRIPTION
Optimize size of taurus docker image using some best practices that are common to docker development. These include:
- Reduce number of image layers by consolidating ```RUN``` commands into a single ```RUN``` directive.
- Use ```--no-install-recommends``` to skip installing superfluous packages (however include gcc as an explicitly installed package, as this is required to build the image)
- remove cache after install
- NIT: user ```WORKDIR``` to set the container's default working directory

### Size reductions after iteratively applying changes
- original size:  735.1 MB
- with RUN cmds consolidated: 722.6 MB
- with --no-install-recommends + install gcc:  603.2 MB
- with rm -rf /var/lib/apt/lists/*:  581.1 MB