### PR TITLE
Introduce `bytes` field for KPISet

### DIFF
--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -199,7 +199,7 @@ class JMX(object):
             "requestHeaders": False,
             "responseDataOnError": False,
             "saveAssertionResultsFailureMessage": False,
-            "bytes": False,
+            "bytes": True,
             "hostname": True,
             "threadCounts": True,
             "url": False

--- a/bzt/modules/ab.py
+++ b/bzt/modules/ab.py
@@ -201,8 +201,9 @@ class TSVDataReader(ResultsReader):
             _con_time = float(log_vals[2]) / 1000  # connection time
             _etime = float(log_vals[4]) / 1000  # elapsed time
             _latency = float(log_vals[5]) / 1000  # latency (aka waittime)
+            _bytes = None
 
-            yield _tstamp, _url, _concur, _etime, _con_time, _latency, _rstatus, _error, ''
+            yield _tstamp, _url, _concur, _etime, _con_time, _latency, _rstatus, _error, '', _bytes
 
 
 class ApacheBenchmark(RequiredTool):

--- a/bzt/modules/blazemeter.py
+++ b/bzt/modules/blazemeter.py
@@ -1379,7 +1379,7 @@ class BlazeMeterClient(object):
             "bytes": cumul[KPISet.BYTE_COUNT],
             "bytesMax": 0,
             "bytesMin": 0,
-            "bytesAvg": 0,
+            "bytesAvg": int(cumul[KPISet.BYTE_COUNT] / float(cumul[KPISet.SAMPLE_COUNT])),
             "bytesSTD": 0,
 
             "otherErrorsSpillcount": 0,

--- a/bzt/modules/blazemeter.py
+++ b/bzt/modules/blazemeter.py
@@ -1376,7 +1376,7 @@ class BlazeMeterClient(object):
             "latencyMin": 0,
             "latencySTD": 0,
 
-            "bytes": 0,
+            "bytes": cumul[KPISet.BYTE_COUNT],
             "bytesMax": 0,
             "bytesMin": 0,
             "bytesAvg": 0,
@@ -1412,10 +1412,10 @@ class BlazeMeterClient(object):
             "by": {
                 "min": 0,
                 "max": 0,
-                "sum": 0,
-                "n": 0,
+                "sum": item[KPISet.BYTE_COUNT],
+                "n": item[KPISet.SAMPLE_COUNT],
                 "std": 0,
-                "avg": 0
+                "avg": item[KPISet.BYTE_COUNT] / float(item[KPISet.SAMPLE_COUNT])
             },
         }
 

--- a/bzt/modules/gatling.py
+++ b/bzt/modules/gatling.py
@@ -608,7 +608,8 @@ class DataLogReader(ResultsReader):
                 continue
 
             t_stamp, label, r_time, con_time, latency, r_code, error = data
-            yield t_stamp, label, self.concurrency, r_time, con_time, latency, r_code, error, ''
+            bytes_count = None
+            yield t_stamp, label, self.concurrency, r_time, con_time, latency, r_code, error, '', bytes_count
 
     def __open_fds(self):
         """

--- a/bzt/modules/grinder.py
+++ b/bzt/modules/grinder.py
@@ -310,8 +310,9 @@ class DataLogReader(ResultsReader):
                 error = "There were some errors in Grinder test"
             else:
                 error = None
+            bytes_count = int(fields[self.idx["HTTP response length"]].strip())
             concur = None  # TODO: how to get this for grinder
-            yield int(t_stamp), label, concur, r_time, con_time, latency, r_code, error, ''
+            yield int(t_stamp), label, concur, r_time, con_time, latency, r_code, error, '', bytes_count
 
     def __open_fds(self):
         """

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -889,9 +889,11 @@ class JTLReader(ResultsReader):
             else:
                 error = None
 
+            byte_count = int(row.get("bytes", 0))
+
             tstmp = int(int(row["timeStamp"]) / 1000)
             self.read_records += 1
-            yield tstmp, label, concur, rtm, cnn, ltc, rcd, error, trname
+            yield tstmp, label, concur, rtm, cnn, ltc, rcd, error, trname, byte_count
 
     def _calculate_datapoints(self, final_pass=False):
         for point in super(JTLReader, self)._calculate_datapoints(final_pass):

