### PR TITLE
Fix mutual recursion detection for `include-scenario` blocks

### DIFF
--- a/site/dat/docs/changes/1.7.6/fux-jmeter-include-scenario-recursion-detection.change
+++ b/site/dat/docs/changes/1.7.6/fux-jmeter-include-scenario-recursion-detection.change
@@ -1,0 +1,17 @@
+Fix mutual recursion detection for `include-scenario` blocks in JMeter executor.
+
+It was affecting scenarios like this one:
+```yaml
+---
+scenarios:
+  main:
+    requests:
+    - include-scenario: subroutine
+    - include-scenario: subroutine
+  subroutine:
+    requests:
+      - ${url}
+
+execution:
+- scenario: main
+```

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -2086,6 +2086,36 @@ class TestJMeterExecutor(BZTestCase):
         self.assertIn("TestSuite 1-index-1", self.obj.engine.config["scenarios"])
         self.assertIn("TestSuite 1-index-2", self.obj.engine.config["scenarios"])
 
+    def test_include_scenario_mutual_recursion(self):
+        self.configure({
+            "execution": {
+                "scenario": "scen",
+            },
+            "scenarios": {
+                "scen": {
+                    "requests": [{"include-scenario": "subroutine"},
+                                 {"include-scenario": "subroutine"}]
+                },
+                "subroutine": {"requests": ["http://blazedemo.com"]},
+            },
+        })
+        self.obj.prepare()
+
+    def test_include_scenario_mutual_recursion_resources(self):
+        self.configure({
+            "execution": {
+                "scenario": "scen",
+            },
+            "scenarios": {
+                "scen": {
+                    "requests": [{"include-scenario": "subroutine"},
+                                 {"include-scenario": "subroutine"}]
+                },
+                "subroutine": {"requests": ["http://blazedemo.com"]},
+            },
+        })
+        self.obj.resource_files()
+
 
 class TestJMX(BZTestCase):
     def test_jmx_unicode_checkmark(self):


### PR DESCRIPTION
It was affecting cases like this one:
```yaml
---
scenarios:
  main:
    requests:
    - include-scenario: subroutine
    - include-scenario: subroutine
  subroutine:
    requests:
      - ${url}

execution:
- scenario: main
```