### PR TITLE
.gitignore /geckodriver.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/geckodriver.log
+
 **/target/
 *.iml
 **/.idea/


### PR DESCRIPTION
After running the test suite locally `sudo ./run-test.sh` I found geckodrive.log in the taurus project root path, this is not a big deal but I though this would be good to git-ignore it, and the perfect opportunity to warm-up in order to start contributing to Taurus project by creating an easy PR and become familiar with the contributing/building process on this project, "I didn't found a contributing section anywhere"

Thanks