--- a/bzt/modules/locustio.py
+++ b/bzt/modules/locustio.py
@@ -277,6 +277,7 @@ class SlavesReader(ResultsProvider):
             kpiset = KPISet()
             kpiset[KPISet.SAMPLE_COUNT] = item['num_reqs_per_sec'][timestamp]
             kpiset[KPISet.CONCURRENCY] = data['user_count']
+            kpiset[KPISet.BYTE_COUNT] = item['total_content_length']
             if item['num_requests']:
                 avg_rt = (item['total_response_time'] / 1000.0) / item['num_requests']
                 kpiset.sum_rt = item['num_reqs_per_sec'][timestamp] * avg_rt

--- a/bzt/modules/pbench.py
+++ b/bzt/modules/pbench.py
@@ -604,8 +604,9 @@ class PBenchKPIReader(ResultsReader):
                 rcd = row["responseCode"]
 
             tstmp = int(float(row["timeStamp"]) + rtm)
+            byte_count = int(row["brecv"])
             concur = 0
-            yield tstmp, label, concur, rtm, cnn, ltc, rcd, error, ''
+            yield tstmp, label, concur, rtm, cnn, ltc, rcd, error, '', byte_count
 
         self.offset = self.fds.tell()
 

--- a/bzt/modules/selenium.py
+++ b/bzt/modules/selenium.py
@@ -1292,7 +1292,8 @@ class LoadSamplesReader(ResultsReader):
         rcd = self.STATUS_TO_CODE.get(item["status"], "UNKNOWN")
         error = item["error_msg"] if item["status"] in SeleniumReportReader.FAILING_TESTS_STATUSES else None
         trname = ""
-        return tstmp, label, concur, rtm, cnn, ltc, rcd, error, trname
+        byte_count = None
+        return tstmp, label, concur, rtm, cnn, ltc, rcd, error, trname, byte_count
 
     def _read(self, last_pass=False):
         for row in self.report_reader.read(last_pass):

--- a/bzt/modules/siege.py
+++ b/bzt/modules/siege.py
@@ -207,11 +207,10 @@ class DataLogReader(ResultsReader):
             log_vals = [val.strip() for val in line.split(',')]
 
             # _mark = log_vals[0]           # 0. current test mark, defined by --mark key
-            # _user_id = int(log_vals[1])   # 1. fake user id
-            # _http = log_vals[2]           # 2. http protocol
-            _rstatus = log_vals[2]  # 3. response status code
-            _etime = float(log_vals[3])  # 4. elapsed time (total time - connection time)
-            # _rsize = int(log_vals[5])     # 5. size of response
+            # _http = log_vals[1]           # 1. http protocol
+            _rstatus = log_vals[2]  # 2. response status code
+            _etime = float(log_vals[3])  # 3. elapsed time (total time - connection time)
+            _rsize = int(log_vals[4])     # 4. size of response
             _url = log_vals[5]  # 6. long or short URL value
             # _url_id = int(log_vals[7])    # 7. url number
             _tstamp = time.strptime(log_vals[7], "%Y-%m-%d %H:%M:%S")
@@ -222,7 +221,7 @@ class DataLogReader(ResultsReader):
             _error = None
             _concur = self.concurrency
 
-            yield _tstamp, _url, _concur, _etime, _con_time, _latency, _rstatus, _error, ''
+            yield _tstamp, _url, _concur, _etime, _con_time, _latency, _rstatus, _error, '', _rsize
 
     def __del__(self):
         if self.fds:

--- a/bzt/modules/tsung.py
+++ b/bzt/modules/tsung.py
@@ -251,6 +251,7 @@ class TsungStatsReader(ResultsReader):
             tstamp = int(float(fields[0]))
             url = fields[4] + fields[5]
             rstatus = fields[6]
+            rsize = int(fields[7])
             etime = float(fields[8]) / 1000
             trname = fields[9]
             error = fields[10] or None
@@ -258,7 +259,7 @@ class TsungStatsReader(ResultsReader):
             con_time = 0
             latency = 0
 
-            yield tstamp, url, self.concurrency, etime, con_time, latency, rstatus, error, trname
+            yield tstamp, url, self.concurrency, etime, con_time, latency, rstatus, error, trname, rsize
 
 
 class TsungConfig(object):

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -17,6 +17,7 @@
  - don't exclude executable nose scripts for Selenium 
  - add setup of global `additional-classpath` ability to SeleniumExecutor
  - support `keepalive` flag for Locust and Grinder
