### PR TITLE
Always set `continue_forever` to True when compiling into Loop Controllers

### DIFF
--- a/bzt/jmx.py
+++ b/bzt/jmx.py
@@ -989,14 +989,13 @@ class JMX(object):
 
     @staticmethod
     def _get_loop_controller(loops):
-        loop_forever = loops == 'forever'
-        if loop_forever:
+        if loops == 'forever':
             iterations = -1
         else:
             iterations = loops
         controller = etree.Element("LoopController", guiclass="LoopControlPanel", testclass="LoopController",
                                    testname="Loop Controller")
-        controller.append(JMX._bool_prop("LoopController.continue_forever", loop_forever))
+        controller.append(JMX._bool_prop("LoopController.continue_forever", True))
         controller.append(JMX._string_prop("LoopController.loops", str(iterations)))
         return controller
 

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -16,6 +16,7 @@
  - disable console if stdout isn't a tty
  - add creating of new stringProp ability to jmx modifications
  - fix Gatling path lookup for JARs from execution's `files`
+ - alter `loop` block to JMX compilation scheme to better reflect JMeter defaults (kudos to @rogerbramon)
 
 ## 1.7.4 <sup>11 nov 2016</sup>
  - fix Locust crash when used with 'requests'-style scenario and cloud provisioning

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1387,7 +1387,7 @@ class TestJMeterExecutor(BZTestCase):
         loops = xml_tree.find(".//LoopController/stringProp[@name='LoopController.loops']")
         self.assertEqual(loops.text, "10")
         forever = xml_tree.find(".//LoopController/boolProp[@name='LoopController.continue_forever']")
-        self.assertEqual(forever.text, "false")
+        self.assertEqual(forever.text, "true")
 
     def test_request_logic_loop_forever(self):
         self.configure({


### PR DESCRIPTION
This is to make JMX handling inside Taurus consistent with JMeter's own behaviour.

Kudos to @rogerbramon for noticing.

Discussion link: https://github.com/Blazemeter/taurus/commit/79a751ffb2383e0922f7975ea2b11b8d3f9f4e6c#commitcomment-20201839