### PR TITLE
Alpine-based Docker Image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Ignore all the project files from context, as we're using PIP to download the code into the
+# container image. It's a bit better if we use the code already in the project, so we should later
+# remove this:
+./*


### PR DESCRIPTION
# What does this PR do?

A continuation of #334, these are the changes done to achieve an even smaller image size:

```
REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
undera/bzt          latest              105d98a53b30        About a minute ago   581 MB
undera/bzt          alpine              7aef1cd4afee        11 minutes ago       292.4 MB
```

Also, I noticed that the bzt image wasn't honoring the `/tmp/artifact` directory anymore, so I added that option in the default command.