+ - track `bytes received` KPI and attach it to BZA report
 
 ## 1.7.0 <sup>2 oct 2016</sup>
  - add RSpec tests runner for Selenium

--- a/tests/modules/test_consolidatingAggregator.py
+++ b/tests/modules/test_consolidatingAggregator.py
@@ -64,28 +64,28 @@ class TestConsolidatingAggregator(BZTestCase):
     @staticmethod
     def get_success_reader(offset=0):
         mock = MockReader()
-        mock.data.append((1 + offset, "", 1, r(), r(), r(), 200, None, ''))
-        mock.data.append((2 + offset, "", 1, r(), r(), r(), 200, None, ''))
-        mock.data.append((2 + offset, "", 1, r(), r(), r(), 200, None, ''))
-        mock.data.append((3 + offset, "", 1, r(), r(), r(), 200, None, ''))
-        mock.data.append((3 + offset, "", 1, r(), r(), r(), 200, None, ''))
-        mock.data.append((4 + offset, "", 1, r(), r(), r(), 200, None, ''))
-        mock.data.append((4 + offset, "", 1, r(), r(), r(), 200, None, ''))
-        mock.data.append((6 + offset, "", 1, r(), r(), r(), 200, None, ''))
-        mock.data.append((6 + offset, "", 1, r(), r(), r(), 200, None, ''))
-        mock.data.append((6 + offset, "", 1, r(), r(), r(), 200, None, ''))
-        mock.data.append((5 + offset, "", 1, r(), r(), r(), 200, None, ''))
+        mock.data.append((1 + offset, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((2 + offset, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((2 + offset, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((3 + offset, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((3 + offset, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((4 + offset, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((4 + offset, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((6 + offset, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((6 + offset, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((6 + offset, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((5 + offset, "", 1, r(), r(), r(), 200, None, '', 0))
         return mock
 
     @staticmethod
     def get_fail_reader(offset=0):
         mock = MockReader()
-        mock.data.append((1 + offset, "first", 1, r(), r(), r(), 200, 'FAILx3', ''))
-        mock.data.append((2 + offset, "first", 1, r(), r(), r(), 200, 'FAILx1', ''))
-        mock.data.append((5 + offset, "first", 1, r(), r(), r(), 200, None, ''))
-        mock.data.append((7 + offset, "second", 1, r(), r(), r(), 200, 'FAILx3', ''))
-        mock.data.append((3 + offset, "first", 1, r(), r(), r(), 200, 'FAILx3', ''))
-        mock.data.append((6 + offset, "second", 1, r(), r(), r(), 200, 'unique FAIL', ''))
+        mock.data.append((1 + offset, "first", 1, r(), r(), r(), 200, 'FAILx3', '', 0))
+        mock.data.append((2 + offset, "first", 1, r(), r(), r(), 200, 'FAILx1', '', 0))
+        mock.data.append((5 + offset, "first", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((7 + offset, "second", 1, r(), r(), r(), 200, 'FAILx3', '', 0))
+        mock.data.append((3 + offset, "first", 1, r(), r(), r(), 200, 'FAILx3', '', 0))
+        mock.data.append((6 + offset, "second", 1, r(), r(), r(), 200, 'unique FAIL', '', 0))
         return mock
 
     def test_errors_cumulative(self):

--- a/tests/modules/test_defaultAggregator.py
+++ b/tests/modules/test_defaultAggregator.py
@@ -20,21 +20,21 @@ class TestDefaultAggregator(BZTestCase):
 
         mock = MockReader()
         mock.buffer_scale_idx = '100.0'
-        mock.data.append((1, "", 1, r(), r(), r(), 200, None, ''))
-        mock.data.append((2, "", 1, r(), r(), r(), 200, None, ''))
-        mock.data.append((2, "", 1, r(), r(), r(), 200, None, ''))
-        mock.data.append((3, "", 1, r(), r(), r(), 200, None, ''))
-        mock.data.append((3, "", 1, r(), r(), r(), 200, None, ''))
-        mock.data.append((4, "", 1, r(), r(), r(), 200, None, ''))
-        mock.data.append((4, "", 1, r(), r(), r(), 200, None, ''))
+        mock.data.append((1, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((2, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((2, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((3, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((3, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((4, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((4, "", 1, r(), r(), r(), 200, None, '', 0))
 
         obj.add_listener(mock)
 
         for point in mock.datapoints():
             self.assertNotEquals(0, point[DataPoint.CUMULATIVE][''][KPISet.CONCURRENCY])
 
-        mock.data.append((2, "", 1, r(), r(), r(), 200, None, ''))
-        mock.data.append((2, "", 1, r(), r(), r(), 200, None, ''))
+        mock.data.append((2, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((2, "", 1, r(), r(), r(), 200, None, '', 0))
 
         for point in mock.datapoints():
             pass
@@ -57,7 +57,7 @@ class TestDefaultAggregator(BZTestCase):
         # current measurements shows ~25K samples/sec
         for cnt in (10, 100, 1000, 10000, 25000, 40000, 50000):
             for a in range(0, cnt):
-                sample = (cnt, "", 1, r(1000), r(1000), r(1000), rc(), err(), '')
+                sample = (cnt, "", 1, r(1000), r(1000), r(1000), rc(), err(), '', 0)
                 mock.data.append(sample)
             before = time.time()
             for point in mock.datapoints():
@@ -88,35 +88,35 @@ class TestDefaultAggregator(BZTestCase):
 
         buffer_len = mock.buffer_len
         for i in range(5):
-            mock.data.append((100 + i, "", 1, 2, 2, 2, 200, None, ''))
+            mock.data.append((100 + i, "", 1, 2, 2, 2, 200, None, '', 0))
         points = list(mock.datapoints())
         points = list(mock.datapoints())
         self.assertTrue(mock.buffer_len > buffer_len)
         buffer_len = mock.buffer_len
 
         for i in range(10):
-            mock.data.append((200 + i, "", 1, 3, 3, 3, 200, None, ''))
+            mock.data.append((200 + i, "", 1, 3, 3, 3, 200, None, '', 0))
         points = list(mock.datapoints())
         points = list(mock.datapoints())
         self.assertTrue(mock.buffer_len > buffer_len)
         buffer_len = mock.buffer_len
 
         for i in range(20):
-            mock.data.append((300 + i, "", 1, 4, 4, 4, 200, None, ''))
+            mock.data.append((300 + i, "", 1, 4, 4, 4, 200, None, '', 0))
         points = list(mock.datapoints())
         points = list(mock.datapoints())
         self.assertTrue(mock.buffer_len > buffer_len)
         buffer_len = mock.buffer_len
 
         for i in range(15):
-            mock.data.append((400 + i, "", 1, 1, 1, 1, 200, None, ''))
+            mock.data.append((400 + i, "", 1, 1, 1, 1, 200, None, '', 0))
         points = list(mock.datapoints())
         points = list(mock.datapoints())
         self.assertTrue(mock.buffer_len < buffer_len)
         buffer_len = mock.buffer_len
 
         for i in range(30):
-            mock.data.append((500 + i, "", 1, 1, 1, 1, 200, None, ''))
+            mock.data.append((500 + i, "", 1, 1, 1, 1, 200, None, '', 0))
         points = list(mock.datapoints())
         points = list(mock.datapoints())
         self.assertTrue(mock.buffer_len < buffer_len)

--- a/tests/modules/test_locustIOExecutor.py
+++ b/tests/modules/test_locustIOExecutor.py
@@ -98,6 +98,7 @@ class TestLocustIOExecutor(BZTestCase):
         self.assertEquals(107, len(points))
         for point in points:
             self.assertGreater(point[DataPoint.CURRENT][''][KPISet.AVG_RESP_TIME], 0)
+            self.assertGreater(point[DataPoint.CURRENT][''][KPISet.BYTE_COUNT], 0)
 
     def test_locust_resource_files(self):
         if six.PY3:


### PR DESCRIPTION
It measures number of bytes received per sample.

- [x] Add field to KPISet
- [x] Support extracting `bytes` value from JMeter's JTL
- [x] Walk through all executors to see which ones can supply this value
- [x] Extract bytes from JMeter, Grinder, Locust, PBench, Siege, Tsung
- [x] Report `bytes` value to BM
- [ ] Show `bytes` somewhere in console UI (?)
