### PR TITLE
change logging verbosity for HTTPError

### DIFF
--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -182,7 +182,7 @@ class CLI(object):
         info_level = http_level = default_level = logging.DEBUG
         if not self.exit_code:  # only fist exception goes to the screen
             info_level = logging.WARNING
-            http_level = logging.WARNING
+            http_level = logging.ERROR
             default_level = logging.ERROR
             if isinstance(exc, RCProvider):
                 self.exit_code = exc.get_rc()
@@ -196,7 +196,8 @@ class CLI(object):
         elif isinstance(exc, NormalShutdown):
             self.log.log(info_level, "Normal shutdown")
         elif isinstance(exc, HTTPError):
-            self.log.log(http_level, "Response from %s: %s", exc.geturl(), exc.read())
+            msg = "Response from %s: [%s] %s" % (exc.geturl(), exc.code, exc.reason)
+            self.log.log(http_level, msg)
         else:
             self.log.log(default_level, "%s: %s", type(exc).__name__, exc)
             self.log.log(default_level, get_stacktrace(exc))

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -11,6 +11,7 @@
  - remove MirrorsManager from Gatling
  - add final stats reporting for functional mode
  - add `content-encoding` request- and scenario-level option to JMeter
+ - fix log verbosity for HTTPError
 
 ## 1.7.2 <sup>13 oct 2016</sup>
  - fix keep-alive processing in Gatling


### PR DESCRIPTION
show code and reason, hide content of response (because it can be empty or too long)