### PR TITLE
Allow YAML multi-docs for configs

### DIFF
--- a/bzt/engine.py
+++ b/bzt/engine.py
@@ -558,45 +558,28 @@ class Configuration(BetterDict):
         self.log = logging.getLogger('')
         self.dump_filename = None
 
-    def load(self, configs, callback=None):
+    def load(self, config_files, callback=None):
         """
         Load and merge JSON/YAML files into current dict
 
         :type callback: callable
-        :type configs: list[str]
+        :type config_files: list[str]
         """
-        self.log.debug("Configs: %s", configs)
-        for config_file in configs:
+        self.log.debug("Configs: %s", config_files)
+        for config_file in config_files:
             try:
-                config = self.__read_file(config_file)
+                configs = []
+                self.log.debug("Reading %s", config_file)
+                with open(config_file) as fds:
+                    configs.extend(yaml.load_all(fds))
             except BaseException as exc:
                 raise TaurusConfigError("Error when reading config file '%s': %s" % (config_file, exc))
 
-            self.merge(config)
+            for config in configs:
+                self.merge(config)
 
             if callback is not None:
                 callback(config_file)
-
-    def __read_file(self, filename):
-        """
-        Read and parse config file
-        :param filename: str
-        :return: list
-        """
-        with open(filename) as fds:
-            first_line = "#"
-            while first_line.startswith("#"):
-                first_line = fds.readline().strip()
-            fds.seek(0)
-
-            if first_line.startswith('---'):
-                self.log.debug("Reading %s as YAML", filename)
-                return yaml.load(fds)
-            elif first_line.strip().startswith('{'):
-                self.log.debug("Reading %s as JSON", filename)
-                return json.loads(fds.read())
-            else:
-                raise TaurusConfigError("Cannot detect file format for %s" % filename)
 
     def set_dump_file(self, filename):
         """

--- a/site/dat/docs/ApacheBenchmark.md
+++ b/site/dat/docs/ApacheBenchmark.md
@@ -20,7 +20,6 @@ Keep in mind the following rules when using `executor: ab`:
 
 Simplest working example:
 ```yaml
----
 execution:
 - executor: ab
   scenario: simple
@@ -33,7 +32,6 @@ scenarios:
 
 Example of `hold-for` usage:
 ```yaml
----
 execution:
 - executor: ab
   hold-for: 30s
@@ -47,7 +45,6 @@ scenarios:
 
 Complex example:
 ```yaml
----
 execution:
 - executor: ab
   concurrency: 20
@@ -72,7 +69,6 @@ scenarios:
 If you have Apache Benchmark in non-standard location, use `path` option to point Taurus to the `ab`:
 
 ```yaml
----
 modules:
   ab:
     path: /home/john/build/apache2/bin/ab

--- a/site/dat/docs/BlazemeterReporter.md
+++ b/site/dat/docs/BlazemeterReporter.md
@@ -27,7 +27,6 @@ under your [Settings => API Key](https://a.blazemeter.com/app/#settings/api-key)
 into `token` option:
 
 ```yaml
----
 modules:
   blazemeter:
     token: TDknBxu0hmVnJ7NqtG2F
@@ -47,7 +46,6 @@ Now you can use `-report` command-line switch, or you can set BlazeMeter reporti
 your config, the `test` option specifies test name to use, `project` names group of tests:
 
 ```yaml
----
 reporting:
 - module: blazemeter
   report-name: Jenkins Build 1
@@ -58,7 +56,6 @@ reporting:
 Advanced settings:
 
 ```yaml
----
 modules:
   blazemeter:
     address: https://a.blazemeter.com  # reporting service address

--- a/site/dat/docs/ChromeProfiler.md
+++ b/site/dat/docs/ChromeProfiler.md
@@ -12,7 +12,6 @@ calculated metrics to the terminal at the end of the test.
 
 Here's an example of Taurus configuration that uses profiler service:
 ```yaml
----
 execution:
 - executor: selenium
   scenario: simple

--- a/site/dat/docs/Cloud.md
+++ b/site/dat/docs/Cloud.md
@@ -5,13 +5,11 @@ The default mode for taurus is to use `local` provisioning, which means all the 
 It is done by setting `cloud` provisioning like this:
 
 ```yaml
----
 provisioning: cloud
 ```
 
 To access BlazeMeter cloud, Taurus would require to have API key set inside `cloud` module settings:
 ```yaml
----
 modules:
   cloud:
     token: ******  # API key
@@ -38,7 +36,6 @@ being logged and collected in artifacts.
 By default, cloud-provisioned execution will read `concurrency` and `throughput` options normally. There's a notation that allows configuring values for `local` and `cloud` at once, to remove the need to edit load settings when switching `provisioning` during test debugging from `local` to `cloud` and back:
 
 ```yaml
----
 execution:
 - scenario: my-scen
   concurrency:
@@ -55,7 +52,6 @@ The `concurrency` and `througput` are always *total* value for execution, no mat
 ## Detach Mode
 You can start Cloud test and stop Taurus without waiting for test results with attribute `detach`:
 ```yaml
----
 modules:
   cloud:
     token: ******    
@@ -68,7 +64,6 @@ or use appropriate alias for this: `bzt config.yml -cloud -detach`
 Cloud locations are specified per-execution. Specifying multiple cloud locations for execution means that its `concurrency` and/or `throughput` will be distributed among the locations. Locations is the map of location id's and their relative weights. Relative weight determines how much value from `concurrency` and `throughput` will be put into corresponding location. 
 
 ```yaml
----
 execution:
 - locations:
     us-west-1: 1
@@ -80,7 +75,6 @@ If no locations specified for cloud execution, default value from `modules.cloud
 By default, Taurus will calculate machines count for each location based on their limits obtained from *User API Call*. To switch to manual machines count just set option `locations-weighted` into `false`. Exact numbers of machines for each location will be used in that case:
 
 ```yaml
----
 execution:
 - locations:
     us-west-1: 2
@@ -89,7 +83,6 @@ execution:
 ```
 
 ```yaml
----
 execution: 
   - scenario: dummy 
     concurrency:
@@ -113,7 +106,6 @@ scenarios:
 ## Reporting Settings
 
 ```yaml
----
 modules:
   cloud:
     test: Taurus Test  # test name
@@ -127,7 +119,6 @@ this behaviour by setting `delete-test-files` module setting to `false`.
 
 Example:
 ```yaml
----
 modules:
   cloud:
     delete-test-files: false
@@ -137,7 +128,6 @@ modules:
 If you need some additional files as part of your test and Taurus fails to detect them automatically, you can attach them to execution using `files` section:
 
 ```yaml
----
 execution:
 - locations:
     us-east-1: 1
@@ -162,7 +152,6 @@ In shellexec service, the `run-at` parameter allows to set where commands will b
 If you need to install additional python modules via `pip`, you can do it by using `shellexec` service and running `pip install <package>` command at `prepare` stage:
 
 ```yaml
----
 services:
 - module: shellexec
   prepare: 
@@ -172,7 +161,6 @@ services:
 You can even upload your proprietary python eggs into workers by specifying them in `files` option and then installing by shellexec:
 
 ```yaml
----
 execution:
 - executor: locust
   scenario: locust-scen

--- a/site/dat/docs/CommandLine.md
+++ b/site/dat/docs/CommandLine.md
@@ -39,7 +39,6 @@ Rule for composing the override path is simple: it is built from dictionary keys
 
 Consider the following Taurus configuration:
 ```yaml
----
 execution:
 - concurrency: 100
   hold-for: 60s
@@ -81,7 +80,6 @@ There is a way to create some config chunks and apply them from command-line lik
 Those aliases then searched in the config, in the section `cli-aliases` and applied over the configuration. Example:
 
 ```yaml
----
 cli-aliases:
   gui-mode:
     modules:

--- a/site/dat/docs/ConfigSyntax.md
+++ b/site/dat/docs/ConfigSyntax.md
@@ -14,7 +14,6 @@ Configuration dictionary has several top-level keys:
 Example for config that touches all sections:
 
 ```yaml
----
 execution:
 - concurrency: 10
   hold-for: 5m
@@ -70,7 +69,6 @@ Module settings section is dictionary, having module aliases as keys and setting
 The shorthand is to specify module class string instead of settings dictionary, Taurus will expand it into dict automatically. For example,
 
 ```yaml
----
 modules:
   final_stats: bzt.modules.reporting.FinalStatus
 ```
@@ -78,7 +76,6 @@ modules:
 is equivalent to
 
 ```yaml
----
 modules:
   final_stats:
     class: bzt.modules.reporting.FinalStatus
@@ -97,7 +94,6 @@ Available settings are:
 See default settings below:
 
 ```yaml
----
 settings:
   artifacts-dir: /tmp/%H%M%S # path where to save artifacts, default is %Y-%m-%d_%H-%M-%S.%f
   aggregator: consolidator
@@ -165,7 +161,6 @@ engine will perfectly deal with it. For example, following JSON file:
 is equivalent to YAML:
 
 ```yaml
----
 aggregator: aggregator
 
 execution:
@@ -198,7 +193,6 @@ Hint: YAML config files on Linux/MacOS allows a trick of self-executing config. 
 
 ```yaml
 #! /usr/local/bin/bzt
----
 execution:
 - hold-for: 1m
   scenario: simple
@@ -225,7 +219,6 @@ Now you are able to start this file on its own:
 After all config files loaded, Taurus will also merge into resulting configuration any `included-configs` from the list. Example syntax piece:
 
 ```yaml
----
 included-configs:  # it must be a list of string values
 - additional-local-file.yml  # to add local file just set its path
 - http://central.host/mystorage/remote.yml  # you can also download config from http/https location
@@ -245,7 +238,6 @@ There are a few limitations about using `hostaliases` setting:
 
 Here's an example of using `hostaliases`:
 ```yaml
----
 execution:
 - scenario: host_sample
 

--- a/site/dat/docs/ExecutionSettings.md
+++ b/site/dat/docs/ExecutionSettings.md
@@ -3,7 +3,6 @@
 Execution objects represent actual underlying tool executions. You can launch unlimited number of JMeter's, Gatling Tool's, Grinder Tools, etc. Executions are configured under top-level config key `execution`. Specifying single execution config is equivalent to specifying array of executions with single element, for example:
 
 ```yaml
----
 execution:
   scenario: scenario_name    
 ```
@@ -11,7 +10,6 @@ execution:
 is equivalent for 
 
 ```yaml
----
 execution:
 - scenario: scenario_name
 ```
@@ -36,7 +34,6 @@ Taurus tool may use different underlying tools as executors for scenarios. Curre
 
 Default executor is `jmeter` and can be changed under [general settings](ConfigSyntax.md#top-level-settings) section.
 ```yaml
----
 settings:
   default-executor: jmeter
 ```
@@ -56,7 +53,6 @@ Execution has several options to set load profile settings. Support for options 
  - `scenario` - name of scenario that described in `scenarios` part (see below)
 
 ```yaml
----
 execution: 
 - concurrency: 10
   ramp-up: 15s
@@ -71,7 +67,6 @@ execution:
 Scenario is a sequence of steps that is used to build script for underlying tool (e.g. generate JMX file for JMeter). It is described in special `scenarios` top-level config element. There are three examples of scenario syntax:
 
 ```yaml
----
 scenarios:
   get-requests:                     # normal form: scenario is dictionary
     requests:
@@ -95,7 +90,6 @@ execution:
 
 You can run different executions at different times with `delay` option:
 ```yaml
----
 execution:
 - concurrency: 10
   hold-for: 20s
@@ -114,7 +108,6 @@ By this way, the first execution works 10 seconds, then two executions will work
 
 Another way to schedule is usage of `start-at`:
 ```yaml
----
 execution:
 - concurrency: 10
   hold-for: 20s
@@ -141,7 +134,6 @@ When your execution requires additional files (e.g. JARs, certificates etc.) and
 By default, Taurus runs items under `execution` in parallel. To switch it into sequential mode, run it with `-sequential` command-line option. This is an alias for this setting:
 
 ```yaml
----
 modules:
   local:
     sequential: true

--- a/site/dat/docs/Gatling.md
+++ b/site/dat/docs/Gatling.md
@@ -7,7 +7,6 @@ In Taurus you have two way for run it: with native gatling script or with usual 
 ## Run Gatling Tool
 
 ```yaml
----
 execution:
 - executor: gatling
   scenario: sample
@@ -69,7 +68,6 @@ class BasicSimulation extends Simulation {
 If your Gatling test suite is really huge or has dependencies on other files - you can bundle it in a jar (with the help of sbt or Maven) and then run this jar with Taurus. Just specify it as a `script` value in scenario.
 
 ```yaml
----
 execution:
 - executor: gatling
   scenario: sample
@@ -89,7 +87,6 @@ Some asserts can be added to request. Assert describes templates and area for se
  Next yaml example shows the way these features can be used and ready to conversion to scala automatically:
 
 ```yaml
----
 execution:
 - executor: gatling
   iterations: 15
@@ -144,7 +141,6 @@ scenarios:
  - `properties`: dictionary for tuning of gatling tool behaviour (see list of available parameters in gatling documentation) and sending your own variables into Scala program:
 
 ```yaml
----
 modules:
   gatling:
     properties:
@@ -164,7 +160,6 @@ class BasicSimulation extends Simulation {
 Thanks to Taurus you can use additional Java classes in your scala code. For this add required jar files or contained dir to `files` list:
 
 ```yaml
----
 execution:
 - executor: gatling
   concurrency: 10

--- a/site/dat/docs/Grinder.md
+++ b/site/dat/docs/Grinder.md
@@ -18,7 +18,6 @@ All parameters are passed with .properties file, so they will work for your scri
 ## Running Grinder
 Running Grinder with existing script and properties file.
 ```yaml
----
 execution:
 - executor: grinder
   concurrency: 3

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -7,7 +7,6 @@ This executor type is used by default, it uses [Apache JMeter](http://jmeter.apa
 If there is no JMeter installed at the configured `path`, Taurus will attempt to install latest JMeter and Plugins into
 this location, by default `~/.bzt/jmeter-taurus/bin/jmeter`. You can change this setting to your preferred JMeter location (consider putting it into `~/.bzt-rc` file). All module settings that relates to JMeter path and auto-installing are listed below:
 ```yaml
----
 modules:
   jmeter:
     path: ~/.bzt/jmeter-taurus/bin/jmeter
@@ -22,7 +21,6 @@ modules:
     
 ## Run Existing JMX File
 ```yaml
----
 execution:
 - scenario: simple
 
@@ -42,7 +40,6 @@ You may also specify system properties for JMeter in system-properties section. 
 Global properties are set like this:
 
 ```yaml
----
 modules:
   jmeter:
     properties:
@@ -56,7 +53,6 @@ modules:
 Scenario-level properties are set like this:
 
 ```yaml
----
 scenarios:
   prop_example: 
     properties:
@@ -68,7 +64,6 @@ scenarios:
 When you want to verify or debug the JMX file that were generated from your requests scenario, you don't need to search for the file on disk, just enable GUI mode for JMeter module:
 
 ```yaml
----
 modules:
   jmeter:
     gui: false  # set it to true to open JMeter GUI instead of running non-GUI test
@@ -80,7 +75,6 @@ For the command-line, use alias `-gui` or option `-o modules.jmeter.gui=true`, w
 Distributed mode for JMeter is enabled with simple option `distributed` under execution settings, listing JMeter servers under it:
 
 ```yaml
----
 execution:
 - distributed: 
   - host1.mynet.com
@@ -102,7 +96,6 @@ By default, Taurus tries to call graceful JMeter shutdown by using its UDP shutd
 JMeter executor allows you to apply some modifications to the JMX file before running JMeter (this affects both existing JMXes and generated from requests):
 
 ```yaml
----
 scenarios:
   modification_example:
     script: tests/jmx/dummy.jmx
@@ -132,7 +125,6 @@ Scenario is the sequence of steps and some settings that will be used by underly
 Scenarios are listed in top-level `scenarios` element and referred from executions by their alias:
 
 ```yaml
----
 scenarios:
   get-requests:  # the alias for scenario
     requests:
@@ -148,7 +140,6 @@ execution:
 Scenario has some global settings:
 
 ```yaml
----
 scenarios:
   get-requests:  
     store-cache: true  # browser cache simulation, enabled by default
@@ -193,7 +184,6 @@ Request objects can be of two kinds:
 The base element for requests scenario is HTTP Request. In its simplest form it contains just the URL as string:
 
 ```yaml
----
 scenarios:
   get-requests:  
     requests:
@@ -204,7 +194,6 @@ scenarios:
 The full form for request is dictionary, all fields except `url` are optional:
 
 ```yaml
----
 scenarios:
   my-req: 
     requests:
@@ -250,7 +239,6 @@ The concept is based on JMeter's extractors. The following types of extractors a
 To specify extractors in shorthand form, use following configuration:
 
 ```yaml
----
 scenarios:
   my-req: 
     requests:
@@ -271,7 +259,6 @@ scenarios:
 The full form for extractors is:
 
 ```yaml
----
 scenarios:
   my-req: 
     requests:
@@ -318,7 +305,6 @@ Currently three types of response assertions are available.
 First one checks http response fields, its short form looks like this:
 
 ```yaml
----
 scenarios:
   my-req: 
     requests:
@@ -330,7 +316,6 @@ scenarios:
 The full form has following format:
 
 ```yaml
----
 scenarios:
   my-req: 
     requests:
@@ -353,7 +338,6 @@ Possible subjects are:
 The second assertion type is used to perform validation of JSON response against JSONPath expression.
 
 ```yaml
----
 scenarios:
   my-req:
     requests:
@@ -366,7 +350,6 @@ scenarios:
 Full form:
 
 ```yaml
----
 scenarios:
   my-req:
     requests:
@@ -383,7 +366,6 @@ scenarios:
 And the third assertion type uses XPath query to validate XML response.
 
 ```yaml
----
 scenarios:
   assertion-demo:
     requests:
@@ -396,7 +378,6 @@ scenarios:
 Full form:
 
 ```yaml
----
 scenarios:
   my-req:
     requests:
@@ -416,7 +397,6 @@ after each request. Taurus allows that with `jsr223` block.
 
 Minimal example that will generate one JSR223 Post Processor.
 ```yaml
----
 scenarios:
   jsr-example:
     requests:
@@ -439,7 +419,6 @@ By default it's set to `after`.
 
 Full form:
 ```yaml
----
 scenarios:
   jsr-example:
     requests:
@@ -671,7 +650,6 @@ scenarios:
 ## JMeter Test Log
 You can tune JTL file content with option `write-xml-jtl`. Possible values are 'error' (default), 'full', or any other value for 'none'. Keep in mind: max `full` logging can seriously load your system.
 ```yaml
----
 execution:
 - write-xml-jtl: full
   scenario: simple_script
@@ -683,7 +661,6 @@ scenarios:
 ```
 Another way to adjust verbosity is to change flags in `xml-jtl-flags` dictionary. Next example shows all flags with default values (you don't have to use full dictionary if you want to change some from them):
 ```yaml
----
 modules:
   jmeter:
     xml-jtl-flags:
@@ -721,7 +698,6 @@ Use `K`, `M` or `G` suffixes to specify memory limit in kilobytes, megabytes or 
 
 Example:
 ```yaml
----
 modules:
   jmeter:
     memory-xmx: 4G  # allow JMeter to use up to 4G of memory
@@ -734,7 +710,6 @@ Taurus scenarios and execute them with JMeter.
 
 Example:
 ```yaml
----
 execution:
 - concurrency: 10
   hold-for: 5m

--- a/site/dat/docs/Locust.md
+++ b/site/dat/docs/Locust.md
@@ -10,7 +10,6 @@ Taurus appends `PYTHONPATH` with path to artifacts directory and current working
 Here's example config that uses existing locust file:
 
 ```yaml
----
 execution:
 - executor: locust
   concurrency: 10
@@ -55,7 +54,6 @@ LocustIO executor partially supports building scenario from requests. Supported 
  - set timeout/think-time on both scenario/request levels
  - assertions (for body and http-code)
 ```yaml
----
 scenarios:
   request_example:
     timeout: 10  #  global scenario timeout for connecting, receiving results, 30 seconds by default

--- a/site/dat/docs/Monitoring.md
+++ b/site/dat/docs/Monitoring.md
@@ -19,7 +19,6 @@ Following metrics are collected locally:
 - `engine-loop` - Taurus "check loop" utilization, values higher than 1.0 means you should increase `settings.check-interval`
 
 ```yaml
----
 services:
 - module: monitoring
   local:
@@ -47,7 +46,6 @@ you need to install and launch ServerAgent on each of your target servers and th
 [metrics](http://jmeter-plugins.org/wiki/PerfMonMetrics/) to collect under `services` item.
 For example: 
 ```yaml
----
 services:
 - module: monitoring
   server-agent:
@@ -66,7 +64,6 @@ Graphite data source uses graphite The Render URL API to receive metrics.
 In this example you can see usage optional server `label`, `timeout` for graphite answers, `interval`
 between requests and interesting graphite data range definition with parameters `from`/`until`.
 ```yaml
----
 services:
 - module: monitoring
   graphite:

--- a/site/dat/docs/PBench.md
+++ b/site/dat/docs/PBench.md
@@ -14,7 +14,6 @@ sudo dpkg -i blazemeter-pbench-extras_0.0.6.1_amd64.deb  # built from https://gi
 
 Then use it like this:
 ```yaml
----
 execution:
 - executor: pbench
   scenario: simple_usage
@@ -54,7 +53,6 @@ High throughput and precision comes with a price of lost requests logic. No loop
 
 First way to give it requests is to use usual Taurus requests spec of:
 ```yaml
----
 scenarios:
   pbench-example:
     default-address: http://blazedemo.com
@@ -77,7 +75,6 @@ scenarios:
  
 Second way is to generate the payload script yourself and use it. This is frequently done with custom scripts that takes production server logs as source data:
 ```yaml
----
 scenarios:
   pbench-example:
     default-address: http://blazedemo.com

--- a/site/dat/docs/PassFail.md
+++ b/site/dat/docs/PassFail.md
@@ -7,7 +7,6 @@ resources.
 
 Pass/fail criteria are specified as array of `criteria`, set through `reporting` item in config:
 ```yaml
----
 reporting:
 - module: passfail
   criteria:
@@ -57,7 +56,6 @@ The full form of the criteria is conducted by Taurus automatically from short fo
 specify it as this:
 
 ```yaml
----
 reporting:
 - module: passfail
   criteria:
@@ -82,7 +80,6 @@ to change the message, you can do one of:
  - use dictionary instead of array to specify message and criteria, like this:
  
 ```yaml
----
 reporting:
 - module: passfail
   criteria:
@@ -98,7 +95,6 @@ for metric specification because of the need to specify metric class `bzt.module
 For example, to stop test once local CPU is exhausted, use:
 
 ```yaml
----
 reporting:
 - module: passfail
   criteria:

--- a/site/dat/docs/Proxy2JMX.md
+++ b/site/dat/docs/Proxy2JMX.md
@@ -4,7 +4,6 @@ It's possible to convert existing Selenium scripts into JMeter JMX file. Keep in
 For this purpose Taurus uses [BlazeMeter Recorder](https://guide.blazemeter.com/hc/en-us/articles/207420545-BlazeMeter-Recorder-Mobile-Recorder-) so you need valid token. This service starts proxy for logging requests and build jmx file based on the requests when test is finished. You will need [BlazeMeter API key configured](BlazemeterReporter/#Personalized-Usage) for this approach to work. Lets see example config:
 
 ```yaml
----
 execution:
 - executor: selenium
   iterations: 1

--- a/site/dat/docs/Reporting.md
+++ b/site/dat/docs/Reporting.md
@@ -7,7 +7,6 @@ Reporters are specified as list under top-level config key `reporting`, by defau
 configured with two reporters:
 
 ```yaml
----
 reporting:
 - final_stats
 - console
@@ -17,7 +16,6 @@ The example above uses a shorthand form for specifying reporters. Full form is u
 and allows specifying some additional settings for reporters:
 
 ```yaml
----
 reporting:
 - module: final_stats
 - module: console
@@ -61,7 +59,6 @@ for example:
 This reporter is enabled by default. You can tweak its behaviour with the following options:
 
 ```yaml
----
 reporting:
 - module: final_stats
   summary: true  # overall samples count and percent of failures
@@ -106,7 +103,6 @@ If `pass-fail` used as source data, report will contain [Pass/Fail](PassFail.md)
 Sample configuration:
 
 ```yaml
----
 reporting:
 - module: junit-xml
   filename: /path_to_file/file.xml
@@ -119,7 +115,6 @@ Aggregating facility module is set through general settings, by default
 it is: 
 
 ```yaml
----
 settings:
   aggregator: consolidator
 ```
@@ -127,7 +122,6 @@ settings:
 The `consolidator` has several settings:
 
 ```yaml
----
 modules:
   consolidator:
     generalize-labels: false  # replace digits and UUID sequences 
@@ -161,7 +155,6 @@ modules:
  Here's a sample:
  
  ```yaml
- ---
  reporting:
  - module: passfail
    criteria:

--- a/site/dat/docs/Selenium.md
+++ b/site/dat/docs/Selenium.md
@@ -45,7 +45,6 @@ Supported values:
 
 Usage:
 ```yaml
----
 execution:
 - executor: selenium
   runner: nose
@@ -64,7 +63,6 @@ downloaded and installed automatically into `~/.bzt/selenium-taurus`.
 Configuration options:
 
 ```yaml
----
 modules:
   selenium:
     selenium-tools:
@@ -107,7 +105,6 @@ Just like JUnit runner, TestNG runner supports the `additional-classpath` option
 Configuration options:
 
 ```yaml
----
 modules:
   selenium:
     selenium-tools:
@@ -131,7 +128,6 @@ and packages).
 Configuration options:
 
 ```yaml
----
 modules:
   selenium:
     selenium-tools:
@@ -212,7 +208,6 @@ Taurus supports only python scripts for appium in Selenium executor. Additionall
 There is typical example of usage:
  
 ```yaml
----
 execution:
 - executor: selenium
   scenario: ap_scen
@@ -252,7 +247,6 @@ Action names are built as `<action>By<selector type>(<selector>)`. Sometimes act
 
 Sample request scenario:
 ```yaml
----
 scenarios:
   request_example:
     browser: Firefox  # available browsers are: ["Firefox", "Chrome", "Ie", "Opera"]
@@ -280,7 +274,6 @@ scenarios:
 
 JUnit-based test with single .java file:
 ```yaml
----
 execution:
 - executor: selenium
   scenario: simple
@@ -292,7 +285,6 @@ scenarios:
 
 Running folder of test scripts with automatic runner detection:
 ```yaml
----
 execution:
 - executor: selenium
   scenario: simple
@@ -304,7 +296,6 @@ scenarios:
 
 Extended scenario with runner options:
 ```yaml
----
 execution:
 - executor: selenium
   iterations: 5  # loop over test suite for 5 times
@@ -335,7 +326,6 @@ If you want to run headless tests on Linux using virtual framebuffer (Xvfb), you
 display by using following config piece:
 
 ```yaml
----
 modules:
   selenium:
     virtual-display:

--- a/site/dat/docs/Services.md
+++ b/site/dat/docs/Services.md
@@ -7,7 +7,6 @@ top-level section of config with list of service module configs:
 Services are configured with `services` toplevel section. `services` section contains a list of
 services to run:
 ```yaml
----
 services:
 - module: shellexec:
   post-process: ...
@@ -32,7 +31,6 @@ Taurus provides hooks to all Taurus [test execution phases](Lifecycle.md).
 
 Sample configuration:
 ```yaml
----
 services:
 - module: shellexec
   prepare:  
@@ -98,7 +96,6 @@ You can learn more about `chrome-profiler` service at its [own page](ChromeProfi
 You can ask Taurus to unzip some of your files into artifacts directory before test starts (only zip format is supported). It's easy with `unpacker` service:
    
 ```yaml
----
 services:
 - module: unpacker
   files:
@@ -121,7 +118,6 @@ To invoke this service, just run Taurus like this `bzt -install-tools`.
 Useful for start/stop appium server automatically. This service doesn't provide installation ability so use [official documentation](http://appium.io) to get appium. You can specify path to appium through the appropriate setting:
 
 ```yaml
----
 services:
 - appium
 modules:
@@ -135,7 +131,6 @@ modules:
 It used to start/stop android emulator. For that purpose you have to get Android SDK by yourself and tell Taurus where it placed with path to emulator (usualy it can be found in <sdk_directory>/tools) in config or environment variable ANDROID_HOME, which contains SDK location. Moreover, you should choose one of your android emulators with `avd` option. 
 
 ```yaml
-----
 services:
 - android-emulator
 modules:

--- a/site/dat/docs/ShellExec.md
+++ b/site/dat/docs/ShellExec.md
@@ -2,7 +2,6 @@
 
 Sample configuration:
 ```yaml
----
 services:
 - module: shellexec
   prepare:  
@@ -28,7 +27,6 @@ scenarios:
 
 Extended task configuration sample:
 ```yaml
----
 services:
 - module: shellexec
   prepare: # stage names: [prepare, startup, check]
@@ -47,7 +45,6 @@ services:
 
 Minimum task configuration sample:
 ```yaml
----
 services:
 - module: shellexec
   prepare: ls -la
@@ -65,7 +62,6 @@ Notes:
  - There is module setting `env` which contains dictionary for additional environment variables for commands
 
 ```yaml
----
 modules:
   shellexec:
     default-cwd: /tmp

--- a/site/dat/docs/Siege.md
+++ b/site/dat/docs/Siege.md
@@ -21,7 +21,6 @@ Please keep in mind these rules when using Siege test executor:
 
 Simplest working example - use it to get taste of the tool.
 ```yaml
----
 execution:
 - executor: siege
   concurrency: 3 
@@ -36,7 +35,6 @@ scenarios:
 
 Five repeats by hundred of users without any delay (might hurt the server):
 ```yaml
----
 execution:
 - executor: siege
   concurrency: 100
@@ -51,7 +49,6 @@ scenarios:
 
 Test URLs from `nodes.list` file with 50 users, hold load for 5 minutes
 ```yaml
----
 execution:
 - executor: siege
   concurrency: 50
@@ -66,7 +63,6 @@ scenarios:
 
 Variables example:
 ```yaml
----
 scenarios:
   variables_usage:
     requests:
@@ -81,7 +77,6 @@ scenarios:
 If you have Siege in non-standard location, please use `path` option to point Taurus to `siege` binary:
 
 ```yaml
----
 modules:
   siege:
     path: /home/user/sources/siege/bin/siege

--- a/site/dat/docs/SoapUI.md
+++ b/site/dat/docs/SoapUI.md
@@ -7,7 +7,6 @@ and convert it to Taurus scenario.
 
 Example:
 ```yaml
----
 execution:
 - executor: jmeter
   concurrency: 20

--- a/site/dat/docs/Tsung.md
+++ b/site/dat/docs/Tsung.md
@@ -41,7 +41,6 @@ process. User executes all requests from given scenario and then stops.
 
 Example of using constant `concurrency` and `hold-for`:
 ```yaml
----
 execution:
 - executor: tsung
   concurrency: 100
@@ -58,7 +57,6 @@ scenarios:
 
 Example of using user's Tsung config:
 ```yaml
----
 execution:
 - executor: tsung
   scenario: sample
@@ -73,7 +71,6 @@ configuration and overwrite `<load>` section. The rest of your Tsung config will
 
 Example:
 ```yaml
----
 execution:
 - executor: tsung
   concurrency: 100
@@ -90,7 +87,6 @@ Note that Tsung doesn't support `throughput` and `ramp-up` options.
 Here's the example of various HTTP requests features that Taurus supports:
 
 ```yaml
----
 scenarios:
   features:
     default-address: http://blazedemo.com  # base address for HTTP requests
@@ -132,7 +128,6 @@ If you have installed Tsung in non-standard location (i.e. `tsung` is not in you
 to point Taurus to the `tsung` executable.
 
 ```yaml
----
 modules:
   tsung:
     path: /usr/local/bin/tsung

--- a/site/dat/docs/YAMLTutorial.md
+++ b/site/dat/docs/YAMLTutorial.md
@@ -8,7 +8,6 @@ it because of its readability, simplicity and good support for many programming 
 Here’s an example of YAML document (which is actually a Taurus config):
 
 ```yaml
----
 execution:
 - concurrency: 10
   hold-for: 5m
@@ -71,8 +70,6 @@ braces). Other than that, JSON and YAML are very similar. Here's the same YAML d
 
 
 ## YAML Syntax
-
-All Taurus YAML files should begin with `---`. This is a part of the YAML format and indicates the start of a document.
 
 YAML document consists of the following elements.
 

--- a/site/dat/docs/YAMLTutorial.md
+++ b/site/dat/docs/YAMLTutorial.md
@@ -21,8 +21,8 @@ scenarios:
       - http://example.com/
 
 reporting:
-  - module: final_stats
-  - module: console
+- module: final_stats
+- module: console
 
 settings:
   check-interval: 5s
@@ -135,6 +135,17 @@ episodes: [1, 2, 3, 4, 5, 6, 7]
 best-jedi: {name: Obi-Wan, side: light} 
 ```
 
+## YAML Multi Documents
+
+YAML format allows multiple documents to be embedded in a single file. They only have to be separated with a line containing triple-dash separator `---`.
+
+```yaml
+document: this is document 1
+---
+document: this is document 2
+```
+
+When reading multi-document YAML, Taurus will treat multiple documents as multiple configs and will load them one by one.
 
 ## YAML Debugging tips
 

--- a/site/dat/docs/changes/yaml-multi-docs.change
+++ b/site/dat/docs/changes/yaml-multi-docs.change
@@ -1,0 +1,5 @@
+Allow YAML multi-docs in configs
+
+Also:
+- As YAML is a superset of JSON, we can load JSON configs with YAML parser
+- Do not require user to prepend '---\n' to her configuration

--- a/site/dat/kb/Basic1.md
+++ b/site/dat/kb/Basic1.md
@@ -40,7 +40,6 @@ If you aren’t familiar with JMeter, you can also use Taurus’ simple configur
 Take a look at the following example:
 
 ```yaml
----
 execution:
 - concurrency: 5
   ramp-up: 20s
@@ -70,7 +69,6 @@ There are two places to specify JMeter properties:
 Global properties are set like this:
 
 ```yaml
----
 modules:
   jmeter:
     properties:
@@ -84,7 +82,6 @@ modules:
 
 Scenario-level properties are set like this:
 ```yaml
----
 execution:
 - scenario: 
     properties:
@@ -108,14 +105,12 @@ The easiest way to do this is to simply use the `-report` command line switch. T
 One of the big disadvantages of running JMeter scripts on your local computer is that it’s not really scalable – you’re limited to the resources of your local computer. Taurus gives you the option of cloud provisioning – meaning you can run your JMX scripts on the cloud with your BlazeMeter account. Again, you don’t have to be a paying customer as free accounts can also execute cloud tests. To use cloud provisioning, you have to set the following:
 
 ```yaml
----
 provisioning: cloud
 ```
 
 To access the BlazeMeter cloud, Taurus needs to have API key set inside the cloud module settings. Like this:
 
 ```yaml
----
 modules:
   cloud:
    token: ******* # API Key
@@ -128,7 +123,6 @@ Regarding the cloud locations, you can choose from all the locations provided by
 If you specify multiple cloud locations for the same execution, Taurus will distribute the concurrency and/or throughput amongst the locations. In order to use cloud locations you have to specify a location and its relative weight - the relative weight determines the amount of concurrent users and throughput that will run in this location.
 
 ```yaml
----
 execution:
 - locations:
     us-west-1: 1

--- a/site/dat/kb/Reporting.md
+++ b/site/dat/kb/Reporting.md
@@ -48,7 +48,6 @@ The last and most convenient and detailed reporting option is by integrating wit
 There are two ways to specify this BlazeMeter API key for your reporting. You can either do it in YAML script, which is not secured, or create a ‘.bzt-rc’ file in your home folder and put the config in it:
 
 ```yaml
----
 modules:
   blazemeter:
     token: <Put your token here>

--- a/site/dat/kb/Scripting.md
+++ b/site/dat/kb/Scripting.md
@@ -103,7 +103,6 @@ Taurus is a free and open-source framework under the Apache 2.0 License. Taurus 
 The simplest script looks like this (TaurusScriptExample.yml):
 
 ```yaml
----
 execution:
 - concurrency: 100
   ramp-up: 1m
@@ -163,7 +162,6 @@ scenarios:
 We can do the same to run Selenium scripts on Taurus with the Selenium executor. Note that if the Selenium test script has a dependency on a class outside of the test section, we need to specify the path to the compiled project jar file:
 
 ```yaml
----
 execution:
 - executor: selenium
   ramp-up: 40m
@@ -227,7 +225,6 @@ In addition to running existing test scenarios, the Taurus framework also allows
 ### JMeter Config 
 
 ```yaml
----
 execution:
 - concurrency: 5
   ramp-up: 1m
@@ -264,7 +261,6 @@ scenarios:
 ### Selenium Config
 
 ```yaml
----
 execution:
 - concurrency: 5
   ramp-up: 1m

--- a/site/dat/kb/ShellexecHooks.md
+++ b/site/dat/kb/ShellexecHooks.md
@@ -44,7 +44,6 @@ Let me show you an easier way to handle your pre/post test actions from a single
 Taurus is an open source tool that lets you run many open-source testing tools (such as JMeter, Gatling, The Grinder, Apache Benchmark, Locust.io and more) using YAML/JSON format. Taurus has a module called [“Shell Executor Service Module”](/docs/ShellExec/) that enables you to divide your test script into different logical steps we talked about and properly set your desired pre/post test actions in a single configuration file:
  
 ```yaml
----
 services:
 - module: shellexec
   prepare:  

--- a/site/dat/sample-scripts/complex_yaml_script.yml.md
+++ b/site/dat/sample-scripts/complex_yaml_script.yml.md
@@ -1,5 +1,4 @@
 ```yaml
----
 execution:
 - concurrency: 250
   throughput: 500

--- a/site/dat/sample-scripts/existing_jmeter_script.yml.md
+++ b/site/dat/sample-scripts/existing_jmeter_script.yml.md
@@ -1,5 +1,4 @@
 ```yaml
----
 execution:
 - iterations: 50
   concurrency: 10

--- a/site/dat/sample-scripts/quick_test.yml.md
+++ b/site/dat/sample-scripts/quick_test.yml.md
@@ -1,5 +1,4 @@
 ```yaml
----
 execution:
 - concurrency: 100
   ramp-up: 1m

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -83,6 +83,16 @@ class TestEngine(BZTestCase):
             }})
         self.obj.prepare()
 
+    def test_yaml_multi_docs(self):
+        configs = [
+            __dir__() + "/../bzt/10-base.json",
+            __dir__() + "/yaml/multi-docs.yml",
+            self.paths
+        ]
+        self.obj.configure(configs)
+        self.obj.prepare()
+        self.assertEqual(len(self.obj.config["execution"]), 2)
+
 
 class TestScenarioExecutor(BZTestCase):
     def setUp(self):

--- a/tests/yaml/multi-docs.yml
+++ b/tests/yaml/multi-docs.yml
@@ -1,0 +1,16 @@
+execution:
+- executor: jmeter
+  concurrency: 1
+  scenario:
+    retrieve-resources: false
+    requests:
+    - http://blazedemo.com/?runner=jmeter
+
+---
+
+execution:
+- executor: gatling
+  concurrency: 1
+  scenario:
+    requests:
+    - http://blazedemo.com/?runner=gatling

--- a/tests/yaml/multi-docs.yml
+++ b/tests/yaml/multi-docs.yml
@@ -8,9 +8,14 @@ execution:
 
 ---
 
-execution:
-- executor: gatling
-  concurrency: 1
-  scenario:
-    requests:
-    - http://blazedemo.com/?runner=gatling
+{
+  "execution": [{
+    "executor": "gatling",
+    "concurrency": 1,
+    "scenario": {
+      "requests": [
+        "http://blazedemo.com/?runner=gatling"
+      ]
+    }
+  }]
+}


### PR DESCRIPTION
Also:
- As YAML is a superset of JSON, we can load JSON configs with YAML parser
- Do not require user to prepend '---\n' to her configuration