### PR TITLE
Allow options overrides as provided by the bzt cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,5 +70,12 @@ RUN bzt /tmp/bzt-src/examples/all-executors.yml -o settings.artifacts-dir=/tmp/a
 RUN mkdir /bzt-configs \
   && rm -rf /tmp/*
 
+ENV OVERRIDES ""
+
 WORKDIR /bzt-configs
-CMD bzt -l /tmp/artifacts/bzt.log /bzt-configs/*.yml
+CMD if [ -e /bzt-configs/overrides.txt ]; then \
+    while overrides= read -r line; do \
+      OVERRIDES="-o $line $OVERRIDES"; \
+    done < /bzt-configs/overrides.txt; \
+    fi; \
+    bzt -l /tmp/artifacts/bzt.log $OVERRIDES /bzt-configs/*.yml


### PR DESCRIPTION
## Background:
I have an application where users are able to schedule events and then have other users register for those events. I want to load test our event registration endpoints using the [undera/taurus/](https://hub.docker.com/r/undera/taurus/) Docker image in my Jenkins environment. I want the tests to run against a new event each time, which means I have to be able to dynamically pass the registration URL for the event under test to the Docker run.

## What this PR does:
Users will be able to pass an arbitrary number of option overrides to the Docker run. Since [Docker environment variable only support simple values](https://github.com/docker/docker/issues/20169#issuecomment-268548383), I configured the Dockerfile CMD to look for a file named `overrides.txt` in the `/bzt-configs` directory that will contain an option override on each line. If that file exists, the CMD will parse each line and include it as a `-o` argument to the `bzt` command.