### PR TITLE
Add `action` blocks to JMeter's requests

### DIFF
--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -1002,3 +1002,11 @@ class JMX(object):
     @staticmethod
     def _get_functional_mode_prop(enabled):
         return JMX._bool_prop("TestPlan.functional_mode", enabled)
+
+    @staticmethod
+    def _get_action_block(action_index, target_index, duration_ms):
+        action = etree.Element("TestAction", guiclass="TestActionGui", testclass="TestAction", testname="Test Action")
+        action.append(JMX.int_prop("ActionProcessor.action", action_index))
+        action.append(JMX.int_prop("ActionProcessor.target", target_index))
+        action.append(JMX._string_prop("ActionProcessor.duration", str(duration_ms)))
+        return action

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1971,6 +1971,11 @@ class RequestsParser(object):
         elif 'include-scenario' in req:
             name = req.get('include-scenario')
             return IncludeScenarioBlock(name, req)
+        elif 'action' in req:
+            action = req.get('action')
+            target = req.get('target', 'current-thread')
+            duration = req.get('pause-duration', None)  # TODO: dehumanize
+            return ActionBlock(action, target, duration, req)
         else:
             return HierarchicHTTPRequest(req, self.engine)
 
@@ -1998,6 +2003,14 @@ class HierarchicHTTPRequest(HTTPRequest):
             path = file_dict.get('path', ValueError("Items from upload-files must specify path to file"))
             mime = mimetypes.guess_type(path)[0] or "application/octet-stream"
             file_dict.get('mime-type', mime)
+
+
+class ActionBlock(Request):
+    def __init__(self, action, target, duration, config):
+        super(ActionBlock, self).__init__(config)
+        self.action = action
+        self.target = target
+        self.duration = duration
 
 
 class RequestVisitor(object):

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -6,6 +6,7 @@
  - do not copy Selenium scripts in artifacts dir before running them
  - fix KPI merging error
  - introduce `language` option for Selenium tests
+ - add `action` blocks to JMeter's requests
 
 ## 1.6.8 <sup>1 sep 2016</sup>
  - fix hamcrest installation for Java-based Selenium tests

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -408,6 +408,7 @@ Taurus allows to control execution flow with the following constructs:
 - `foreach` blocks
 - `transaction` blocks
 - `include-scenario` blocks
+- `action` blocks
 
 ##### If Blocks
 
@@ -554,7 +555,7 @@ scenarios:
 ```
 
 ##### Include Scenario blocks
-`include-scenario` blocks allows you to include scenario in another one. You can use it to split your test plan into
+`include-scenario` block allows you to include scenario in another one. You can use it to split your test plan into
 a few of independent scenarios that can be reused.
 
 Example:
@@ -583,6 +584,33 @@ scenarios:
 
 Taurus translates each `include-scenario` block to a JMeter's `Simple Controller` and puts all scenario-level
 settings and requests there.
+
+##### Action Blocks
+
+`action` block allows you to specify a thread-specific action that will be performed. You can use it to pause or stop
+the current thread, or force it to go to the next loop iteration.
+
+The following actions are available:
+- `pause` - pause the target thread (pause duration is controlled with `pause-duration` field)
+- `stop` - stop the target thread gracefully
+- `stop-now` - stop the test without waiting for samples to complete
+- `continue` - send target thread to the next iteration of the loop
+
+Actions can be applied to the following targets:
+- `current-thread` - set by default
+- `all-threads` - action will be applied to all threads (unavailable for `continue` action)
+
+Examples:
+```yaml
+scenarios:
+  action_example:
+    requests:
+    - action: pause
+      target: current-thread
+      pause-duration: 1s500ms
+    - action: stop-now
+      target: all-threads
+```
 
 ## JMeter Test Log
 You can tune JTL file content with option `write-xml-jtl`. Possible values are 'error' (default), 'full', or any other value for 'none'. Keep in mind: max `full` logging can seriously load your system.


### PR DESCRIPTION
It corresponds to `Test Action` element and allows to pause or stop one or many JMeter threads.