### PR TITLE
 Add `content-encoding` request- and scenario-level option to JMeter executor 

### DIFF
--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -646,7 +646,8 @@ class JMX(object):
         return mgr
 
     @staticmethod
-    def _get_http_defaults(default_address=None, timeout=None, retrieve_resources=None, concurrent_pool_size=4):
+    def _get_http_defaults(default_address=None, timeout=None, retrieve_resources=None, concurrent_pool_size=4,
+                           content_encoding=None):
         """
         :rtype: lxml.etree.Element
         """
@@ -682,6 +683,9 @@ class JMX(object):
         if timeout:
             cfg.append(JMX._string_prop("HTTPSampler.connect_timeout", timeout))
             cfg.append(JMX._string_prop("HTTPSampler.response_timeout", timeout))
+
+        if content_encoding:
+            cfg.append(JMX._string_prop("HTTPSampler.contentEncoding", content_encoding))
         return cfg
 
     @staticmethod

--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -265,7 +265,7 @@ class JMX(object):
                              guiclass="ArgumentsPanel", testclass="Arguments")
 
     @staticmethod
-    def _get_http_request(url, label, method, timeout, body, keepalive, files=()):
+    def _get_http_request(url, label, method, timeout, body, keepalive, files=(), encoding=None):
         """
         Generates HTTP request
         :type method: str
@@ -300,6 +300,9 @@ class JMX(object):
         if timeout is not None:
             proxy.append(JMX._string_prop("HTTPSampler.connect_timeout", timeout))
             proxy.append(JMX._string_prop("HTTPSampler.response_timeout", timeout))
+
+        if encoding is not None:
+            proxy.append(JMX._string_prop("HTTPSampler.contentEncoding", encoding))
 
         if files:
             proxy.append(JMX._bool_prop("HTTPSampler.DO_MULTIPART_POST", True))

--- a/bzt/jmx2yaml.py
+++ b/bzt/jmx2yaml.py
@@ -369,6 +369,8 @@ class JMXasDict(JMX):
                     if url_info.retrieve_resources:
                         if url_info.retrieve_concurrency and url_info.retrieve_concurrency.isdigit():
                             request_defaults["concurrent-pool-size"] = int(url_info.retrieve_concurrency)
+                if url_info.content_encoding is not None:
+                    request_defaults["content-encoding"] = url_info.content_encoding
         self.log.debug('Got %s for request-defaults in %s (%s)', request_defaults, element.tag, element.get("testname"))
         return request_defaults
 

--- a/bzt/jmx2yaml.py
+++ b/bzt/jmx2yaml.py
@@ -392,7 +392,7 @@ class JMXasDict(JMX):
         """
         http_sampler_info = namedtuple("http_sampler_info",
                                        ["domain", "port", "timeout", "protocol", "path", "method", "retrieve_resources",
-                                        "retrieve_concurrency"])
+                                        "retrieve_concurrency", "content_encoding"])
         if element is not None:
             domain = self._get_string_prop(element, 'HTTPSampler.domain')
             port = self._get_string_prop(element, 'HTTPSampler.port')
@@ -402,8 +402,9 @@ class JMXasDict(JMX):
             retrieve_resources = self._get_bool_prop(element, 'HTTPSampler.image_parser')
             retrieve_concurrency = self._get_string_prop(element, 'HTTPSampler.concurrentPool')
             method = self._get_string_prop(element, 'HTTPSampler.method')
+            encoding = self._get_string_prop(element, 'HTTPSampler.contentEncoding')
             url_info = http_sampler_info(domain, port, timeout, protocol, path, method, retrieve_resources,
-                                         retrieve_concurrency)
+                                         retrieve_concurrency, encoding)
             return url_info
         return None
 
@@ -419,6 +420,8 @@ class JMXasDict(JMX):
             base_settings["url"] = full_url
             if url_info.method:
                 base_settings["method"] = url_info.method
+            if url_info.content_encoding:
+                base_settings["content-encoding"] = url_info.content_encoding
         if element.get("testname"):
             base_settings["label"] = element.get("testname")
         self.log.debug('Got %s for base settings in %s (%s)', base_settings, element.tag, element.get("testname"))

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1517,7 +1517,7 @@ class JMeterScenarioBuilder(JMX):
             body = request.body
 
         http = JMX._get_http_request(request.url, request.label, request.method, timeout, body, global_keepalive,
-                                     request.upload_files)
+                                     request.upload_files, request.content_encoding)
 
         children = etree.Element("hashTree")
 
