### PR TITLE
Level down log file verbosity after 'startup' phase

### DIFF
--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -169,13 +169,13 @@ class CLI(object):
         self.engine.default_cwd = os.getcwd()
 
     def _level_down_logging(self):
-        self.log.info("Leveling down log file verbosity")
+        self.log.debug("Leveling down log file verbosity")
         for handler in self.log.handlers:
             if issubclass(handler.__class__, logging.FileHandler):
                 handler.setLevel(logging.INFO)
 
     def _level_up_logging(self):
-        self.log.info("Leveling up log file verbosity")
+        self.log.debug("Leveling up log file verbosity")
         for handler in self.log.handlers:
             if issubclass(handler.__class__, logging.FileHandler):
                 handler.setLevel(logging.DEBUG)

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -175,10 +175,10 @@ class CLI(object):
                 handler.setLevel(logging.INFO)
 
     def _level_up_logging(self):
-        self.log.debug("Leveling up log file verbosity")
         for handler in self.log.handlers:
             if issubclass(handler.__class__, logging.FileHandler):
                 handler.setLevel(logging.DEBUG)
+        self.log.debug("Leveled up log file verbosity")
 
     def perform(self, configs):
         """

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -168,6 +168,18 @@ class CLI(object):
         self.engine.create_artifacts_dir(configs, merged_config)
         self.engine.default_cwd = os.getcwd()
 
+    def _level_down_logging(self):
+        self.log.info("Leveling down log file verbosity")
+        for handler in self.log.handlers:
+            if issubclass(handler.__class__, logging.FileHandler):
+                handler.setLevel(logging.INFO)
+
+    def _level_up_logging(self):
+        self.log.info("Leveling up log file verbosity")
+        for handler in self.log.handlers:
+            if issubclass(handler.__class__, logging.FileHandler):
+                handler.setLevel(logging.DEBUG)
+
     def perform(self, configs):
         """
         Run the tool
@@ -180,6 +192,9 @@ class CLI(object):
             jmx_shorthands = self.__get_jmx_shorthands(configs)
             configs.extend(jmx_shorthands)
 
+            if not self.options.verbose:
+                self.engine.post_startup_hook = self._level_down_logging
+                self.engine.pre_shutdown_hook = self._level_up_logging
             self.__configure(configs)
             self.__copy_log_to_artifacts()
 

--- a/bzt/engine.py
+++ b/bzt/engine.py
@@ -79,6 +79,8 @@ class Engine(object):
         self.prepared = []
         self.started = []
         self.default_cwd = None
+        self.post_startup_hook = None
+        self.pre_shutdown_hook = None
 
     def configure(self, user_configs, read_config_files=True):
         """
@@ -142,6 +144,8 @@ class Engine(object):
         exc_info = None
         try:
             self._startup()
+            if self.post_startup_hook is not None:
+                self.post_startup_hook()
             self._wait()
         except BaseException as exc:
             self.log.debug("%s:\n%s", exc, traceback.format_exc())
@@ -150,6 +154,8 @@ class Engine(object):
         finally:
             self.log.warning("Please wait for graceful shutdown...")
             try:
+                if self.pre_shutdown_hook is not None:
+                    self.pre_shutdown_hook()
                 self._shutdown()
             except BaseException as exc:
                 self.log.debug("%s:\n%s", exc, traceback.format_exc())

--- a/bzt/engine.py
+++ b/bzt/engine.py
@@ -79,8 +79,8 @@ class Engine(object):
         self.prepared = []
         self.started = []
         self.default_cwd = None
-        self.post_startup_hook = None
-        self.pre_shutdown_hook = None
+        self.post_startup_hook = lambda: None
+        self.pre_shutdown_hook = lambda: None
 
     def configure(self, user_configs, read_config_files=True):
         """
@@ -144,8 +144,7 @@ class Engine(object):
         exc_info = None
         try:
             self._startup()
-            if self.post_startup_hook is not None:
-                self.post_startup_hook()
+            self.post_startup_hook()
             self._wait()
         except BaseException as exc:
             self.log.debug("%s:\n%s", exc, traceback.format_exc())
@@ -154,8 +153,7 @@ class Engine(object):
         finally:
             self.log.warning("Please wait for graceful shutdown...")
             try:
-                if self.pre_shutdown_hook is not None:
-                    self.pre_shutdown_hook()
+                self.pre_shutdown_hook()
                 self._shutdown()
             except BaseException as exc:
                 self.log.debug("%s:\n%s", exc, traceback.format_exc())

--- a/site/dat/docs/changes/adapt-logging-verbosity.change
+++ b/site/dat/docs/changes/adapt-logging-verbosity.change
@@ -1,0 +1,3 @@
+Level up logging verbosity after `startup()` phase
+
+(And level it down before performing `shutdown()`).

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -122,6 +122,27 @@ class TestCLI(BZTestCase):
             if os.path.exists(artifacts_dir):
                 shutil.rmtree(artifacts_dir)
 
+    def test_logging_verbosity_adjustment(self):
+        try:
+            was_verbose = self.verbose
+            self.verbose = False
+            ret = self.obj.perform([
+                __dir__() + "/json/mock_normal.json",
+            ])
+            self.assertEquals(0, ret)
+            log_lines = open(os.path.join(self.obj.engine.artifacts_dir, "bzt.log")).readlines()
+            checking = False
+            for line in log_lines:
+                if "Leveling down" in line:
+                    checking = True
+                elif "Leveling up" in line:
+                    checking = False
+                else:
+                    if checking:
+                        self.assertNotIn("DEBUG", line)
+        finally:
+            self.verbose = was_verbose
+
 
 class TestConfigOverrider(BZTestCase):
     def setUp(self):

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -123,8 +123,8 @@ class TestCLI(BZTestCase):
                 shutil.rmtree(artifacts_dir)
 
     def test_logging_verbosity_adjustment(self):
+        was_verbose = self.verbose
         try:
-            was_verbose = self.verbose
             self.verbose = False
             ret = self.obj.perform([
                 __dir__() + "/json/mock_normal.json",
@@ -132,14 +132,17 @@ class TestCLI(BZTestCase):
             self.assertEquals(0, ret)
             log_lines = open(os.path.join(self.obj.engine.artifacts_dir, "bzt.log")).readlines()
             checking = False
+            found_line = False
             for line in log_lines:
                 if "Leveling down" in line:
+                    found_line = True
                     checking = True
-                elif "Leveling up" in line:
+                elif "Leveled up" in line:
                     checking = False
                 else:
                     if checking:
                         self.assertNotIn("DEBUG", line)
+            self.assertTrue(found_line)
         finally:
             self.verbose = was_verbose
 


### PR DESCRIPTION
By using engine-level 'post-startup' and 'pre-shutdown' hooks.

Solution is pretty ugly, but there's so much that can be done about it.

We should probably discuss it first and see if we can come up with more sane approach.