### PR TITLE
Hide reader creation behind a boolean flag in Selenium executor

### DIFF
--- a/bzt/modules/selenium.py
+++ b/bzt/modules/selenium.py
@@ -111,6 +111,7 @@ class SeleniumExecutor(AbstractSeleniumExecutor, WidgetProvider, FileLister):
         self.self_generated_script = False
         self.generated_methods = BetterDict()
         self.runner_working_dir = None
+        self.register_reader = True
 
     def get_virtual_display(self):
         return self.virtual_display
@@ -223,7 +224,8 @@ class SeleniumExecutor(AbstractSeleniumExecutor, WidgetProvider, FileLister):
         self.runner = self._create_runner(self.report_file)
 
         self.runner.prepare()
-        self.reader = self._register_reader(self.report_file)
+        if self.register_reader:
+            self.reader = self._register_reader(self.report_file)
 
     def __setup_script(self):
         self.script = self.get_script_path()


### PR DESCRIPTION
A bit hack-ish, but not as hack-ish as removing readers from aggregator.

It may be a good idea to use strategy pattern for Selenium execution, so concurrent or single-threaded way of execution can be pluggable and interchangeable.