### PR TITLE
Fix unicode handling in JMX2YAML

### DIFF
--- a/bzt/engine.py
+++ b/bzt/engine.py
@@ -608,8 +608,7 @@ class Configuration(BetterDict):
         if fmt == self.JSON:
             fds.write(to_json(self))
         elif fmt == self.YAML:
-            yml = yaml.dump(self, default_flow_style=False,
-                            explicit_start=True, canonical=False)
+            yml = yaml.dump(self, default_flow_style=False, explicit_start=True, canonical=False, allow_unicode=True)
             fds.write(yml)
         else:
             raise ValueError("Unknown dump format: %s" % fmt)

--- a/bzt/jmx2yaml.py
+++ b/bzt/jmx2yaml.py
@@ -14,12 +14,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import codecs
 import itertools
 import logging
 import os
 import sys
 import traceback
-from codecs import open
 from collections import namedtuple
 from copy import deepcopy
 from optparse import OptionParser
@@ -1255,7 +1255,7 @@ class JMX2YAML(object):
             path = os.path.join(additional_files_dir, filename)
             self.log.info("Writing additional file: %s", path)
             content = self.converter.dialect.additional_files[filename]
-            with open(path, 'w', encoding='utf-8') as f:
+            with codecs.open(path, 'w', encoding='utf-8') as f:
                 f.write(content)
 
         self.log.info("Done processing, result saved in %s", file_name)

--- a/bzt/jmx2yaml.py
+++ b/bzt/jmx2yaml.py
@@ -19,6 +19,7 @@ import logging
 import os
 import sys
 import traceback
+from codecs import open
 from collections import namedtuple
 from copy import deepcopy
 from optparse import OptionParser
@@ -1254,7 +1255,7 @@ class JMX2YAML(object):
             path = os.path.join(additional_files_dir, filename)
             self.log.info("Writing additional file: %s", path)
             content = self.converter.dialect.additional_files[filename]
-            with open(path, 'w') as f:
+            with open(path, 'w', encoding='utf-8') as f:
                 f.write(content)
 
         self.log.info("Done processing, result saved in %s", file_name)

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -3,6 +3,7 @@
 ## 1.7.3 <sup>next</sup>
  - fix assertion disappearance in nose_plugin
  - improve exception logging in Engine/CLI
+ - fix unicode issues in jmx2yaml
   
 ## 1.7.2 <sup>13 oct 2016</sup>
  - fix keep-alive processing in Gatling

--- a/tests/test_jmx2yaml.py
+++ b/tests/test_jmx2yaml.py
@@ -418,3 +418,8 @@ class TestConverter(BZTestCase):
         self.assertTrue(os.path.exists(os.path.join(get_full_path(yml_file, step_up=1), 'script.bsh')))
         self.assertTrue(os.path.exists(os.path.join(get_full_path(yml_file, step_up=1), 'script.js')))
         self.assertTrue(os.path.exists(os.path.join(get_full_path(yml_file, step_up=1), 'script-1.js')))
+
+    def test_unicode(self):
+        obj = self._get_jmx2yaml("/yaml/converter/unicode.jmx", self._get_tmp())
+        obj.process()
+        obj.converter.convert(obj.file_to_convert)

--- a/tests/yaml/converter/unicode.jmx
+++ b/tests/yaml/converter/unicode.jmx
@@ -11,7 +11,7 @@
       <stringProp name="TestPlan.user_define_classpath"></stringProp>
     </TestPlan>
     <hashTree>
-      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group" enabled="true">
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="ТредГруппа" enabled="true">
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
           <boolProp name="LoopController.continue_forever">false</boolProp>
@@ -19,24 +19,31 @@
         </elementProp>
         <stringProp name="ThreadGroup.num_threads">1</stringProp>
         <stringProp name="ThreadGroup.ramp_time">1</stringProp>
-        <longProp name="ThreadGroup.start_time">1476291341000</longProp>
-        <longProp name="ThreadGroup.end_time">1476291341000</longProp>
+        <longProp name="ThreadGroup.start_time">1476870176000</longProp>
+        <longProp name="ThreadGroup.end_time">1476870176000</longProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>
         <stringProp name="ThreadGroup.delay"></stringProp>
       </ThreadGroup>
       <hashTree>
-        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="HTTP Request" enabled="true">
-          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
-            <collectionProp name="Arguments.arguments"/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="индекс" enabled="true">
+          <boolProp name="HTTPSampler.postBodyRaw">true</boolProp>
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="" elementType="HTTPArgument">
+                <boolProp name="HTTPArgument.always_encode">false</boolProp>
+                <stringProp name="Argument.value">{&quot;message&quot;: &quot;Привет&quot;}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
           </elementProp>
-          <stringProp name="HTTPSampler.domain"></stringProp>
+          <stringProp name="HTTPSampler.domain">blazedemo.com</stringProp>
           <stringProp name="HTTPSampler.port"></stringProp>
           <stringProp name="HTTPSampler.connect_timeout"></stringProp>
           <stringProp name="HTTPSampler.response_timeout"></stringProp>
           <stringProp name="HTTPSampler.protocol"></stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path"></stringProp>
+          <stringProp name="HTTPSampler.path">/</stringProp>
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
@@ -45,32 +52,7 @@
           <boolProp name="HTTPSampler.monitor">false</boolProp>
           <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
         </HTTPSamplerProxy>
-        <hashTree>
-          <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="JSR223 PreProcessor" enabled="true">
-            <stringProp name="cacheKey"></stringProp>
-            <stringProp name="filename"></stringProp>
-            <stringProp name="parameters">parames</stringProp>
-            <stringProp name="script">scripty</stringProp>
-            <stringProp name="scriptLanguage">beanshell</stringProp>
-          </JSR223PreProcessor>
-          <hashTree/>
-          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="JSR223 PostProcessor" enabled="true">
-            <stringProp name="cacheKey"></stringProp>
-            <stringProp name="filename"></stringProp>
-            <stringProp name="parameters">a b c</stringProp>
-            <stringProp name="script">console.log(&quot;ПРИВЕТ&quot;);</stringProp>
-            <stringProp name="scriptLanguage">javascript</stringProp>
-          </JSR223PostProcessor>
-          <hashTree/>
-          <JSR223PostProcessor guiclass="TestBeanGUI" testclass="JSR223PostProcessor" testname="JSR223 PostProcessor" enabled="true">
-            <stringProp name="scriptLanguage">javascript</stringProp>
-            <stringProp name="parameters"></stringProp>
-            <stringProp name="filename"></stringProp>
-            <stringProp name="cacheKey"></stringProp>
-            <stringProp name="script">log.info(&quot;bye&quot;);</stringProp>
-          </JSR223PostProcessor>
-          <hashTree/>
-        </hashTree>
+        <hashTree/>
       </hashTree>
     </hashTree>
   </hashTree>


### PR DESCRIPTION
- dump properly unicoded YAML (before it was dumping unicode strings as `"\u0421\u0410\u041F"`)
- dump properly unicoded JSR223 scripts