### PR TITLE
Attach more data from JMeter to functional samples

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1098,22 +1098,22 @@ class FuncJTLReader(FunctionalResultsReader):
 
             "responseCode": sample_elem.get("rc"),
             "responseMessage": sample_elem.get("rm"),
-            "responseTime": int(sample_elem.get("t")),
-            "connectTime": int(sample_elem.get("ct")),
-            "latency": int(sample_elem.get("lt")),
-            "responseSize": int(sample_elem.get("by")),
-            "requestSize": int(sample_elem.get("sby")),
+            "responseTime": int(sample_elem.get("t") or 0),
+            "connectTime": int(sample_elem.get("ct") or 0),
+            "latency": int(sample_elem.get("lt") or 0),
+            "responseSize": int(sample_elem.get("by") or 0),
+            "requestSize": int(sample_elem.get("sby") or 0),
             "requestMethod": method,
             "requestURI": uri,
 
             "assertions": self._extract_sample_assertions(sample_elem),
-        }
 
-        sample_extras["requestBody"] = sample_elem.findtext("queryString")
-        sample_extras["responseBody"] = sample_elem.findtext("responseData")
-        sample_extras["requestCookies"] = sample_elem.findtext("cookies")
-        sample_extras["requestHeaders"] = sample_elem.findtext("requestHeader")
-        sample_extras["responseHeaders"] = sample_elem.findtext("responseHeader")
+            "requestBody": sample_elem.findtext("queryString"),
+            "responseBody": sample_elem.findtext("responseData"),
+            "requestCookies": sample_elem.findtext("cookies"),
+            "requestHeaders": sample_elem.findtext("requestHeader"),
+            "responseHeaders": sample_elem.findtext("responseHeader")
+        }
 
         sample_extras["requestBodySize"] = len(sample_extras["requestBody"])
         sample_extras["responseBodySize"] = len(sample_extras["responseBody"])

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1075,6 +1075,17 @@ class FuncJTLReader(FunctionalResultsReader):
         with open(os.path.join(self.artifacts_dir, filename), 'wb') as fds:
             fds.write(contents.encode('utf-8'))
 
+    def _extract_sample_assertions(self, sample_elem):
+        assertions = []
+        for result in sample_elem.findall("assertionResult"):
+            name = result.findtext("name")
+            failed = result.findtext("failure") == "true" or result.findtext("error") == "true"
+            error_message = ""
+            if failed:
+                error_message = result.findtext("failureMessage")
+            assertions.append({"name": name, "isFailed": failed, "errorMessage": error_message})
+        return assertions
+
     def _extract_sample_extras(self, sample_elem):
         method = sample_elem.findtext("method")
         uri = sample_elem.findtext("java.net.URL")  # smells like Java automarshalling
@@ -1092,7 +1103,7 @@ class FuncJTLReader(FunctionalResultsReader):
             "requestMethod": method,
             "requestURI": uri,
 
-            "assertions": [],  # TODO
+            "assertions": self._extract_sample_assertions(sample_elem),
         }
 
         sample_extras["requestBody"] = sample_elem.findtext("queryString")

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1010,6 +1010,8 @@ class FuncJTLReader(FunctionalResultsReader):
     :type parent_logger: logging.Logger
     """
 
+    FILE_EXTRACTED_FIELDS = ["requestBody", "responseBody", "requestCookies", "requestHeaders", "responseHeaders"]
+
     def __init__(self, filename, artifacts_dir, parent_logger):
         super(FuncJTLReader, self).__init__()
         self.log = parent_logger.getChild(self.__class__.__name__)
@@ -1108,7 +1110,7 @@ class FuncJTLReader(FunctionalResultsReader):
         return sample_extras
 
     def __write_sample_data_to_artifacts(self, sample_extras):
-        for file_field in ["requestBody", "responseBody", "requestCookies", "requestHeaders", "responseHeaders"]:
+        for file_field in self.FILE_EXTRACTED_FIELDS:
             if sample_extras[file_field]:
                 filename = "sample-%d-%s.bin" % (self.__sample_cnt, file_field)
                 self._write_sample_data(filename, sample_extras[file_field])

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1025,7 +1025,6 @@ class FuncJTLReader(FunctionalResultsReader):
         self.fds = None
         self.failed_processing = False
         self.read_records = 0
-        self.__sample_cnt = 0
 
     def __del__(self):
         if self.fds:
@@ -1096,8 +1095,6 @@ class FuncJTLReader(FunctionalResultsReader):
         uri = sample_elem.findtext("java.net.URL")  # smells like Java automarshalling
 
         sample_extras = {
-            "id": self.__sample_cnt,
-
             "responseCode": sample_elem.get("rc"),
             "responseMessage": sample_elem.get("rm"),
             "responseTime": int(sample_elem.get("t") or 0),
@@ -1129,7 +1126,7 @@ class FuncJTLReader(FunctionalResultsReader):
         for file_field in self.FILE_EXTRACTED_FIELDS:
             contents = sample_extras.pop(file_field)
             if contents:
-                filename = "sample-%d-%s" % (self.__sample_cnt, file_field)
+                filename = "sample-%s" % file_field
                 artifact = self._write_sample_data(filename, contents)
                 sample_extras[file_field] = artifact
 
@@ -1159,7 +1156,6 @@ class FuncJTLReader(FunctionalResultsReader):
 
         sample_extras = self._extract_sample_extras(sample_elem)
         self.__write_sample_data_to_artifacts(sample_extras)
-        self.__sample_cnt += 1
 
         return FunctionalSample(test_case=label, test_suite=suite_name, status=status,
                                 start_time=tstmp, duration=duration,

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1095,11 +1095,11 @@ class FuncJTLReader(FunctionalResultsReader):
 
             "responseCode": sample_elem.get("rc"),
             "responseMessage": sample_elem.get("rm"),
-            "responseTime": sample_elem.get("ts"),
-            "connectTime": sample_elem.get("ct"),
-            "latency": sample_elem.get("lt"),
-            "responseSize": sample_elem.get("by"),
-            "requestSize": sample_elem.get("sby"),
+            "responseTime": int(sample_elem.get("t")),
+            "connectTime": int(sample_elem.get("ct")),
+            "latency": int(sample_elem.get("lt")),
+            "responseSize": int(sample_elem.get("by")),
+            "requestSize": int(sample_elem.get("sby")),
             "requestMethod": method,
             "requestURI": uri,
 

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1119,19 +1119,16 @@ class FuncJTLReader(FunctionalResultsReader):
         sample_extras["requestBody"] = sample_elem.findtext("queryString")
         sample_extras["responseBody"] = sample_elem.findtext("responseData")
         sample_extras["requestCookies"] = sample_elem.findtext("cookies")
-        sample_extras["responseCookies"] = ""  # TODO: filter out `Set-Cookie` headers from response headers?
         sample_extras["requestHeaders"] = sample_elem.findtext("requestHeader")
         sample_extras["responseHeaders"] = sample_elem.findtext("responseHeader")
 
         sample_extras["requestBodySize"] = len(sample_extras["requestBody"])
         sample_extras["responseBodySize"] = len(sample_extras["responseBody"])
         sample_extras["requestCookiesSize"] = len(sample_extras["requestCookies"])
-        sample_extras["responseCookiesSize"] = len(sample_extras["responseCookies"])
         sample_extras["requestHeadersSize"] = len(sample_extras["requestHeaders"])
         sample_extras["responseHeadersSize"] = len(sample_extras["responseHeaders"])
 
-        for file_field in ["requestBody", "responseBody", "requestCookies",
-                           "responseCookies", "requestHeaders", "responseHeaders"]:
+        for file_field in ["requestBody", "responseBody", "requestCookies", "requestHeaders", "responseHeaders"]:
             if sample_extras[file_field]:
                 filename = "sample-%d-%s.bin" % (self.__sample_cnt, file_field)
                 self.__write_sample_data(filename, sample_extras[file_field])

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1122,9 +1122,10 @@ class FuncJTLReader(FunctionalResultsReader):
 
     def __write_sample_data_to_artifacts(self, sample_extras):
         for file_field in self.FILE_EXTRACTED_FIELDS:
-            if sample_extras[file_field]:
+            contents = sample_extras.pop(file_field)
+            if contents:
                 filename = "sample-%d-%s.bin" % (self.__sample_cnt, file_field)
-                self._write_sample_data(filename, sample_extras[file_field])
+                self._write_sample_data(filename, contents)
 
     def _extract_sample(self, sample_elem):
         tstmp = int(float(sample_elem.get("ts")) / 1000)

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -154,6 +154,9 @@ class JMeterExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInstall
         else:
             raise TaurusConfigError("You must specify either a JMX file or list of requests to run JMeter")
 
+        if isinstance(self.engine.aggregator, FunctionalAggregator):
+            self.settings.merge({"xml-jtl-flags": {"connectTime": True, "sentBytes": True}})
+
         load = self.get_load()
 
         modified = self.__get_modified_jmx(self.original_jmx, load)

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1091,10 +1091,21 @@ class FuncJTLReader(FunctionalResultsReader):
         if error_msg.startswith("The operation lasted too long"):
             error_msg = "The operation lasted too long"
 
+        # TODO: we'd probably need to read XML-based JTL file with all the flags
+        # to extract items like 'response body' or 'request headers'
+        extras = {
+            "responseCode": elem.get("rc"),
+            "responseMessage": elem.get("rm"),
+            "responseTime": elem.get("ts"),
+            "connectTime": elem.get("ct"),
+            "latency": elem.get("lt"),
+            "responseSize": elem.get("by"),
+        }
+
         return FunctionalSample(test_case=label, test_suite=suite_name, status=status,
                                 start_time=tstmp, duration=duration,
                                 error_msg=error_msg, error_trace=error_trace,
-                                extras=None)
+                                extras=extras)
 
     def get_failure(self, element):
         """

