### PR TITLE
Apply `Engine.find_file` to JAR candidates for Gatling

### DIFF
--- a/bzt/modules/gatling.py
+++ b/bzt/modules/gatling.py
@@ -220,22 +220,26 @@ class GatlingExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInstal
 
         jar_files = []
         files = self.execution.get('files', [])
-        for _file in files:
-            _file = get_full_path(_file)
-            if os.path.isfile(_file) and _file.lower().endswith('.jar'):
-                jar_files.append(_file)
-            elif os.path.isdir(_file):
-                for element in os.listdir(_file):
-                    element = os.path.join(_file, element)
+        for candidate in files:
+            candidate = get_full_path(self.engine.find_file(candidate))
+            if os.path.isfile(candidate) and candidate.lower().endswith('.jar'):
+                jar_files.append(candidate)
+            elif os.path.isdir(candidate):
+                for element in os.listdir(candidate):
+                    element = os.path.join(candidate, element)
                     if os.path.isfile(element) and element.lower().endswith('.jar'):
                         jar_files.append(element)
+
+        self.log.debug("JAR files list for Gatling: %s", jar_files)
         if jar_files:
             separator = os.pathsep
             self.jar_list = separator + separator.join(jar_files)
 
         if is_windows() or jar_files:
+            self.log.debug("Building Gatling launcher")
             self.launcher = self.__build_launcher()
         else:
+            self.log.debug("Will not build Gatling launcher")
             self.launcher = self.settings["path"]
 
         if Scenario.SCRIPT in scenario and scenario[Scenario.SCRIPT]:

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -14,7 +14,8 @@
  - allow controling JMeter HTTP redirects with `follow-redirects` option
  - add warning message for concurrency setting in Selenium config
  - disable console if stdout isn't a tty
- - add creating of new stringProp ability to jmx modifications 
+ - add creating of new stringProp ability to jmx modifications
+ - fix Gatling path lookup for JARs from execution's `files`
 
 ## 1.7.4 <sup>11 nov 2016</sup>
  - fix Locust crash when used with 'requests'-style scenario and cloud provisioning

--- a/tests/modules/test_Gatling.py
+++ b/tests/modules/test_Gatling.py
@@ -331,6 +331,34 @@ class TestGatlingExecutor(BZTestCase):
             obj.shutdown()
         self.assertIn('simulations.jar', obj.jar_list)
 
+    def test_files_find_file(self):
+        curdir = os.curdir
+        try:
+            os.chdir(__dir__() + "/../")
+            obj = self.getGatling()
+            obj.engine.file_search_paths.append(__dir__() + "/../gatling/")
+            obj.engine.config.merge({
+                "execution":{
+                    "scenario": {
+                        "script": "simulations.jar",
+                        "simulation": "tests.gatling.BasicSimulation"
+                    },
+                    "files": ["deps.jar"]
+                }
+            })
+            obj.execution.merge(obj.engine.config["execution"])
+            obj.prepare()
+            try:
+                obj.startup()
+                while not obj.check():
+                    time.sleep(obj.engine.check_interval)
+            finally:
+                obj.shutdown()
+            self.assertIn('simulations.jar', obj.jar_list)
+            self.assertIn('deps.jar', obj.jar_list)
+        finally:
+            os.chdir(curdir)
+
 
 class TestDataLogReader(BZTestCase):
     def test_read(self):

--- a/tests/modules/test_Gatling.py
+++ b/tests/modules/test_Gatling.py
@@ -332,7 +332,7 @@ class TestGatlingExecutor(BZTestCase):
         self.assertIn('simulations.jar', obj.jar_list)
 
     def test_files_find_file(self):
-        curdir = os.curdir
+        curdir = get_full_path(os.curdir)
         try:
             os.chdir(__dir__() + "/../")
             obj = self.getGatling()


### PR DESCRIPTION
So it won't mess relative paths.

Also, add a few debug logs to ease debugging issues like this one in the future.