### PR TITLE
fix types mistake in nose_plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 - nvm install 4.2
 - nvm use 4.2
 - gem install rspec
-- pip install colorlog pyyaml psutil lxml cssselect urwid six selenium progressbar33 locustio pyvirtualdisplay
+- pip install colorlog pyyaml psutil lxml cssselect urwid six selenium==2.53.1 progressbar33 locustio pyvirtualdisplay
 script: coverage run `which nosetests`
 after_success:
   - codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
 
 install:
   - "%PYTHON%\\python.exe -m pip install nose"
-  - "%PYTHON%\\python.exe -m pip install colorlog pyyaml psutil lxml==3.4.2 cssselect urwid six selenium progressbar33 locustio pyvirtualdisplay"
+  - "%PYTHON%\\python.exe -m pip install colorlog pyyaml psutil lxml==3.4.2 cssselect urwid six selenium==2.53.1 progressbar33 locustio pyvirtualdisplay"
 
 build: off
 

--- a/bzt/modules/selenium.py
+++ b/bzt/modules/selenium.py
@@ -1187,12 +1187,12 @@ from selenium.common.exceptions import NoAlertPresentException
                 assert_method = "self.assertEqual" if reverse else "self.assertNotEqual"
                 assertion_elements.append(self.gen_statement("re_pattern = re.compile(r'%s')" % val))
 
-                method = '%s(0, len(re.findall(re_pattern, body)), "AssertionError: %s")'
+                method = '%s(0, len(re.findall(re_pattern, body)), "Assertion: %s")'
                 method %= assert_method, assert_message
                 assertion_elements.append(self.gen_statement(method))
             else:
                 assert_method = "self.assertNotIn" if reverse else "self.assertIn"
-                method = '%s("%s", body, "AssertionError: %s")'
+                method = '%s("%s", body, "Assertion: %s")'
                 method %= assert_method, val, assert_message
                 assertion_elements.append(self.gen_statement(method))
         return assertion_elements

--- a/bzt/resources/nose_plugin.py
+++ b/bzt/resources/nose_plugin.py
@@ -94,7 +94,8 @@ class BZTPlugin(Plugin):
         :param error:
         :return:
         """
-        exc_type, exc_msg, trace = error
+        exc_type, exc, trace = error
+        exc_msg = str(exc)
         # test_dict will be None if startTest wasn't called (i.e. exception in setUp/setUpClass)
         if self.test_dict is not None:
             self.test_dict["status"] = "BROKEN"
@@ -109,7 +110,8 @@ class BZTPlugin(Plugin):
 
         :return:
         """
-        exc_type, exc_msg, trace = error
+        exc_type, exc, trace = error
+        exc_msg = str(exc)
         self.test_dict["status"] = "FAILED"
         self.test_dict["error_msg"] = exc_msg.split('\n')[0]
         self.test_dict["error_trace"] = ''.join(traceback.format_exception(exc_type, exc_msg, trace)).rstrip()

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.7.3 <sup>next</sup>
+ - fix assertion disappearance in nose_plugin
+  
 ## 1.7.2 <sup>13 oct 2016</sup>
  - fix keep-alive processing in Gatling
  - add ability of JMeter variables usage in data-sources path options

--- a/site/dat/docs/Changelog2015.md
+++ b/site/dat/docs/Changelog2015.md
@@ -2,7 +2,6 @@
 
 ## 0.5.2 <sup>17 dec 15</sup>
  - fix JMeter installation on windows
- - fix assertion disappearance in nose_plugin 
 
 ## 0.5.1 <sup>11/16/15</sup>
  - fix shellexec env variables

--- a/site/dat/docs/Changelog2015.md
+++ b/site/dat/docs/Changelog2015.md
@@ -2,6 +2,7 @@
 
 ## 0.5.2 <sup>17 dec 15</sup>
  - fix JMeter installation on windows
+ - fix assertion disappearance in nose_plugin 
 
 ## 0.5.1 <sup>11/16/15</sup>
  - fix shellexec env variables

--- a/tests/jmeter/jmx/delimiters.jmx
+++ b/tests/jmeter/jmx/delimiters.jmx
@@ -49,7 +49,7 @@
         <CSVDataSet guiclass="TestBeanGUI" testclass="CSVDataSet" testname="CSV Data Set Config0" enabled="true">
           <stringProp name="delimiter">1</stringProp>
           <stringProp name="fileEncoding"></stringProp>
-          <stringProp name="filename">/home/taras/tmp/csv</stringProp>
+          <stringProp name="filename">name_of_csv_file</stringProp>
           <boolProp name="quotedData">false</boolProp>
           <boolProp name="recycle">true</boolProp>
           <stringProp name="shareMode">shareMode.all</stringProp>
@@ -58,7 +58,7 @@
         </CSVDataSet>
         <hashTree/>
         <CSVDataSet guiclass="TestBeanGUI" testclass="CSVDataSet" testname="CSV Data Set Config1" enabled="true">
-          <stringProp name="filename">/home/taras/tmp/csv</stringProp>
+          <stringProp name="filename">name_of_csv_file</stringProp>
           <stringProp name="fileEncoding"></stringProp>
           <stringProp name="variableNames"></stringProp>
           <stringProp name="delimiter">2</stringProp>
@@ -69,7 +69,7 @@
         </CSVDataSet>
         <hashTree/>
         <CSVDataSet guiclass="TestBeanGUI" testclass="CSVDataSet" testname="CSV Data Set Config2" enabled="true">
-          <stringProp name="filename">/home/taras/tmp/csv</stringProp>
+          <stringProp name="filename">name_of_csv_file</stringProp>
           <stringProp name="fileEncoding"></stringProp>
           <stringProp name="variableNames"></stringProp>
           <stringProp name="delimiter"></stringProp>

--- a/tests/selenium/generated_from_requests.py
+++ b/tests/selenium/generated_from_requests.py
@@ -9,7 +9,7 @@ class TestRequests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         profile = webdriver.FirefoxProfile()
-        profile.set_preference('webdriver.log.file', '/home/taras/Projects/taurus/build/test/2016-10-17_12-36-09.996191/webdriver.log')
+        profile.set_preference('webdriver.log.file', 'somewhere')
         cls.driver = webdriver.Firefox(profile)
         cls.driver.implicitly_wait(30.0)
         cls.driver.maximize_window()

--- a/tests/selenium/generated_from_requests.py
+++ b/tests/selenium/generated_from_requests.py
@@ -9,7 +9,7 @@ class TestRequests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         profile = webdriver.FirefoxProfile()
-        profile.set_preference('webdriver.log.file', '/home/taras/Projects/taurus/build/test/2016-10-10_17-14-53.506595/webdriver.log')
+        profile.set_preference('webdriver.log.file', '/home/taras/Projects/taurus/build/test/2016-10-17_12-36-09.996191/webdriver.log')
         cls.driver = webdriver.Firefox(profile)
         cls.driver.implicitly_wait(30.0)
         cls.driver.maximize_window()
@@ -23,6 +23,6 @@ class TestRequests(unittest.TestCase):
         self.driver.get('http://blazedemo.com/')
         body = self.driver.page_source
         re_pattern = re.compile(r'contained_text')
-        self.assertEqual(0, len(re.findall(re_pattern, body)), "AssertionError: 'contained_text' found in BODY")
+        self.assertEqual(0, len(re.findall(re_pattern, body)), "Assertion: 'contained_text' found in BODY")
         # end request: http://blazedemo.com/
         


### PR DESCRIPTION
When nose_plugin addError()/addFailure get exception type in 'error' variable split() fails. As type can be exception sometimes type casting is needed.