### PR TITLE
Be a bit more defensive about handling BZA test results

### DIFF
--- a/bzt/modules/blazemeter.py
+++ b/bzt/modules/blazemeter.py
@@ -1878,23 +1878,23 @@ class ResultsFromBZA(ResultsProvider):
             aggr[label['labelName']] = label
 
         for label in data:
-            if label['kpis'] and not final_pass:
+            if label.get('kpis') and not final_pass:
                 label['kpis'].pop(-1)  # never take last second since it could be incomplete
 
         timestamps = []
         for label in data:
-            if label['label'] == 'ALL':
-                timestamps.extend([kpi['ts'] for kpi in label['kpis']])
+            if label.get('label') == 'ALL':
+                timestamps.extend([kpi['ts'] for kpi in label.get('kpis', [])])
 
         for tstmp in timestamps:
             point = DataPoint(tstmp)
             for label in data:
-                for kpi in label['kpis']:
+                for kpi in label.get('kpis', []):
                     if kpi['ts'] != tstmp:
                         continue
 
-                    label_str = label['label']
-                    if label_str not in aggr:
+                    label_str = label.get('label')
+                    if label_str is None or label_str not in aggr:
                         self.log.warning("Skipping inconsistent data from API for label: %s", label_str)
                         continue
 

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -18,6 +18,7 @@
  - fix passfail `rc404>10 within 1m` logic
  - fix overriding concurrency in case thread groups have non-int values inside
  - fix JMeter's treatment of resource files for cloud tests that have paths relative to the JMX
+ - fix crash on cloud test results handling caused by API changes
 
 
 [Changelog for Year 2016](Changelog2016.md)

--- a/tests/modules/test_blazeMeterUploader.py
+++ b/tests/modules/test_blazeMeterUploader.py
@@ -413,6 +413,93 @@ class TestResultsFromBZA(BZTestCase):
         percentiles_ = total[KPISet.PERCENTILES]
         self.assertEquals(1.05, percentiles_['99.0'])
 
+    def test_no_kpis_on_cloud_crash(self):
+        client = BlazeMeterClientEmul(logging.getLogger(""))
+        client.results.append({
+            "api_version": 2,
+            "error": None,
+            "result": [
+                {
+                    "sessions": [
+                        "r-t-5746a8e38569a"
+                    ],
+                    "id": "ALL",
+                    "name": "ALL"
+                },
+                {
+                    "sessions": [
+                        "r-t-5746a8e38569a"
+                    ],
+                    "id": "e843ff89a5737891a10251cbb0db08e5",
+                    "name": "http://blazedemo.com/"
+                }
+            ]
+        })
+        client.results.append({
+            "api_version": 2,
+            "error": None,
+            "result": [
+                {
+                    "labelId": "ALL",
+                    "labelName": "ALL",
+                }
+            ]
+        })
+        client.results.append({
+            "api_version": 2,
+            "error": None,
+            "result": [
+                {
+                    "labelId": "ALL",
+                    "labelName": "ALL",
+                    "samples": 152,
+                    "avgResponseTime": 786,
+                    "90line": 836,
+                    "95line": 912,
+                    "99line": 1050,
+                    "minResponseTime": 531,
+                    "maxResponseTime": 1148,
+                    "avgLatency": 81,
+                    "geoMeanResponseTime": None,
+                    "stDev": 108,
+                    "duration": 119,
+                    "avgBytes": 0,
+                    "avgThroughput": 1.2773109243697,
+                    "medianResponseTime": 0,
+                    "errorsCount": 0,
+                    "errorsRate": 0,
+                    "hasLabelPassedThresholds": None
+                },
+                {
+                    "labelId": "e843ff89a5737891a10251cbb0db08e5",
+                    "labelName": "http://blazedemo.com/",
+                    "samples": 152,
+                    "avgResponseTime": 786,
+                    "90line": 836,
+                    "95line": 912,
+                    "99line": 1050,
+                    "minResponseTime": 531,
+                    "maxResponseTime": 1148,
+                    "avgLatency": 81,
+                    "geoMeanResponseTime": None,
+                    "stDev": 108,
+                    "duration": 119,
+                    "avgBytes": 0,
+                    "avgThroughput": 1.2773109243697,
+                    "medianResponseTime": 0,
+                    "errorsCount": 0,
+                    "errorsRate": 0,
+                    "hasLabelPassedThresholds": None
+                }
+            ]
+        })
+
+        obj = ResultsFromBZA(client)
+        obj.master_id = 0
+
+        res = list(obj.datapoints(True))
+        self.assertEqual(res, [])
+
 
 class TestMonitoringBuffer(BZTestCase):
     def to_rad(self, deg):


### PR DESCRIPTION
I.e. don't crash when BZA sends us test results data without KPIs and labels.