@@ -2064,6 +2064,7 @@ class HierarchicHTTPRequest(HTTPRequest):
             path = file_dict.get('path', ValueError("Items from upload-files must specify path to file"))
             mime = mimetypes.guess_type(path)[0] or "application/octet-stream"
             file_dict.get('mime-type', mime)
+        self.content_encoding = config.get('content-encoding', None)
 
 
 class ActionBlock(Request):

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1365,11 +1365,12 @@ class JMeterScenarioBuilder(JMX):
         default_address = scenario.get("default-address", None)
         retrieve_resources = scenario.get("retrieve-resources", True)
         concurrent_pool_size = scenario.get("concurrent-pool-size", 4)
+        content_encoding = scenario.get("content-encoding", None)
 
         timeout = scenario.get("timeout", None)
         timeout = self.smart_time(timeout)
-        elements = [self._get_http_defaults(default_address, timeout,
-                                            retrieve_resources, concurrent_pool_size),
+        elements = [self._get_http_defaults(default_address, timeout, retrieve_resources,
+                                            concurrent_pool_size, content_encoding),
                     etree.Element("hashTree")]
         return elements
 

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -9,6 +9,7 @@
  - jmx2yaml: use `HTTPSampler.path` even when there's no `HTTPSampler.domain` set
  - fix cumulative part of BlazeMeter reporting
  - remove MirrorsManager from Gatling
+ - add `content-encoding` request-level option to JMeter
 
 ## 1.7.2 <sup>13 oct 2016</sup>
  - fix keep-alive processing in Gatling

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -9,7 +9,7 @@
  - jmx2yaml: use `HTTPSampler.path` even when there's no `HTTPSampler.domain` set
  - fix cumulative part of BlazeMeter reporting
  - remove MirrorsManager from Gatling
- - add `content-encoding` request-level option to JMeter
+ - add `content-encoding` request- and scenario-level option to JMeter
 
 ## 1.7.2 <sup>13 oct 2016</sup>
  - fix keep-alive processing in Gatling

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -111,13 +111,13 @@ scenarios:
       user_def_var: http://demo.blazemeter.com/api/user
       user_def_var2: user_def_val_2
     modifications:
-        disable:  # Names of the tree elements to disable
-        - Thread Group 1
-        enable:  # Names of the tree elements to ensable
-        - Thread Group 2
-        set-prop:  # Set element properties, selected as [Element Name]>[property name]
-          "HTTP Sampler>HTTPSampler.connect_timeout": "0"
-          "HTTP Sampler>HTTPSampler.protocol": "https"
+      disable:  # Names of the tree elements to disable
+      - Thread Group 1
+      enable:  # Names of the tree elements to ensable
+      - Thread Group 2
+      set-prop:  # Set element properties, selected as [Element Name]>[property name]
+        "HTTP Sampler>HTTPSampler.connect_timeout": "0"
+        "HTTP Sampler>HTTPSampler.protocol": "https"
 ```
 
 ## Building Test Plan from Config
@@ -221,6 +221,7 @@ scenarios:
         Referer: http://taurus.blazemeter/docs
       think-time: 1s  # local think-time, overrides global
       timeout: 1s  # local timeout, overrides global
+      content-encoding: utf-8  # content encoding (at JMeter's level), unset by default
 
       extract-regexp: {}  # explained below
       extract-jsonpath: {}  # explained below

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -164,6 +164,8 @@ scenarios:
                              # behind dns load balancers. True by default.
     force-parent-sample: true  # generate only parent sample for transaction controllers.
                                # True by default
+    content-encoding: utf-8  # global content encoding, applied to all requests.
+                             # Unset by default
     data-sources: # list of external data sources
     - path/to/my.csv  # this is a shorthand form
     - path: path/to/another.csv  # this is full form, path option is required

--- a/tests/jmeter/jmx/http.jmx
+++ b/tests/jmeter/jmx/http.jmx
@@ -67,7 +67,7 @@
           <stringProp name="CookieManager.implementation">org.apache.jmeter.protocol.http.control.HC4CookieHandler</stringProp>
         </CookieManager>
         <hashTree/>
-        <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="true">
+        <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="false">
           <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
             <collectionProp name="Arguments.arguments"/>
           </elementProp>
@@ -76,7 +76,7 @@
           <stringProp name="HTTPSampler.connect_timeout"></stringProp>
           <stringProp name="HTTPSampler.response_timeout"></stringProp>
           <stringProp name="HTTPSampler.protocol"></stringProp>
-          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding">cp1251</stringProp>
           <stringProp name="HTTPSampler.path"></stringProp>
           <boolProp name="HTTPSampler.concurrentDwn">true</boolProp>
           <stringProp name="HTTPSampler.concurrentPool">4</stringProp>

--- a/tests/jmeter/jmx/http.jmx
+++ b/tests/jmeter/jmx/http.jmx
@@ -163,7 +163,7 @@ test</stringProp>
           <stringProp name="HTTPSampler.connect_timeout"></stringProp>
           <stringProp name="HTTPSampler.response_timeout"></stringProp>
           <stringProp name="HTTPSampler.protocol"></stringProp>
-          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding">utf-8</stringProp>
           <stringProp name="HTTPSampler.path"></stringProp>
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1840,6 +1840,24 @@ class TestJMeterExecutor(BZTestCase):
         self.assertEqual("beanshell", pre.find(".//stringProp[@name='scriptLanguage']").text)
         self.assertEqual(None, pre.find(".//stringProp[@name='parameters']").text)
 
+    def test_request_content_encoding(self):
+        self.configure({
+            "execution": {
+                "scenario": {
+                    "requests": [{
+                        "url": "http://blazedemo.com/",
+                        "body": "S'il vous plaît",
+                        "content-encoding": "utf-8",
+                    }]
+                }
+            }
+        })
+        self.obj.prepare()
+        xml_tree = etree.fromstring(open(self.obj.modified_jmx, "rb").read())
+        sampler_encoding_prop = xml_tree.find(".//HTTPSamplerProxy/stringProp[@name='HTTPSampler.contentEncoding']")
+        self.assertIsNotNone(sampler_encoding_prop)
+        self.assertEqual(sampler_encoding_prop.text, 'utf-8')
+
 
 class TestJMX(BZTestCase):
     def test_jmx_unicode_checkmark(self):

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1844,6 +1844,7 @@ class TestJMeterExecutor(BZTestCase):
         self.configure({
             "execution": {
                 "scenario": {
+                    'content-encoding': 'cp1251',
                     "requests": [{
                         "url": "http://blazedemo.com/",
                         "body": "S'il vous plaît",
@@ -1854,6 +1855,9 @@ class TestJMeterExecutor(BZTestCase):
         })
         self.obj.prepare()
         xml_tree = etree.fromstring(open(self.obj.modified_jmx, "rb").read())
+        defaults_encoding_prop = xml_tree.find(".//ConfigTestElement/stringProp[@name='HTTPSampler.contentEncoding']")
+        self.assertIsNotNone(defaults_encoding_prop)
+        self.assertEqual(defaults_encoding_prop.text, 'cp1251')
         sampler_encoding_prop = xml_tree.find(".//HTTPSamplerProxy/stringProp[@name='HTTPSampler.contentEncoding']")
         self.assertIsNotNone(sampler_encoding_prop)
         self.assertEqual(sampler_encoding_prop.text, 'utf-8')

--- a/tests/test_jmx2yaml.py
+++ b/tests/test_jmx2yaml.py
@@ -435,3 +435,15 @@ class TestConverter(BZTestCase):
         self.assertEqual(len(requests), 3)
         without_domain = requests[2]
         self.assertEqual(without_domain['url'], '/path')
+
+    def test_request_content_encoding(self):
+        yml_file = self._get_tmp()
+        obj = self._get_jmx2yaml("/jmeter/jmx/http.jmx", yml_file)
+        obj.process()
+        yml = yaml.load(open(yml_file).read())
+        scenarios = yml.get("scenarios")
+        scenario = scenarios["Thread Group"]
+        requests = scenario["requests"]
+        self.assertEqual(len(requests), 3)
+        request = requests[1]
+        self.assertEqual(request['content-encoding'], 'utf-8')


### PR DESCRIPTION
This options seems useful enough to include it in the scenario language.

Example:
```yaml
scenarios:
  demo:
    content-encoding: cp1251  # global setting
    requests:
    - url: http://blazedemo.com/reserve.php
      body: s'il vous plaît
      content-encoding: utf-8  # request-specific setting         
```