### PR TITLE
Capture JMeter's stdout/stderr streams and save them to artifacts dir

### DIFF
--- a/site/dat/docs/changes/capture-jmeter-stdout-stderr.change
+++ b/site/dat/docs/changes/capture-jmeter-stdout-stderr.change
@@ -1,0 +1,3 @@
+Capture JMeter's stdout/stderr streams and save them to artifacts dir
+
+This fixes "JMeter threads stuck on `System.out.println()` call".

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1260,10 +1260,11 @@ class TestJMeterExecutor(BZTestCase):
         self.obj.prepare()
         self.obj._env['TEST_MODE'] = 'heap'
         self.obj.startup()
-        stdout, _ = self.obj.process.communicate()
         self.obj.shutdown()
         self.obj.post_process()
-        self.assertIn("-Xmx2G", str(stdout))
+        with open(os.path.join(self.obj.engine.artifacts_dir, "jmeter.out")) as fds:
+            stdout = fds.read()
+        self.assertIn("-Xmx2G", stdout)
 
     def test_data_sources_in_artifacts(self):
         self.configure({

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -2160,6 +2160,21 @@ class TestJMeterExecutor(BZTestCase):
         self.assertNotIn("a.csv", resources)
         self.assertTrue(any(res.endswith(os.path.join("nested", "directory", "a.csv")) for res in resources))
 
+    def test_stdout_stderr_capture(self):
+        self.configure(json.loads(open(__dir__() + "/../json/get-post.json").read()))
+        self.obj.prepare()
+        try:
+            self.obj.startup()
+            while not self.obj.check():
+                self.obj.log.debug("Check...")
+                time.sleep(1)
+            self.obj.shutdown()
+            self.obj.post_process()
+        except:
+            pass
+        self.assertTrue(os.path.exists(os.path.join(self.obj.engine.artifacts_dir, "jmeter.out")))
+        self.assertTrue(os.path.exists(os.path.join(self.obj.engine.artifacts_dir, "jmeter.err")))
+
 
 class TestJMX(BZTestCase):
     def test_jmx_unicode_checkmark(self):

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -828,7 +828,7 @@ class TestJMeterExecutor(BZTestCase):
                 "script": __dir__() + "/../jmeter/jmx/variable_csv.jmx"}})
         self.obj.prepare()
         artifacts = os.listdir(self.obj.engine.artifacts_dir)
-        self.assertEqual(len(artifacts), 3)  # 2*effective, .properties, jmx
+        self.assertEqual(len(artifacts), 5)  # 2*effective, .properties, .out, .err
         with open(self.obj.modified_jmx) as fds:
             jmx = fds.read()
             self.assertIn('<stringProp name="filename">${root}/csvfile.csv</stringProp>', jmx)


### PR DESCRIPTION
This fixes "JMeter threads stuck on `System.out.println()` call" issue.