### PR TITLE
Introduce `retrieve-resources-regex` scenario-level option for JMeter

### DIFF
--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -646,8 +646,8 @@ class JMX(object):
         return mgr
 
     @staticmethod
-    def _get_http_defaults(default_address=None, timeout=None, retrieve_resources=None, concurrent_pool_size=4,
-                           content_encoding=None):
+    def _get_http_defaults(default_address=None, timeout=None, retrieve_resources=None, resources_regex=None,
+                           concurrent_pool_size=4, content_encoding=None):
         """
         :rtype: lxml.etree.Element
         """
@@ -686,6 +686,10 @@ class JMX(object):
 
         if content_encoding:
             cfg.append(JMX._string_prop("HTTPSampler.contentEncoding", content_encoding))
+
+        if resources_regex:
+            cfg.append(JMX._string_prop("HTTPSampler.embedded_url_re", resources_regex))
+
         return cfg
 
     @staticmethod

--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -646,8 +646,8 @@ class JMX(object):
         return mgr
 
     @staticmethod
-    def _get_http_defaults(default_address=None, timeout=None, retrieve_resources=None, resources_regex=None,
-                           concurrent_pool_size=4, content_encoding=None):
+    def _get_http_defaults(default_address=None, timeout=None, retrieve_resources=None, concurrent_pool_size=4,
+                           content_encoding=None, resources_regex=None):
         """
         :rtype: lxml.etree.Element
         """

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1358,12 +1358,14 @@ class JMeterScenarioBuilder(JMX):
     def __gen_defaults(self, scenario):
         default_address = scenario.get("default-address", None)
         retrieve_resources = scenario.get("retrieve-resources", True)
+        resources_regex = scenario.get("retrieve-resources-regex", None)
         concurrent_pool_size = scenario.get("concurrent-pool-size", 4)
         content_encoding = scenario.get("content-encoding", None)
 
         timeout = scenario.get("timeout", None)
         timeout = self.smart_time(timeout)
-        elements = [self._get_http_defaults(default_address, timeout, retrieve_resources,
+        elements = [self._get_http_defaults(default_address, timeout,
+                                            retrieve_resources, resources_regex,
                                             concurrent_pool_size, content_encoding),
                     etree.Element("hashTree")]
         return elements

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1364,9 +1364,8 @@ class JMeterScenarioBuilder(JMX):
 
         timeout = scenario.get("timeout", None)
         timeout = self.smart_time(timeout)
-        elements = [self._get_http_defaults(default_address, timeout,
-                                            retrieve_resources, resources_regex,
-                                            concurrent_pool_size, content_encoding),
+        elements = [self._get_http_defaults(default_address, timeout, retrieve_resources,
+                                            concurrent_pool_size, content_encoding, resources_regex),
                     etree.Element("hashTree")]
         return elements
 

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -8,6 +8,7 @@
  - bump up auto-installed JMeter to 3.1 and pmgr to 0.11
  - fix the crash when multiple BM reporters are in use
  - add `public-report` option to BlazeMeter reporter and cloud provisioning
+ - add `retrieve-resources-regex` scenario-level option to JMeter
 
 ## 1.7.4 <sup>11 nov 2016</sup>
  - fix Locust crash when used with 'requests'-style scenario and cloud provisioning

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -159,8 +159,10 @@ scenarios:
     default-address: "https://www.blazedemo.com:8080"  # http request defaults scheme, domain, port
     keepalive: true  # true by default, applied on all requests in scenario
     retrieve-resources: true  # true by default, retrieves all embedded resources from HTML pages
+    retrieve-resources-regex: null  # regular expression that is used to match against any embedded URLs found.
+                                    # Unset bu default
     concurrent-pool-size: 4  # concurrent pool size for resources download, 4 by default
-    use-dns-cache-mgr: true  # use DNS Cache Manager to test resources 
+    use-dns-cache-mgr: true  # use DNS Cache Manager to test resources
                              # behind dns load balancers. True by default.
     force-parent-sample: true  # generate only parent sample for transaction controllers.
                                # True by default

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -159,8 +159,8 @@ scenarios:
     default-address: "https://www.blazedemo.com:8080"  # http request defaults scheme, domain, port
     keepalive: true  # true by default, applied on all requests in scenario
     retrieve-resources: true  # true by default, retrieves all embedded resources from HTML pages
-    retrieve-resources-regex: null  # regular expression that is used to match against any embedded URLs found.
-                                    # Unset bu default
+    retrieve-resources-regex: null  # regular expression used to match against any resource URLs found in HTML document.
+                                    # Unset by default
     concurrent-pool-size: 4  # concurrent pool size for resources download, 4 by default
     use-dns-cache-mgr: true  # use DNS Cache Manager to test resources
                              # behind dns load balancers. True by default.

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -159,8 +159,8 @@ scenarios:
     default-address: "https://www.blazedemo.com:8080"  # http request defaults scheme, domain, port
     keepalive: true  # true by default, applied on all requests in scenario
     retrieve-resources: true  # true by default, retrieves all embedded resources from HTML pages
-    retrieve-resources-regex: null  # regular expression used to match against any resource URLs found in HTML document.
-                                    # Unset by default
+    retrieve-resources-regex: ^((?!google|facebook).)*$  # regular expression used to match any resource
+                                                         # URLs found in HTML document against. Unset by default
     concurrent-pool-size: 4  # concurrent pool size for resources download, 4 by default
     use-dns-cache-mgr: true  # use DNS Cache Manager to test resources
                              # behind dns load balancers. True by default.

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1139,6 +1139,17 @@ class TestJMeterExecutor(BZTestCase):
         jmx = JMX(self.obj.modified_jmx)
         self.assertEqual(jmx.get(selector)[0].text, u"✓")
 
+    def test_resources_regex(self):
+        self.obj.execution.merge({
+            "scenario": {
+                "retrieve-resources": True,
+                "retrieve-resources-regex": "myregex",
+                "requests": [{"url": "http://blazedemo.com/"}]}})
+        self.obj.prepare()
+        jmx = JMX(self.obj.modified_jmx)
+        self.assertEqual(jmx.get('boolProp[name="HTTPSampler.image_parser"]')[0].text, "true")
+        self.assertEqual(jmx.get('stringProp[name="HTTPSampler.embedded_url_re"]')[0].text, "myregex")
+
     def test_data_source_list(self):
         self.obj.execution.merge({
             "scenario": {


### PR DESCRIPTION
It corresponds to the "Embedded URLs must match regex" option in JMeter's GUI.