--- a/site/dat/docs/changes/detailed-functional-samples-for-jmeter.change
+++ b/site/dat/docs/changes/detailed-functional-samples-for-jmeter.change
@@ -1,0 +1,3 @@
+Save detailed data from JMeter in functional mode.
+
+It can be used to generate detailed test reports.

--- a/tests/jmeter/jtl/trace.jtl
+++ b/tests/jmeter/jtl/trace.jtl
@@ -1,0 +1,267 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testResults version="1.2">
+<httpSample t="556" lt="556" ts="1489491284900" s="true" lb="http://blazedemo.com/" rc="200" rm="OK" tn="ThreadGroup 1-1" dt="text" de="UTF-8" by="7876" ng="1" na="1">
+  <responseHeader class="java.lang.String">HTTP/1.1 200 OK
+Cache-Control: no-cache
+Content-Type: text/html; charset=UTF-8
+Date: Tue, 14 Mar 2017 11:34:43 GMT
+Server: Apache
+Content-Length: 7693
+Connection: keep-alive
+</responseHeader>
+  <requestHeader class="java.lang.String">Connection: keep-alive
+Content-Length: 0
+Content-Type: text/plain; charset=ISO-8859-1
+Host: blazedemo.com
+User-Agent: Apache-HttpClient/4.5.2 (Java/1.8.0_121)
+</requestHeader>
+  <responseData class="java.lang.String">&lt;!doctype html&gt;
+&lt;html lang=&quot;en&quot;&gt;
+&lt;head&gt;
+    &lt;meta charset=&quot;utf-8&quot;&gt;&lt;script type=&quot;text/javascript&quot;&gt;window.NREUM||(NREUM={}),__nr_require=function(e,n,t){function r(t){if(!n[t]){var o=n[t]={exports:{}};e[t][0].call(o.exports,function(n){var o=e[t][1][n];return r(o||n)},o,o.exports)}return n[t].exports}if(&quot;function&quot;==typeof __nr_require)return __nr_require;for(var o=0;o&lt;t.length;o++)r(t[o]);return r}({1:[function(e,n,t){function r(){}function o(e,n,t){return function(){return i(e,[c.now()].concat(u(arguments)),n?null:this,t),n?void 0:this}}var i=e(&quot;handle&quot;),a=e(2),u=e(3),f=e(&quot;ee&quot;).get(&quot;tracer&quot;),c=e(&quot;loader&quot;),s=NREUM;&quot;undefined&quot;==typeof window.newrelic&amp;&amp;(newrelic=s);var p=[&quot;setPageViewName&quot;,&quot;setCustomAttribute&quot;,&quot;setErrorHandler&quot;,&quot;finished&quot;,&quot;addToTrace&quot;,&quot;inlineHit&quot;,&quot;addRelease&quot;],d=&quot;api-&quot;,l=d+&quot;ixn-&quot;;a(p,function(e,n){s[n]=o(d+n,!0,&quot;api&quot;)}),s.addPageAction=o(d+&quot;addPageAction&quot;,!0),s.setCurrentRouteName=o(d+&quot;routeName&quot;,!0),n.exports=newrelic,s.interaction=function(){return(new r).get()};var m=r.prototype={createTracer:function(e,n){var t={},r=this,o=&quot;function&quot;==typeof n;return i(l+&quot;tracer&quot;,[c.now(),e,t],r),function(){if(f.emit((o?&quot;&quot;:&quot;no-&quot;)+&quot;fn-start&quot;,[c.now(),r,o],t),o)try{return n.apply(this,arguments)}finally{f.emit(&quot;fn-end&quot;,[c.now()],t)}}}};a(&quot;setName,setAttribute,save,ignore,onEnd,getContext,end,get&quot;.split(&quot;,&quot;),function(e,n){m[n]=o(l+n)}),newrelic.noticeError=function(e){&quot;string&quot;==typeof e&amp;&amp;(e=new Error(e)),i(&quot;err&quot;,[e,c.now()])}},{}],2:[function(e,n,t){function r(e,n){var t=[],r=&quot;&quot;,i=0;for(r in e)o.call(e,r)&amp;&amp;(t[i]=n(r,e[r]),i+=1);return t}var o=Object.prototype.hasOwnProperty;n.exports=r},{}],3:[function(e,n,t){function r(e,n,t){n||(n=0),&quot;undefined&quot;==typeof t&amp;&amp;(t=e?e.length:0);for(var r=-1,o=t-n||0,i=Array(o&lt;0?0:o);++r&lt;o;)i[r]=e[n+r];return i}n.exports=r},{}],4:[function(e,n,t){n.exports={exists:&quot;undefined&quot;!=typeof window.performance&amp;&amp;window.performance.timing&amp;&amp;&quot;undefined&quot;!=typeof window.performance.timing.navigationStart}},{}],ee:[function(e,n,t){function r(){}function o(e){function n(e){return e&amp;&amp;e instanceof r?e:e?f(e,u,i):i()}function t(t,r,o,i){if(!d.aborted||i){e&amp;&amp;e(t,r,o);for(var a=n(o),u=m(t),f=u.length,c=0;c&lt;f;c++)u[c].apply(a,r);var p=s[y[t]];return p&amp;&amp;p.push([b,t,r,a]),a}}function l(e,n){v[e]=m(e).concat(n)}function m(e){return v[e]||[]}function w(e){return p[e]=p[e]||o(t)}function g(e,n){c(e,function(e,t){n=n||&quot;feature&quot;,y[t]=n,n in s||(s[n]=[])})}var v={},y={},b={on:l,emit:t,get:w,listeners:m,context:n,buffer:g,abort:a,aborted:!1};return b}function i(){return new r}function a(){(s.api||s.feature)&amp;&amp;(d.aborted=!0,s=d.backlog={})}var u=&quot;nr@context&quot;,f=e(&quot;gos&quot;),c=e(2),s={},p={},d=n.exports=o();d.backlog=s},{}],gos:[function(e,n,t){function r(e,n,t){if(o.call(e,n))return e[n];var r=t();if(Object.defineProperty&amp;&amp;Object.keys)try{return Object.defineProperty(e,n,{value:r,writable:!0,enumerable:!1}),r}catch(i){}return e[n]=r,r}var o=Object.prototype.hasOwnProperty;n.exports=r},{}],handle:[function(e,n,t){function r(e,n,t,r){o.buffer([e],r),o.emit(e,n,t)}var o=e(&quot;ee&quot;).get(&quot;handle&quot;);n.exports=r,r.ee=o},{}],id:[function(e,n,t){function r(e){var n=typeof e;return!e||&quot;object&quot;!==n&amp;&amp;&quot;function&quot;!==n?-1:e===window?0:a(e,i,function(){return o++})}var o=1,i=&quot;nr@id&quot;,a=e(&quot;gos&quot;);n.exports=r},{}],loader:[function(e,n,t){function r(){if(!x++){var e=h.info=NREUM.info,n=d.getElementsByTagName(&quot;script&quot;)[0];if(setTimeout(s.abort,3e4),!(e&amp;&amp;e.licenseKey&amp;&amp;e.applicationID&amp;&amp;n))return s.abort();c(y,function(n,t){e[n]||(e[n]=t)}),f(&quot;mark&quot;,[&quot;onload&quot;,a()+h.offset],null,&quot;api&quot;);var t=d.createElement(&quot;script&quot;);t.src=&quot;https://&quot;+e.agent,n.parentNode.insertBefore(t,n)}}function o(){&quot;complete&quot;===d.readyState&amp;&amp;i()}function i(){f(&quot;mark&quot;,[&quot;domContent&quot;,a()+h.offset],null,&quot;api&quot;)}function a(){return E.exists&amp;&amp;performance.now?Math.round(performance.now()):(u=Math.max((new Date).getTime(),u))-h.offset}var u=(new Date).getTime(),f=e(&quot;handle&quot;),c=e(2),s=e(&quot;ee&quot;),p=window,d=p.document,l=&quot;addEventListener&quot;,m=&quot;attachEvent&quot;,w=p.XMLHttpRequest,g=w&amp;&amp;w.prototype;NREUM.o={ST:setTimeout,CT:clearTimeout,XHR:w,REQ:p.Request,EV:p.Event,PR:p.Promise,MO:p.MutationObserver};var v=&quot;&quot;+location,y={beacon:&quot;bam.nr-data.net&quot;,errorBeacon:&quot;bam.nr-data.net&quot;,agent:&quot;js-agent.newrelic.com/nr-1026.min.js&quot;},b=w&amp;&amp;g&amp;&amp;g[l]&amp;&amp;!/CriOS/.test(navigator.userAgent),h=n.exports={offset:u,now:a,origin:v,features:{},xhrWrappable:b};e(1),d[l]?(d[l](&quot;DOMContentLoaded&quot;,i,!1),p[l](&quot;load&quot;,r,!1)):(d[m](&quot;onreadystatechange&quot;,o),p[m](&quot;onload&quot;,r)),f(&quot;mark&quot;,[&quot;firstbyte&quot;,u],null,&quot;api&quot;);var x=0,E=e(4)},{}]},{},[&quot;loader&quot;]);&lt;/script&gt;
+    &lt;title&gt; BlazeDemo&lt;/title&gt;
+    &lt;meta name=&quot;description&quot; content=&quot;BlazeMeter demo app&quot;&gt;
+    &lt;meta name=&quot;sage&quot; content=&quot;flights app&quot;&gt;
+
+    &lt;script src=&quot;http://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js&quot;&gt;&lt;/script&gt;
+    &lt;script src=&quot;assets/bootstrap.min.js&quot;&gt;&lt;/script&gt;
+    &lt;script src=&quot;assets/bootstrap-table.js&quot;&gt;&lt;/script&gt;
+    &lt;link href=&quot;assets/bootstrap.min.css&quot; rel=&quot;stylesheet&quot; media=&quot;screen&quot;&gt;
+    &lt;link href=&quot;assets/bootstrap-table.css&quot; rel=&quot;stylesheet&quot; media=&quot;screen&quot;&gt;
+    &lt;style type=&quot;text/css&quot;&gt;
+        body {
+            background: #f5f5f5);
+        }
+
+        .hero-unit {
+            background-color: #fff;
+        }
+
+        .center {
+            display: block;
+            margin: 0 auto;
+        }
+    &lt;/style&gt;
+&lt;/head&gt;
+&lt;body&gt;
+        &lt;div class=&quot;navbar navbar-inverse&quot;&gt;
+        &lt;div class=&quot;navbar-inner&quot;&gt;
+            &lt;div class=&quot;container&quot;&gt;
+                &lt;a class=&quot;btn btn-navbar&quot; data-toggle=&quot;collapse&quot; data-target=&quot;.nav-collapse&quot;&gt;
+                    &lt;span class=&quot;icon-bar&quot;&gt;&lt;/span&gt;
+                    &lt;span class=&quot;icon-bar&quot;&gt;&lt;/span&gt;
+                    &lt;span class=&quot;icon-bar&quot;&gt;&lt;/span&gt;
+                &lt;/a&gt;
+                &lt;a class=&quot;brand&quot; href=&quot;index.php&quot;&gt;Travel The World&lt;/a&gt;
+                &lt;a class=&quot;brand&quot; href=&quot;home&quot;&gt;home&lt;/a&gt;
+            &lt;/div&gt;
+        &lt;/div&gt;
+    &lt;/div&gt;
+
+
+    &lt;div class=&quot;jumbotron&quot;&gt;
+        &lt;div class=&quot;container&quot;&gt;
+            &lt;h1&gt;Welcome to the Simple Travel Agency!&lt;/h1&gt;
+            &lt;p&gt;The is a sample site you can test with BlazeMeter! &lt;/p&gt;
+            &lt;p&gt;Check out our &lt;a href=&quot;vacation.html&quot;&gt;destination of the week! The Beach!&lt;/a&gt;&lt;/p&gt;
+        &lt;/div&gt;
+    &lt;/div&gt;
+&lt;div class=&quot;container&quot;&gt;
+        &lt;h2&gt;Choose your departure city:&lt;/h2&gt;
+    &lt;form action=&quot;reserve.php&quot; method=&quot;post&quot;&gt;
+        &lt;select name=&quot;fromPort&quot; class=&quot;form-inline&quot;&gt;
+            &lt;option value=&quot;Paris&quot;&gt;Paris&lt;/option&gt;
+            &lt;option value=&quot;Philadelphia&quot;&gt;Philadelphia&lt;/option&gt;
+            &lt;option value=&quot;Boston&quot;&gt;Boston&lt;/option&gt;
+            &lt;option value=&quot;Portland&quot;&gt;Portland&lt;/option&gt;
+            &lt;option value=&quot;San Diego&quot;&gt;San Diego&lt;/option&gt;
+            &lt;option value=&quot;Mexico City&quot;&gt;Mexico City&lt;/option&gt;
+            &lt;option value=&quot;São Paolo&quot;&gt;São Paolo&lt;/option&gt;
+        &lt;/select&gt;
+        &lt;p&gt;
+        &lt;h2&gt;Choose your destination city:&lt;/h2&gt;
+        &lt;select name=&quot;toPort&quot; class=&quot;form-inline&quot;&gt;
+            &lt;option value=&quot;Buenos Aires&quot;&gt;Buenos Aires&lt;/option&gt;
+            &lt;option value=&quot;Rome&quot;&gt;Rome&lt;/option&gt;
+            &lt;option value=&quot;London&quot;&gt;London&lt;/option&gt;
+            &lt;option value=&quot;Berlin&quot;&gt;Berlin&lt;/option&gt;
+            &lt;option value=&quot;New York&quot;&gt;New York&lt;/option&gt;
+            &lt;option value=&quot;Dublin&quot;&gt;Dublin&lt;/option&gt;
+            &lt;option value=&quot;Cairo&quot;&gt;Cairo&lt;/option&gt;
+        &lt;/select&gt;
+        &lt;p&gt;&lt;/p&gt;
+        &lt;div class=&quot;container&quot;&gt;
+            &lt;input type=&quot;submit&quot; class=&quot;btn btn-primary&quot; value=&quot;Find Flights&quot;/&gt;
+        &lt;/div&gt;
+    &lt;/form&gt;
+&lt;/div&gt;
+&lt;script type=&quot;text/javascript&quot;&gt;window.NREUM||(NREUM={});NREUM.info={&quot;beacon&quot;:&quot;bam.nr-data.net&quot;,&quot;licenseKey&quot;:&quot;338cffe5d3&quot;,&quot;applicationID&quot;:&quot;6657625&quot;,&quot;transactionName&quot;:&quot;YVxSYxACCxcEVRFfWlgWcVQWCgoKSg==&quot;,&quot;queueTime&quot;:0,&quot;applicationTime&quot;:7,&quot;atts&quot;:&quot;TRtRFVgYGBk=&quot;,&quot;errorBeacon&quot;:&quot;bam.nr-data.net&quot;,&quot;agent&quot;:&quot;&quot;}&lt;/script&gt;&lt;/body&gt;
+&lt;/html&gt;</responseData>
+  <cookies class="java.lang.String"></cookies>
+  <method class="java.lang.String">GET</method>
+  <queryString class="java.lang.String"></queryString>
+  <java.net.URL>http://blazedemo.com/</java.net.URL>
+</httpSample>
+<httpSample t="72" lt="71" ts="1489491285463" s="true" lb="http://blazedemo.com/reserve.php" rc="200" rm="OK" tn="ThreadGroup 1-1" dt="text" de="UTF-8" by="10394" ng="1" na="1">
+  <responseHeader class="java.lang.String">HTTP/1.1 200 OK
+Cache-Control: no-cache
+Content-Type: text/html; charset=UTF-8
+Date: Tue, 14 Mar 2017 11:34:43 GMT
+Server: Apache
+transfer-encoding: chunked
+Connection: keep-alive
+</responseHeader>
+  <requestHeader class="java.lang.String">Connection: keep-alive
+Content-Length: 0
+Content-Type: text/plain; charset=ISO-8859-1
+Host: blazedemo.com
+User-Agent: Apache-HttpClient/4.5.2 (Java/1.8.0_121)
+</requestHeader>
+  <responseData class="java.lang.String">&lt;!doctype html&gt;
+&lt;html lang=&quot;en&quot;&gt;
+&lt;head&gt;
+    &lt;meta charset=&quot;utf-8&quot;&gt;&lt;script type=&quot;text/javascript&quot;&gt;window.NREUM||(NREUM={}),__nr_require=function(e,n,t){function r(t){if(!n[t]){var o=n[t]={exports:{}};e[t][0].call(o.exports,function(n){var o=e[t][1][n];return r(o||n)},o,o.exports)}return n[t].exports}if(&quot;function&quot;==typeof __nr_require)return __nr_require;for(var o=0;o&lt;t.length;o++)r(t[o]);return r}({1:[function(e,n,t){function r(){}function o(e,n,t){return function(){return i(e,[c.now()].concat(u(arguments)),n?null:this,t),n?void 0:this}}var i=e(&quot;handle&quot;),a=e(2),u=e(3),f=e(&quot;ee&quot;).get(&quot;tracer&quot;),c=e(&quot;loader&quot;),s=NREUM;&quot;undefined&quot;==typeof window.newrelic&amp;&amp;(newrelic=s);var p=[&quot;setPageViewName&quot;,&quot;setCustomAttribute&quot;,&quot;setErrorHandler&quot;,&quot;finished&quot;,&quot;addToTrace&quot;,&quot;inlineHit&quot;,&quot;addRelease&quot;],d=&quot;api-&quot;,l=d+&quot;ixn-&quot;;a(p,function(e,n){s[n]=o(d+n,!0,&quot;api&quot;)}),s.addPageAction=o(d+&quot;addPageAction&quot;,!0),s.setCurrentRouteName=o(d+&quot;routeName&quot;,!0),n.exports=newrelic,s.interaction=function(){return(new r).get()};var m=r.prototype={createTracer:function(e,n){var t={},r=this,o=&quot;function&quot;==typeof n;return i(l+&quot;tracer&quot;,[c.now(),e,t],r),function(){if(f.emit((o?&quot;&quot;:&quot;no-&quot;)+&quot;fn-start&quot;,[c.now(),r,o],t),o)try{return n.apply(this,arguments)}finally{f.emit(&quot;fn-end&quot;,[c.now()],t)}}}};a(&quot;setName,setAttribute,save,ignore,onEnd,getContext,end,get&quot;.split(&quot;,&quot;),function(e,n){m[n]=o(l+n)}),newrelic.noticeError=function(e){&quot;string&quot;==typeof e&amp;&amp;(e=new Error(e)),i(&quot;err&quot;,[e,c.now()])}},{}],2:[function(e,n,t){function r(e,n){var t=[],r=&quot;&quot;,i=0;for(r in e)o.call(e,r)&amp;&amp;(t[i]=n(r,e[r]),i+=1);return t}var o=Object.prototype.hasOwnProperty;n.exports=r},{}],3:[function(e,n,t){function r(e,n,t){n||(n=0),&quot;undefined&quot;==typeof t&amp;&amp;(t=e?e.length:0);for(var r=-1,o=t-n||0,i=Array(o&lt;0?0:o);++r&lt;o;)i[r]=e[n+r];return i}n.exports=r},{}],4:[function(e,n,t){n.exports={exists:&quot;undefined&quot;!=typeof window.performance&amp;&amp;window.performance.timing&amp;&amp;&quot;undefined&quot;!=typeof window.performance.timing.navigationStart}},{}],ee:[function(e,n,t){function r(){}function o(e){function n(e){return e&amp;&amp;e instanceof r?e:e?f(e,u,i):i()}function t(t,r,o,i){if(!d.aborted||i){e&amp;&amp;e(t,r,o);for(var a=n(o),u=m(t),f=u.length,c=0;c&lt;f;c++)u[c].apply(a,r);var p=s[y[t]];return p&amp;&amp;p.push([b,t,r,a]),a}}function l(e,n){v[e]=m(e).concat(n)}function m(e){return v[e]||[]}function w(e){return p[e]=p[e]||o(t)}function g(e,n){c(e,function(e,t){n=n||&quot;feature&quot;,y[t]=n,n in s||(s[n]=[])})}var v={},y={},b={on:l,emit:t,get:w,listeners:m,context:n,buffer:g,abort:a,aborted:!1};return b}function i(){return new r}function a(){(s.api||s.feature)&amp;&amp;(d.aborted=!0,s=d.backlog={})}var u=&quot;nr@context&quot;,f=e(&quot;gos&quot;),c=e(2),s={},p={},d=n.exports=o();d.backlog=s},{}],gos:[function(e,n,t){function r(e,n,t){if(o.call(e,n))return e[n];var r=t();if(Object.defineProperty&amp;&amp;Object.keys)try{return Object.defineProperty(e,n,{value:r,writable:!0,enumerable:!1}),r}catch(i){}return e[n]=r,r}var o=Object.prototype.hasOwnProperty;n.exports=r},{}],handle:[function(e,n,t){function r(e,n,t,r){o.buffer([e],r),o.emit(e,n,t)}var o=e(&quot;ee&quot;).get(&quot;handle&quot;);n.exports=r,r.ee=o},{}],id:[function(e,n,t){function r(e){var n=typeof e;return!e||&quot;object&quot;!==n&amp;&amp;&quot;function&quot;!==n?-1:e===window?0:a(e,i,function(){return o++})}var o=1,i=&quot;nr@id&quot;,a=e(&quot;gos&quot;);n.exports=r},{}],loader:[function(e,n,t){function r(){if(!x++){var e=h.info=NREUM.info,n=d.getElementsByTagName(&quot;script&quot;)[0];if(setTimeout(s.abort,3e4),!(e&amp;&amp;e.licenseKey&amp;&amp;e.applicationID&amp;&amp;n))return s.abort();c(y,function(n,t){e[n]||(e[n]=t)}),f(&quot;mark&quot;,[&quot;onload&quot;,a()+h.offset],null,&quot;api&quot;);var t=d.createElement(&quot;script&quot;);t.src=&quot;https://&quot;+e.agent,n.parentNode.insertBefore(t,n)}}function o(){&quot;complete&quot;===d.readyState&amp;&amp;i()}function i(){f(&quot;mark&quot;,[&quot;domContent&quot;,a()+h.offset],null,&quot;api&quot;)}function a(){return E.exists&amp;&amp;performance.now?Math.round(performance.now()):(u=Math.max((new Date).getTime(),u))-h.offset}var u=(new Date).getTime(),f=e(&quot;handle&quot;),c=e(2),s=e(&quot;ee&quot;),p=window,d=p.document,l=&quot;addEventListener&quot;,m=&quot;attachEvent&quot;,w=p.XMLHttpRequest,g=w&amp;&amp;w.prototype;NREUM.o={ST:setTimeout,CT:clearTimeout,XHR:w,REQ:p.Request,EV:p.Event,PR:p.Promise,MO:p.MutationObserver};var v=&quot;&quot;+location,y={beacon:&quot;bam.nr-data.net&quot;,errorBeacon:&quot;bam.nr-data.net&quot;,agent:&quot;js-agent.newrelic.com/nr-1026.min.js&quot;},b=w&amp;&amp;g&amp;&amp;g[l]&amp;&amp;!/CriOS/.test(navigator.userAgent),h=n.exports={offset:u,now:a,origin:v,features:{},xhrWrappable:b};e(1),d[l]?(d[l](&quot;DOMContentLoaded&quot;,i,!1),p[l](&quot;load&quot;,r,!1)):(d[m](&quot;onreadystatechange&quot;,o),p[m](&quot;onload&quot;,r)),f(&quot;mark&quot;,[&quot;firstbyte&quot;,u],null,&quot;api&quot;);var x=0,E=e(4)},{}]},{},[&quot;loader&quot;]);&lt;/script&gt;
+    &lt;title&gt;BlazeDemo - reserve&lt;/title&gt;
+    &lt;meta name=&quot;description&quot; content=&quot;BlazeMeter demo app&quot;&gt;
+    &lt;meta name=&quot;sage&quot; content=&quot;flights app&quot;&gt;
+
+    &lt;script src=&quot;http://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js&quot;&gt;&lt;/script&gt;
+    &lt;script src=&quot;assets/bootstrap.min.js&quot;&gt;&lt;/script&gt;
+    &lt;script src=&quot;assets/bootstrap-table.js&quot;&gt;&lt;/script&gt;
+    &lt;link href=&quot;assets/bootstrap.min.css&quot; rel=&quot;stylesheet&quot; media=&quot;screen&quot;&gt;
+    &lt;link href=&quot;assets/bootstrap-table.css&quot; rel=&quot;stylesheet&quot; media=&quot;screen&quot;&gt;
+    &lt;style type=&quot;text/css&quot;&gt;
+        body {
+            background: #f5f5f5);
+        }
+
+        .hero-unit {
+            background-color: #fff;
+        }
+
+        .center {
+            display: block;
+            margin: 0 auto;
+        }
+    &lt;/style&gt;
+&lt;/head&gt;
+&lt;body&gt;
+    &lt;div class=&quot;navbar navbar-inverse&quot;&gt;
+        &lt;div class=&quot;navbar-inner&quot;&gt;
+            &lt;div class=&quot;container&quot;&gt;
+                &lt;a class=&quot;btn btn-navbar&quot; data-toggle=&quot;collapse&quot; data-target=&quot;.nav-collapse&quot;&gt;
+                    &lt;span class=&quot;icon-bar&quot;&gt;&lt;/span&gt;
+                    &lt;span class=&quot;icon-bar&quot;&gt;&lt;/span&gt;
+                    &lt;span class=&quot;icon-bar&quot;&gt;&lt;/span&gt;
+                &lt;/a&gt;
+                &lt;a class=&quot;brand&quot; href=&quot;index.php&quot;&gt;Travel The World&lt;/a&gt;
+                &lt;a class=&quot;brand&quot; href=&quot;home&quot;&gt;home&lt;/a&gt;
+            &lt;/div&gt;
+        &lt;/div&gt;
+    &lt;/div&gt;
+&lt;div class=&quot;container&quot;&gt;
+    
+        &lt;h3&gt;Flights from  to : &lt;/h3&gt;
+    &lt;table class=&quot;table&quot;&gt;
+        &lt;thead&gt;
+        &lt;tr&gt;
+            &lt;th&gt;Choose&lt;/th&gt;
+            &lt;th&gt;Flight #&lt;/th&gt;
+            &lt;th&gt;Airline&lt;/th&gt;
+            &lt;th&gt;Departs: &lt;/th&gt;
+            &lt;th&gt;Arrives: &lt;/th&gt;
+            &lt;th&gt;Price&lt;/th&gt;
+        &lt;/tr&gt;
+        &lt;/thead&gt;
+        &lt;tbody&gt;
+        &lt;tr&gt;
+            &lt;form name=&quot;VA43&quot; method=&quot;post&quot; action=&quot;purchase.php&quot;&gt;
+                &lt;td&gt;&lt;input type=&quot;submit&quot; class=&quot;btn btn-small&quot; value=&quot;Choose This Flight&quot;&gt;&lt;/td&gt;
+                &lt;td&gt;43&lt;/td&gt;
+                &lt;td&gt;Virgin America&lt;/td&gt;
+                &lt;td&gt;1:43 AM&lt;/td&gt;
+                &lt;td&gt;9:45 PM&lt;/td&gt;
+                &lt;td&gt;$472.56&lt;/td&gt;
+                &lt;input type=&quot;hidden&quot; value=&quot;43&quot; name=&quot;flight&quot;&gt;
+                &lt;input type=&quot;hidden&quot; value=&quot;472.56&quot; name=&quot;price&quot;&gt;
+                &lt;input type=&quot;hidden&quot; value=&quot;Virgin America&quot; name=&quot;airline&quot;&gt;
+                &lt;input type=&quot;hidden&quot; name=&quot;fromPort&quot; value=&quot;&quot;/&gt;
+                &lt;input type=&quot;hidden&quot; name=&quot;toPort&quot; value=&quot;&quot;/&gt;
+            &lt;/form&gt;
+        &lt;/tr&gt;
+        &lt;tr&gt;
+            &lt;form name=&quot;UA234&quot; method=&quot;post&quot; action=&quot;purchase.php&quot;&gt;
+                &lt;td&gt;&lt;input type=&quot;submit&quot; class=&quot;btn btn-small&quot; value=&quot;Choose This Flight&quot;&gt;&lt;/td&gt;
+                &lt;td&gt;234&lt;/td&gt;
+                &lt;td&gt;United Airlines&lt;/td&gt;
+                &lt;td&gt;7:43 AM&lt;/td&gt;
+                &lt;td&gt;10:45 PM&lt;/td&gt;
+                &lt;td&gt;$432.98&lt;/td&gt;
+                &lt;input type=&quot;hidden&quot; value=&quot;234&quot; name=&quot;flight&quot;&gt;
+                &lt;input type=&quot;hidden&quot; value=&quot;432.98&quot; name=&quot;price&quot;&gt;
+                &lt;input type=&quot;hidden&quot; value=&quot;United Airlines&quot; name=&quot;airline&quot;&gt;
+                &lt;input type=&quot;hidden&quot; name=&quot;fromPort&quot; value=&quot;&quot;/&gt;
+                &lt;input type=&quot;hidden&quot; name=&quot;toPort&quot; value=&quot;&quot;/&gt;
+            &lt;/form&gt;
+        &lt;/tr&gt;
+        &lt;tr&gt;
+            &lt;form name=&quot;AL969&quot; method=&quot;post&quot; action=&quot;purchase.php&quot;&gt;
+                &lt;td&gt;&lt;input type=&quot;submit&quot; class=&quot;btn btn-small&quot; value=&quot;Choose This Flight&quot;&gt;&lt;/td&gt;
+                &lt;td&gt;9696&lt;/td&gt;
+                &lt;td&gt;Aer Lingus&lt;/td&gt;
+                &lt;td&gt;5:27 AM&lt;/td&gt;
+                &lt;td&gt;8:22 PM&lt;/td&gt;
+                &lt;td&gt;$200.98&lt;/td&gt;
+                &lt;input type=&quot;hidden&quot; value=&quot;9696&quot; name=&quot;flight&quot;&gt;
+                &lt;input type=&quot;hidden&quot; value=&quot;200.98&quot; name=&quot;price&quot;&gt;
+                &lt;input type=&quot;hidden&quot; value=&quot;Aer Lingus&quot; name=&quot;airline&quot;&gt;
+                &lt;input type=&quot;hidden&quot; name=&quot;fromPort&quot; value=&quot;&quot;/&gt;
+                &lt;input type=&quot;hidden&quot; name=&quot;toPort&quot; value=&quot;&quot;/&gt;
+            &lt;/form&gt;
+
+        &lt;/tr&gt;
+        &lt;tr&gt;
+            &lt;form name=&quot;VA12&quot; method=&quot;post&quot; action=&quot;purchase.php&quot;&gt;
+                &lt;td&gt;&lt;input type=&quot;submit&quot; class=&quot;btn btn-small&quot; value=&quot;Choose This Flight&quot;&gt;&lt;/td&gt;
+                &lt;td&gt;12&lt;/td&gt;
+                &lt;td&gt;Virgin America&lt;/td&gt;
+                &lt;td&gt;11:23 AM&lt;/td&gt;
+                &lt;td&gt;1:45 PM&lt;/td&gt;
+                &lt;td&gt;$765.32&lt;/td&gt;
+                &lt;input type=&quot;hidden&quot; value=&quot;12&quot; name=&quot;flight&quot;&gt;
+                &lt;input type=&quot;hidden&quot; value=&quot;765.32&quot; name=&quot;price&quot;&gt;
+                &lt;input type=&quot;hidden&quot; value=&quot;Virgin America&quot; name=&quot;airline&quot;&gt;
+                &lt;input type=&quot;hidden&quot; name=&quot;fromPort&quot; value=&quot;&quot;/&gt;
+                &lt;input type=&quot;hidden&quot; name=&quot;toPort&quot; value=&quot;&quot;/&gt;
+            &lt;/form&gt;
+        &lt;/tr&gt;
+        &lt;tr&gt;
+            &lt;form name=&quot;L4346&quot; method=&quot;post&quot; action=&quot;purchase.php&quot;&gt;
+                &lt;td&gt;&lt;input type=&quot;submit&quot; class=&quot;btn btn-small&quot; value=&quot;Choose This Flight&quot;&gt;&lt;/td&gt;
+                &lt;td&gt;4346&lt;/td&gt;
+                &lt;td&gt;Lufthansa&lt;/td&gt;
+                &lt;td&gt;1:45 AM&lt;/td&gt;
+                &lt;td&gt;8:34 PM&lt;/td&gt;
+                &lt;td&gt;$233.98&lt;/td&gt;
+                &lt;input type=&quot;hidden&quot; value=&quot;4346&quot; name=&quot;flight&quot;&gt;
+                &lt;input type=&quot;hidden&quot; value=&quot;233.98&quot; name=&quot;price&quot;&gt;
+                &lt;input type=&quot;hidden&quot; value=&quot;Lufthansa&quot; name=&quot;airline&quot;&gt;
+                &lt;input type=&quot;hidden&quot; name=&quot;fromPort&quot; value=&quot;&quot;/&gt;
+                &lt;input type=&quot;hidden&quot; name=&quot;toPort&quot; value=&quot;&quot;/&gt;
+            &lt;/form&gt;
+        &lt;/tr&gt;
+        &lt;/tbody&gt;
+    &lt;/table&gt;
+    &lt;input type=&quot;hidden&quot; name=&quot;fromPort&quot; value=&quot;&quot;/&gt;
+    &lt;input type=&quot;hidden&quot; name=&quot;toPort&quot; value=&quot;&quot;/&gt;
+    &lt;/div&gt;
+&lt;/div&gt;
+&lt;script type=&quot;text/javascript&quot;&gt;window.NREUM||(NREUM={});NREUM.info={&quot;beacon&quot;:&quot;bam.nr-data.net&quot;,&quot;licenseKey&quot;:&quot;338cffe5d3&quot;,&quot;applicationID&quot;:&quot;6657625&quot;,&quot;transactionName&quot;:&quot;YVxSYxACCxcEVRFfWlgWcVQWCgoKSkQARVBET1UZEgsV&quot;,&quot;queueTime&quot;:0,&quot;applicationTime&quot;:6,&quot;atts&quot;:&quot;TRtRFVgYGBk=&quot;,&quot;errorBeacon&quot;:&quot;bam.nr-data.net&quot;,&quot;agent&quot;:&quot;&quot;}&lt;/script&gt;&lt;/body&gt;
+&lt;/html&gt;</responseData>
+  <cookies class="java.lang.String"></cookies>
+  <method class="java.lang.String">GET</method>
+  <queryString class="java.lang.String"></queryString>
+  <java.net.URL>http://blazedemo.com/reserve.php</java.net.URL>
+</httpSample>
+
+</testResults>

--- a/tests/jmeter/jtl/trace.jtl
+++ b/tests/jmeter/jtl/trace.jtl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testResults version="1.2">
-<httpSample t="388" lt="388" ts="1489492771539" s="false" lb="blazedemo-index" rc="200" rm="OK" tn="ThreadGroup 1-1" dt="text" de="UTF-8" by="7876" ng="1" na="1">
+<httpSample t="388" lt="388" ts="1489492771539" s="false" lb="blazedemo-index" rc="200" rm="OK" tn="ThreadGroup 1-1" dt="text" de="UTF-8" by="7876" sby="123" ct="123" ng="1" na="1">
   <assertionResult>
     <name>Passing Assertion</name>
     <failure>false</failure>

--- a/tests/jmeter/jtl/trace.jtl
+++ b/tests/jmeter/jtl/trace.jtl
@@ -1,10 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testResults version="1.2">
-<httpSample t="556" lt="556" ts="1489491284900" s="true" lb="http://blazedemo.com/" rc="200" rm="OK" tn="ThreadGroup 1-1" dt="text" de="UTF-8" by="7876" ng="1" na="1">
+<httpSample t="388" lt="388" ts="1489492771539" s="false" lb="blazedemo-index" rc="200" rm="OK" tn="ThreadGroup 1-1" dt="text" de="UTF-8" by="7876" ng="1" na="1">
+  <assertionResult>
+    <name>Passing Assertion</name>
+    <failure>false</failure>
+    <error>false</error>
+  </assertionResult>
+  <assertionResult>
+    <name>Failing Assertion</name>
+    <failure>true</failure>
+    <error>false</error>
+    <failureMessage>Test failed: text expected to contain /something/</failureMessage>
+  </assertionResult>
   <responseHeader class="java.lang.String">HTTP/1.1 200 OK
 Cache-Control: no-cache
 Content-Type: text/html; charset=UTF-8
-Date: Tue, 14 Mar 2017 11:34:43 GMT
+Date: Tue, 14 Mar 2017 11:59:30 GMT
 Server: Apache
 Content-Length: 7693
 Connection: keep-alive
@@ -101,167 +112,6 @@ User-Agent: Apache-HttpClient/4.5.2 (Java/1.8.0_121)
   <method class="java.lang.String">GET</method>
   <queryString class="java.lang.String"></queryString>
   <java.net.URL>http://blazedemo.com/</java.net.URL>
-</httpSample>
-<httpSample t="72" lt="71" ts="1489491285463" s="true" lb="http://blazedemo.com/reserve.php" rc="200" rm="OK" tn="ThreadGroup 1-1" dt="text" de="UTF-8" by="10394" ng="1" na="1">
-  <responseHeader class="java.lang.String">HTTP/1.1 200 OK
-Cache-Control: no-cache
-Content-Type: text/html; charset=UTF-8
-Date: Tue, 14 Mar 2017 11:34:43 GMT
-Server: Apache
-transfer-encoding: chunked
-Connection: keep-alive
-</responseHeader>
-  <requestHeader class="java.lang.String">Connection: keep-alive
-Content-Length: 0
-Content-Type: text/plain; charset=ISO-8859-1
-Host: blazedemo.com
-User-Agent: Apache-HttpClient/4.5.2 (Java/1.8.0_121)
-</requestHeader>
-  <responseData class="java.lang.String">&lt;!doctype html&gt;
-&lt;html lang=&quot;en&quot;&gt;
-&lt;head&gt;
-    &lt;meta charset=&quot;utf-8&quot;&gt;&lt;script type=&quot;text/javascript&quot;&gt;window.NREUM||(NREUM={}),__nr_require=function(e,n,t){function r(t){if(!n[t]){var o=n[t]={exports:{}};e[t][0].call(o.exports,function(n){var o=e[t][1][n];return r(o||n)},o,o.exports)}return n[t].exports}if(&quot;function&quot;==typeof __nr_require)return __nr_require;for(var o=0;o&lt;t.length;o++)r(t[o]);return r}({1:[function(e,n,t){function r(){}function o(e,n,t){return function(){return i(e,[c.now()].concat(u(arguments)),n?null:this,t),n?void 0:this}}var i=e(&quot;handle&quot;),a=e(2),u=e(3),f=e(&quot;ee&quot;).get(&quot;tracer&quot;),c=e(&quot;loader&quot;),s=NREUM;&quot;undefined&quot;==typeof window.newrelic&amp;&amp;(newrelic=s);var p=[&quot;setPageViewName&quot;,&quot;setCustomAttribute&quot;,&quot;setErrorHandler&quot;,&quot;finished&quot;,&quot;addToTrace&quot;,&quot;inlineHit&quot;,&quot;addRelease&quot;],d=&quot;api-&quot;,l=d+&quot;ixn-&quot;;a(p,function(e,n){s[n]=o(d+n,!0,&quot;api&quot;)}),s.addPageAction=o(d+&quot;addPageAction&quot;,!0),s.setCurrentRouteName=o(d+&quot;routeName&quot;,!0),n.exports=newrelic,s.interaction=function(){return(new r).get()};var m=r.prototype={createTracer:function(e,n){var t={},r=this,o=&quot;function&quot;==typeof n;return i(l+&quot;tracer&quot;,[c.now(),e,t],r),function(){if(f.emit((o?&quot;&quot;:&quot;no-&quot;)+&quot;fn-start&quot;,[c.now(),r,o],t),o)try{return n.apply(this,arguments)}finally{f.emit(&quot;fn-end&quot;,[c.now()],t)}}}};a(&quot;setName,setAttribute,save,ignore,onEnd,getContext,end,get&quot;.split(&quot;,&quot;),function(e,n){m[n]=o(l+n)}),newrelic.noticeError=function(e){&quot;string&quot;==typeof e&amp;&amp;(e=new Error(e)),i(&quot;err&quot;,[e,c.now()])}},{}],2:[function(e,n,t){function r(e,n){var t=[],r=&quot;&quot;,i=0;for(r in e)o.call(e,r)&amp;&amp;(t[i]=n(r,e[r]),i+=1);return t}var o=Object.prototype.hasOwnProperty;n.exports=r},{}],3:[function(e,n,t){function r(e,n,t){n||(n=0),&quot;undefined&quot;==typeof t&amp;&amp;(t=e?e.length:0);for(var r=-1,o=t-n||0,i=Array(o&lt;0?0:o);++r&lt;o;)i[r]=e[n+r];return i}n.exports=r},{}],4:[function(e,n,t){n.exports={exists:&quot;undefined&quot;!=typeof window.performance&amp;&amp;window.performance.timing&amp;&amp;&quot;undefined&quot;!=typeof window.performance.timing.navigationStart}},{}],ee:[function(e,n,t){function r(){}function o(e){function n(e){return e&amp;&amp;e instanceof r?e:e?f(e,u,i):i()}function t(t,r,o,i){if(!d.aborted||i){e&amp;&amp;e(t,r,o);for(var a=n(o),u=m(t),f=u.length,c=0;c&lt;f;c++)u[c].apply(a,r);var p=s[y[t]];return p&amp;&amp;p.push([b,t,r,a]),a}}function l(e,n){v[e]=m(e).concat(n)}function m(e){return v[e]||[]}function w(e){return p[e]=p[e]||o(t)}function g(e,n){c(e,function(e,t){n=n||&quot;feature&quot;,y[t]=n,n in s||(s[n]=[])})}var v={},y={},b={on:l,emit:t,get:w,listeners:m,context:n,buffer:g,abort:a,aborted:!1};return b}function i(){return new r}function a(){(s.api||s.feature)&amp;&amp;(d.aborted=!0,s=d.backlog={})}var u=&quot;nr@context&quot;,f=e(&quot;gos&quot;),c=e(2),s={},p={},d=n.exports=o();d.backlog=s},{}],gos:[function(e,n,t){function r(e,n,t){if(o.call(e,n))return e[n];var r=t();if(Object.defineProperty&amp;&amp;Object.keys)try{return Object.defineProperty(e,n,{value:r,writable:!0,enumerable:!1}),r}catch(i){}return e[n]=r,r}var o=Object.prototype.hasOwnProperty;n.exports=r},{}],handle:[function(e,n,t){function r(e,n,t,r){o.buffer([e],r),o.emit(e,n,t)}var o=e(&quot;ee&quot;).get(&quot;handle&quot;);n.exports=r,r.ee=o},{}],id:[function(e,n,t){function r(e){var n=typeof e;return!e||&quot;object&quot;!==n&amp;&amp;&quot;function&quot;!==n?-1:e===window?0:a(e,i,function(){return o++})}var o=1,i=&quot;nr@id&quot;,a=e(&quot;gos&quot;);n.exports=r},{}],loader:[function(e,n,t){function r(){if(!x++){var e=h.info=NREUM.info,n=d.getElementsByTagName(&quot;script&quot;)[0];if(setTimeout(s.abort,3e4),!(e&amp;&amp;e.licenseKey&amp;&amp;e.applicationID&amp;&amp;n))return s.abort();c(y,function(n,t){e[n]||(e[n]=t)}),f(&quot;mark&quot;,[&quot;onload&quot;,a()+h.offset],null,&quot;api&quot;);var t=d.createElement(&quot;script&quot;);t.src=&quot;https://&quot;+e.agent,n.parentNode.insertBefore(t,n)}}function o(){&quot;complete&quot;===d.readyState&amp;&amp;i()}function i(){f(&quot;mark&quot;,[&quot;domContent&quot;,a()+h.offset],null,&quot;api&quot;)}function a(){return E.exists&amp;&amp;performance.now?Math.round(performance.now()):(u=Math.max((new Date).getTime(),u))-h.offset}var u=(new Date).getTime(),f=e(&quot;handle&quot;),c=e(2),s=e(&quot;ee&quot;),p=window,d=p.document,l=&quot;addEventListener&quot;,m=&quot;attachEvent&quot;,w=p.XMLHttpRequest,g=w&amp;&amp;w.prototype;NREUM.o={ST:setTimeout,CT:clearTimeout,XHR:w,REQ:p.Request,EV:p.Event,PR:p.Promise,MO:p.MutationObserver};var v=&quot;&quot;+location,y={beacon:&quot;bam.nr-data.net&quot;,errorBeacon:&quot;bam.nr-data.net&quot;,agent:&quot;js-agent.newrelic.com/nr-1026.min.js&quot;},b=w&amp;&amp;g&amp;&amp;g[l]&amp;&amp;!/CriOS/.test(navigator.userAgent),h=n.exports={offset:u,now:a,origin:v,features:{},xhrWrappable:b};e(1),d[l]?(d[l](&quot;DOMContentLoaded&quot;,i,!1),p[l](&quot;load&quot;,r,!1)):(d[m](&quot;onreadystatechange&quot;,o),p[m](&quot;onload&quot;,r)),f(&quot;mark&quot;,[&quot;firstbyte&quot;,u],null,&quot;api&quot;);var x=0,E=e(4)},{}]},{},[&quot;loader&quot;]);&lt;/script&gt;
-    &lt;title&gt;BlazeDemo - reserve&lt;/title&gt;
-    &lt;meta name=&quot;description&quot; content=&quot;BlazeMeter demo app&quot;&gt;
-    &lt;meta name=&quot;sage&quot; content=&quot;flights app&quot;&gt;
-
-    &lt;script src=&quot;http://ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min.js&quot;&gt;&lt;/script&gt;
-    &lt;script src=&quot;assets/bootstrap.min.js&quot;&gt;&lt;/script&gt;
-    &lt;script src=&quot;assets/bootstrap-table.js&quot;&gt;&lt;/script&gt;
-    &lt;link href=&quot;assets/bootstrap.min.css&quot; rel=&quot;stylesheet&quot; media=&quot;screen&quot;&gt;
-    &lt;link href=&quot;assets/bootstrap-table.css&quot; rel=&quot;stylesheet&quot; media=&quot;screen&quot;&gt;
-    &lt;style type=&quot;text/css&quot;&gt;
-        body {
-            background: #f5f5f5);
-        }
-
-        .hero-unit {
-            background-color: #fff;
-        }
-
-        .center {
-            display: block;
-            margin: 0 auto;
-        }
-    &lt;/style&gt;
-&lt;/head&gt;
-&lt;body&gt;
-    &lt;div class=&quot;navbar navbar-inverse&quot;&gt;
-        &lt;div class=&quot;navbar-inner&quot;&gt;
-            &lt;div class=&quot;container&quot;&gt;
-                &lt;a class=&quot;btn btn-navbar&quot; data-toggle=&quot;collapse&quot; data-target=&quot;.nav-collapse&quot;&gt;
-                    &lt;span class=&quot;icon-bar&quot;&gt;&lt;/span&gt;
-                    &lt;span class=&quot;icon-bar&quot;&gt;&lt;/span&gt;
-                    &lt;span class=&quot;icon-bar&quot;&gt;&lt;/span&gt;
-                &lt;/a&gt;
-                &lt;a class=&quot;brand&quot; href=&quot;index.php&quot;&gt;Travel The World&lt;/a&gt;
-                &lt;a class=&quot;brand&quot; href=&quot;home&quot;&gt;home&lt;/a&gt;
-            &lt;/div&gt;
-        &lt;/div&gt;
-    &lt;/div&gt;
-&lt;div class=&quot;container&quot;&gt;
-    
-        &lt;h3&gt;Flights from  to : &lt;/h3&gt;
-    &lt;table class=&quot;table&quot;&gt;
-        &lt;thead&gt;
-        &lt;tr&gt;
-            &lt;th&gt;Choose&lt;/th&gt;
-            &lt;th&gt;Flight #&lt;/th&gt;
-            &lt;th&gt;Airline&lt;/th&gt;
-            &lt;th&gt;Departs: &lt;/th&gt;
-            &lt;th&gt;Arrives: &lt;/th&gt;
-            &lt;th&gt;Price&lt;/th&gt;
-        &lt;/tr&gt;
-        &lt;/thead&gt;
-        &lt;tbody&gt;
-        &lt;tr&gt;
-            &lt;form name=&quot;VA43&quot; method=&quot;post&quot; action=&quot;purchase.php&quot;&gt;
-                &lt;td&gt;&lt;input type=&quot;submit&quot; class=&quot;btn btn-small&quot; value=&quot;Choose This Flight&quot;&gt;&lt;/td&gt;
-                &lt;td&gt;43&lt;/td&gt;
-                &lt;td&gt;Virgin America&lt;/td&gt;
-                &lt;td&gt;1:43 AM&lt;/td&gt;
-                &lt;td&gt;9:45 PM&lt;/td&gt;
-                &lt;td&gt;$472.56&lt;/td&gt;
-                &lt;input type=&quot;hidden&quot; value=&quot;43&quot; name=&quot;flight&quot;&gt;
-                &lt;input type=&quot;hidden&quot; value=&quot;472.56&quot; name=&quot;price&quot;&gt;
-                &lt;input type=&quot;hidden&quot; value=&quot;Virgin America&quot; name=&quot;airline&quot;&gt;
-                &lt;input type=&quot;hidden&quot; name=&quot;fromPort&quot; value=&quot;&quot;/&gt;
-                &lt;input type=&quot;hidden&quot; name=&quot;toPort&quot; value=&quot;&quot;/&gt;
-            &lt;/form&gt;
-        &lt;/tr&gt;
-        &lt;tr&gt;
-            &lt;form name=&quot;UA234&quot; method=&quot;post&quot; action=&quot;purchase.php&quot;&gt;
-                &lt;td&gt;&lt;input type=&quot;submit&quot; class=&quot;btn btn-small&quot; value=&quot;Choose This Flight&quot;&gt;&lt;/td&gt;
-                &lt;td&gt;234&lt;/td&gt;
-                &lt;td&gt;United Airlines&lt;/td&gt;
-                &lt;td&gt;7:43 AM&lt;/td&gt;
-                &lt;td&gt;10:45 PM&lt;/td&gt;
-                &lt;td&gt;$432.98&lt;/td&gt;
-                &lt;input type=&quot;hidden&quot; value=&quot;234&quot; name=&quot;flight&quot;&gt;
-                &lt;input type=&quot;hidden&quot; value=&quot;432.98&quot; name=&quot;price&quot;&gt;
-                &lt;input type=&quot;hidden&quot; value=&quot;United Airlines&quot; name=&quot;airline&quot;&gt;
-                &lt;input type=&quot;hidden&quot; name=&quot;fromPort&quot; value=&quot;&quot;/&gt;
-                &lt;input type=&quot;hidden&quot; name=&quot;toPort&quot; value=&quot;&quot;/&gt;
-            &lt;/form&gt;
-        &lt;/tr&gt;
-        &lt;tr&gt;
-            &lt;form name=&quot;AL969&quot; method=&quot;post&quot; action=&quot;purchase.php&quot;&gt;
-                &lt;td&gt;&lt;input type=&quot;submit&quot; class=&quot;btn btn-small&quot; value=&quot;Choose This Flight&quot;&gt;&lt;/td&gt;
-                &lt;td&gt;9696&lt;/td&gt;
-                &lt;td&gt;Aer Lingus&lt;/td&gt;
-                &lt;td&gt;5:27 AM&lt;/td&gt;
-                &lt;td&gt;8:22 PM&lt;/td&gt;
-                &lt;td&gt;$200.98&lt;/td&gt;
-                &lt;input type=&quot;hidden&quot; value=&quot;9696&quot; name=&quot;flight&quot;&gt;
-                &lt;input type=&quot;hidden&quot; value=&quot;200.98&quot; name=&quot;price&quot;&gt;
-                &lt;input type=&quot;hidden&quot; value=&quot;Aer Lingus&quot; name=&quot;airline&quot;&gt;
-                &lt;input type=&quot;hidden&quot; name=&quot;fromPort&quot; value=&quot;&quot;/&gt;
-                &lt;input type=&quot;hidden&quot; name=&quot;toPort&quot; value=&quot;&quot;/&gt;
-            &lt;/form&gt;
-
-        &lt;/tr&gt;
-        &lt;tr&gt;
-            &lt;form name=&quot;VA12&quot; method=&quot;post&quot; action=&quot;purchase.php&quot;&gt;
-                &lt;td&gt;&lt;input type=&quot;submit&quot; class=&quot;btn btn-small&quot; value=&quot;Choose This Flight&quot;&gt;&lt;/td&gt;
-                &lt;td&gt;12&lt;/td&gt;
-                &lt;td&gt;Virgin America&lt;/td&gt;
-                &lt;td&gt;11:23 AM&lt;/td&gt;
-                &lt;td&gt;1:45 PM&lt;/td&gt;
-                &lt;td&gt;$765.32&lt;/td&gt;
-                &lt;input type=&quot;hidden&quot; value=&quot;12&quot; name=&quot;flight&quot;&gt;
-                &lt;input type=&quot;hidden&quot; value=&quot;765.32&quot; name=&quot;price&quot;&gt;
-                &lt;input type=&quot;hidden&quot; value=&quot;Virgin America&quot; name=&quot;airline&quot;&gt;
-                &lt;input type=&quot;hidden&quot; name=&quot;fromPort&quot; value=&quot;&quot;/&gt;
-                &lt;input type=&quot;hidden&quot; name=&quot;toPort&quot; value=&quot;&quot;/&gt;
-            &lt;/form&gt;
-        &lt;/tr&gt;
-        &lt;tr&gt;
-            &lt;form name=&quot;L4346&quot; method=&quot;post&quot; action=&quot;purchase.php&quot;&gt;
-                &lt;td&gt;&lt;input type=&quot;submit&quot; class=&quot;btn btn-small&quot; value=&quot;Choose This Flight&quot;&gt;&lt;/td&gt;
-                &lt;td&gt;4346&lt;/td&gt;
-                &lt;td&gt;Lufthansa&lt;/td&gt;
-                &lt;td&gt;1:45 AM&lt;/td&gt;
-                &lt;td&gt;8:34 PM&lt;/td&gt;
-                &lt;td&gt;$233.98&lt;/td&gt;
-                &lt;input type=&quot;hidden&quot; value=&quot;4346&quot; name=&quot;flight&quot;&gt;
-                &lt;input type=&quot;hidden&quot; value=&quot;233.98&quot; name=&quot;price&quot;&gt;
-                &lt;input type=&quot;hidden&quot; value=&quot;Lufthansa&quot; name=&quot;airline&quot;&gt;
-                &lt;input type=&quot;hidden&quot; name=&quot;fromPort&quot; value=&quot;&quot;/&gt;
-                &lt;input type=&quot;hidden&quot; name=&quot;toPort&quot; value=&quot;&quot;/&gt;
-            &lt;/form&gt;
-        &lt;/tr&gt;
-        &lt;/tbody&gt;
-    &lt;/table&gt;
-    &lt;input type=&quot;hidden&quot; name=&quot;fromPort&quot; value=&quot;&quot;/&gt;
-    &lt;input type=&quot;hidden&quot; name=&quot;toPort&quot; value=&quot;&quot;/&gt;
-    &lt;/div&gt;
-&lt;/div&gt;
-&lt;script type=&quot;text/javascript&quot;&gt;window.NREUM||(NREUM={});NREUM.info={&quot;beacon&quot;:&quot;bam.nr-data.net&quot;,&quot;licenseKey&quot;:&quot;338cffe5d3&quot;,&quot;applicationID&quot;:&quot;6657625&quot;,&quot;transactionName&quot;:&quot;YVxSYxACCxcEVRFfWlgWcVQWCgoKSkQARVBET1UZEgsV&quot;,&quot;queueTime&quot;:0,&quot;applicationTime&quot;:6,&quot;atts&quot;:&quot;TRtRFVgYGBk=&quot;,&quot;errorBeacon&quot;:&quot;bam.nr-data.net&quot;,&quot;agent&quot;:&quot;&quot;}&lt;/script&gt;&lt;/body&gt;
-&lt;/html&gt;</responseData>
-  <cookies class="java.lang.String"></cookies>
-  <method class="java.lang.String">GET</method>
-  <queryString class="java.lang.String"></queryString>
-  <java.net.URL>http://blazedemo.com/reserve.php</java.net.URL>
 </httpSample>
 
 </testResults>

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1931,7 +1931,7 @@ class TestJMeterExecutor(BZTestCase):
                             engine_obj.artifacts_dir,
                             logging.getLogger(''))
         samples = list(obj.read(last_pass=True))
-        self.assertEqual(2, len(samples))
+        self.assertEqual(1, len(samples))
         sample = samples[0]
         self.assertIsNotNone(sample.extras)
         fields = [
@@ -1952,12 +1952,30 @@ class TestJMeterExecutor(BZTestCase):
                             engine_obj.artifacts_dir,
                             logging.getLogger(''))
         samples = list(obj.read(last_pass=True))
-        self.assertEqual(2, len(samples))
+        self.assertEqual(1, len(samples))
         for i, sample in enumerate(samples):
             for field in FuncJTLReader.FILE_EXTRACTED_FIELDS:
                 if sample.extras[field]:
                     filename = os.path.join(engine_obj.artifacts_dir, "sample-%d-%s.bin" % (i, field))
                     self.assertTrue(os.path.exists(filename))
+
+    def test_functional_reader_extras_assertions(self):
+        engine_obj = EngineEmul()
+        obj = FuncJTLReader(__dir__() + "/../jmeter/jtl/trace.jtl",
+                            engine_obj.artifacts_dir,
+                            logging.getLogger(''))
+        samples = list(obj.read(last_pass=True))
+        self.assertEqual(1, len(samples))
+        sample = samples[0]
+        self.assertIsNotNone(sample.extras)
+        self.assertEqual(len(sample.extras["assertions"]), 2)
+        first, second = sample.extras["assertions"]
+        self.assertEqual(first, {"name": 'Passing Assertion',
+                                 "isFailed": False,
+                                 "errorMessage": ""})
+        self.assertEqual(second, {"name": 'Failing Assertion',
+                                 "isFailed": True,
+                                 "errorMessage": "Test failed: text expected to contain /something/"})
 
     def test_jsr223_block(self):
         script = __dir__() + "/../jmeter/jsr223_script.js"

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1941,7 +1941,7 @@ class TestJMeterExecutor(BZTestCase):
             'responseBody', 'responseBodySize', 'responseCode', 'responseHeaders', 'responseHeadersSize',
             'responseMessage', 'responseSize', 'responseTime'
         ]
-        for field in fields:
+        for field in set(fields) - set(FuncJTLReader.FILE_EXTRACTED_FIELDS):
             self.assertIn(field, sample.extras)
         self.assertEqual(sample.extras["requestURI"], "http://blazedemo.com/")
         self.assertEqual(sample.extras["requestMethod"], "GET")
@@ -1953,11 +1953,9 @@ class TestJMeterExecutor(BZTestCase):
                             logging.getLogger(''))
         samples = list(obj.read(last_pass=True))
         self.assertEqual(1, len(samples))
-        for i, sample in enumerate(samples):
-            for field in FuncJTLReader.FILE_EXTRACTED_FIELDS:
-                if sample.extras[field]:
-                    filename = os.path.join(engine_obj.artifacts_dir, "sample-%d-%s.bin" % (i, field))
-                    self.assertTrue(os.path.exists(filename))
+        self.assertTrue(os.path.exists(os.path.join(engine_obj.artifacts_dir, "sample-0-requestHeaders.bin")))
+        self.assertTrue(os.path.exists(os.path.join(engine_obj.artifacts_dir, "sample-0-responseHeaders.bin")))
+        self.assertTrue(os.path.exists(os.path.join(engine_obj.artifacts_dir, "sample-0-responseBody.bin")))
 
     def test_functional_reader_extras_assertions(self):
         engine_obj = EngineEmul()

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1881,7 +1881,7 @@ class TestJMeterExecutor(BZTestCase):
     def test_functional_reader_pass(self):
         engine_obj = EngineEmul()
         obj = FuncJTLReader(__dir__() + "/../jmeter/jtl/resource-errors-no-fail.jtl",
-                            engine_obj.artifacts_dir,
+                            engine_obj,
                             logging.getLogger(''))
         samples = list(obj.read(last_pass=True))
         self.assertEqual(2, len(samples))
@@ -1897,7 +1897,7 @@ class TestJMeterExecutor(BZTestCase):
     def test_functional_reader_failed(self):
         engine_obj = EngineEmul()
         obj = FuncJTLReader(__dir__() + "/../jmeter/jtl/standard-errors.jtl",
-                            engine_obj.artifacts_dir,
+                            engine_obj,
                             logging.getLogger(''))
         samples = list(obj.read(last_pass=True))
         self.assertEqual(185, len(samples))
@@ -1912,7 +1912,7 @@ class TestJMeterExecutor(BZTestCase):
     def test_functional_reader_broken(self):
         engine_obj = EngineEmul()
         obj = FuncJTLReader(__dir__() + "/../jmeter/jtl/standard-errors.jtl",
-                            engine_obj.artifacts_dir,
+                            engine_obj,
                             logging.getLogger(''))
         samples = list(obj.read(last_pass=True))
         self.assertEqual(185, len(samples))
@@ -1928,18 +1928,18 @@ class TestJMeterExecutor(BZTestCase):
     def test_functional_reader_extras(self):
         engine_obj = EngineEmul()
         obj = FuncJTLReader(__dir__() + "/../jmeter/jtl/trace.jtl",
-                            engine_obj.artifacts_dir,
+                            engine_obj,
                             logging.getLogger(''))
         samples = list(obj.read(last_pass=True))
         self.assertEqual(1, len(samples))
         sample = samples[0]
         self.assertIsNotNone(sample.extras)
         fields = [
-            'id', 'assertions', 'connectTime', 'latency',
+            'assertions', 'connectTime', 'latency', 'responseTime',
             'requestBody', 'requestBodySize', 'requestCookies', 'requestCookiesSize', 'requestHeaders',
             'requestHeadersSize', 'requestMethod', 'requestSize', 'requestURI',
             'responseBody', 'responseBodySize', 'responseCode', 'responseHeaders', 'responseHeadersSize',
-            'responseMessage', 'responseSize', 'responseTime'
+            'responseMessage', 'responseSize',
         ]
         for field in set(fields) - set(FuncJTLReader.FILE_EXTRACTED_FIELDS):
             self.assertIn(field, sample.extras)
@@ -1949,18 +1949,18 @@ class TestJMeterExecutor(BZTestCase):
     def test_functional_reader_artifact_files(self):
         engine_obj = EngineEmul()
         obj = FuncJTLReader(__dir__() + "/../jmeter/jtl/trace.jtl",
-                            engine_obj.artifacts_dir,
+                            engine_obj,
                             logging.getLogger(''))
         samples = list(obj.read(last_pass=True))
         self.assertEqual(1, len(samples))
-        self.assertTrue(os.path.exists(os.path.join(engine_obj.artifacts_dir, "sample-0-requestHeaders.bin")))
-        self.assertTrue(os.path.exists(os.path.join(engine_obj.artifacts_dir, "sample-0-responseHeaders.bin")))
-        self.assertTrue(os.path.exists(os.path.join(engine_obj.artifacts_dir, "sample-0-responseBody.bin")))
+        self.assertTrue(os.path.exists(os.path.join(engine_obj.artifacts_dir, "sample-requestHeaders.bin")))
+        self.assertTrue(os.path.exists(os.path.join(engine_obj.artifacts_dir, "sample-responseHeaders.bin")))
+        self.assertTrue(os.path.exists(os.path.join(engine_obj.artifacts_dir, "sample-responseBody.bin")))
 
     def test_functional_reader_extras_assertions(self):
         engine_obj = EngineEmul()
         obj = FuncJTLReader(__dir__() + "/../jmeter/jtl/trace.jtl",
-                            engine_obj.artifacts_dir,
+                            engine_obj,
                             logging.getLogger(''))
         samples = list(obj.read(last_pass=True))
         self.assertEqual(1, len(samples))

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1879,7 +1879,10 @@ class TestJMeterExecutor(BZTestCase):
         self.assertEqual(functional_switch.text, "true")
 
     def test_functional_reader_pass(self):
-        obj = FuncJTLReader(__dir__() + "/../jmeter/jtl/resource-errors-no-fail.jtl", logging.getLogger(''))
+        engine_obj = EngineEmul()
+        obj = FuncJTLReader(__dir__() + "/../jmeter/jtl/resource-errors-no-fail.jtl",
+                            engine_obj.artifacts_dir,
+                            logging.getLogger(''))
         samples = list(obj.read(last_pass=True))
         self.assertEqual(2, len(samples))
         first = samples[0]
@@ -1892,7 +1895,10 @@ class TestJMeterExecutor(BZTestCase):
         self.assertEqual(first.error_trace, "")
 
     def test_functional_reader_failed(self):
-        obj = FuncJTLReader(__dir__() + "/../jmeter/jtl/standard-errors.jtl", logging.getLogger(''))
+        engine_obj = EngineEmul()
+        obj = FuncJTLReader(__dir__() + "/../jmeter/jtl/standard-errors.jtl",
+                            engine_obj.artifacts_dir,
+                            logging.getLogger(''))
         samples = list(obj.read(last_pass=True))
         self.assertEqual(185, len(samples))
         first = samples[0]
@@ -1904,7 +1910,10 @@ class TestJMeterExecutor(BZTestCase):
         self.assertEqual(first.error_msg, "The operation lasted too long")
 
     def test_functional_reader_broken(self):
-        obj = FuncJTLReader(__dir__() + "/../jmeter/jtl/standard-errors.jtl", logging.getLogger(''))
+        engine_obj = EngineEmul()
+        obj = FuncJTLReader(__dir__() + "/../jmeter/jtl/standard-errors.jtl",
+                            engine_obj.artifacts_dir,
+                            logging.getLogger(''))
         samples = list(obj.read(last_pass=True))
         self.assertEqual(185, len(samples))
         sample = samples[8]

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1974,8 +1974,8 @@ class TestJMeterExecutor(BZTestCase):
                                  "isFailed": False,
                                  "errorMessage": ""})
         self.assertEqual(second, {"name": 'Failing Assertion',
-                                 "isFailed": True,
-                                 "errorMessage": "Test failed: text expected to contain /something/"})
+                                  "isFailed": True,
+                                  "errorMessage": "Test failed: text expected to contain /something/"})
 
     def test_jsr223_block(self):
         script = __dir__() + "/../jmeter/jsr223_script.js"


### PR DESCRIPTION
# Attach detailed request stats from JMeter to `sample.extras` dictionary when running in functional mode

## Data collected

The following pieces are put in `FunctionalSample.extras` dictionary:
- `id` - integer id for the sample - guaranteed to be unique for one test run, won't be unique between multiple Taurus runs
- `responseCode` - string - response code of the request
- `responseMessage` - string
- `responseTime` - integer - time that it took for the response to arrive (in milliseconds)
- `connectTime` - integer - time to establish the connection (in milliseconds)
- `latency` - integer - (in milliseconds)
- `responseSize` - integer - (in bytes)
- `requestSize` - integer - (in bytes)
- `requestMethod` - string
- `requestURI` - URL string
- `assertions` - list of assertion objects (each object has `name` (string), `isFailed` (bool) and `errorMessage` (string) fields)
- `responseBodySize` - integer
- `requestBodySize` - integer
- `requestCookiesSize` - integer
- `requestHeadersSize` - integer
- `responseHeadersSize` - integer

## `requestBody`, `responseBody` and other potentially huge values

For each functional sample the following files are created in the artifacts dir:
- `sample-{sample_id}-requestBody.bin` - contains request body
- `sample-{sample_id}-responseBody.bin` - contains response body
- `sample-{sample_id}-requestCookies.bin` - contains request cookies
- `sample-{sample_id}-requestHeaders.bin` - contains request headers
- `sample-{sample_id}-responseHeaders.bin` - contains response headers

Note: if no content for the field is extracted (e.g. GET requests have no `requestBody`) - no file will be created for this value.