### PR TITLE
Introduce `bytes` field for KPISet

### DIFF
--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -17,6 +17,7 @@
  - don't exclude executable nose scripts for Selenium 
  - add setup of global `additional-classpath` ability to SeleniumExecutor
  - support `keepalive` flag for Locust and Grinder
+ - track `bytes received` KPI and attach it to BZA report
 
 ## 1.7.0 <sup>2 oct 2016</sup>
  - add RSpec tests runner for Selenium


### PR DESCRIPTION
It measures number of bytes received per sample.

- [x] Add field to KPISet
- [x] Support extracting `bytes` value from JMeter's JTL
- [x] Walk through all executors to see which ones can supply this value
- [x] Extract bytes from JMeter, Grinder, Locust, PBench, Siege, Tsung
- [ ] Report `bytes` value to BM
- [ ] Show `bytes` somewhere in console UI?
