### PR TITLE
Fix JSR223 handling in JMeter's resource_files

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -2094,9 +2094,13 @@ class ResourceFilesCollector(RequestVisitor):
         body_file = request.config.get('body-file')
         if body_file:
             files.append(body_file)
-        jsr_script = request.config.get('jsr223').get('script-file')
-        if jsr_script:
-            files.append(jsr_script)
+        if 'jsr223' in request.config:
+            jsrs = request.config.get('jsr223')
+            if isinstance(jsrs, dict):
+                jsrs = [jsrs]
+            for jsr in jsrs:
+                if 'script-file' in jsr:
+                    files.append(jsr.get('script-file'))
         return files
 
     def visit_ifblock(self, block):

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -2,6 +2,7 @@
 
 ## 1.7.4 (next)
  - fix Locust crash when used with 'requests'-style scenario and cloud provisioning
+ - fix JSR223 block handling when using cloud/remote provisioning
 
 ## 1.7.3 <sup>1 nov 2016</sup>
  - add TestNG-based runner for Selenium tests

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -417,6 +417,26 @@ class TestJMeterExecutor(BZTestCase):
         resource_files = self.obj.resource_files()
         self.assertIn(js_file, resource_files)
 
+    def test_resource_files_jsr223s(self):
+        js_file = __dir__() + '/../data/data.js'
+        js_file2 = __dir__() + '/../data/data2.js'
+        self.configure({
+            'execution': {
+                'scenario': {
+                    'requests': [{
+                        'url': 'http://blazedemo.com/',
+                        'jsr223': [{
+                            'language': 'javascript',
+                            'script-file': js_file,
+                        }, {
+                            'language': 'javascript',
+                            'script-file': js_file2,
+                        }]}]}}})
+        resource_files = self.obj.resource_files()
+        self.assertEqual(2, len(resource_files))
+        self.assertIn(js_file, resource_files)
+        self.assertIn(js_file2, resource_files)
+
     def test_http_request_defaults(self):
         self.configure(json.loads(open(__dir__() + "/../json/get-post.json").read()))
         self.obj.prepare()


### PR DESCRIPTION
And also do not pollute request config with empty BetterDict values when scanning for resource files.