### PR TITLE
Move node.js tool class into utils

### DIFF
--- a/bzt/modules/selenium.py
+++ b/bzt/modules/selenium.py
@@ -32,7 +32,7 @@ from bzt.modules.aggregator import ConsolidatingAggregator, ResultsReader
 from bzt.modules.console import WidgetProvider, PrioritizedWidget
 from bzt.modules.functional import FunctionalResultsReader, FunctionalAggregator, FunctionalSample
 from bzt.six import string_types, parse, iteritems
-from bzt.utils import RequiredTool, shell_exec, shutdown_process, JavaVM, TclLibrary, PythonGenerator
+from bzt.utils import RequiredTool, shell_exec, shutdown_process, JavaVM, TclLibrary, PythonGenerator, Node
 from bzt.utils import dehumanize_time, MirrorsManager, is_windows, BetterDict, get_full_path, get_files_recursive
 
 try:
@@ -1045,30 +1045,6 @@ class Ruby(RequiredTool):
 
     def install(self):
         raise ToolError("The %s is not operable or not available. Consider installing it" % self.tool_name)
-
-
-class Node(RequiredTool):
-    def __init__(self, parent_logger):
-        super(Node, self).__init__("Node.js", "")
-        self.log = parent_logger.getChild(self.__class__.__name__)
-        self.executable = None
-
-    def check_if_installed(self):
-        node_candidates = ["node", "nodejs"]
-        for candidate in node_candidates:
-            try:
-                self.log.debug("Trying %r", candidate)
-                output = subprocess.check_output([candidate, '--version'], stderr=subprocess.STDOUT)
-                self.log.debug("%s output: %s", candidate, output)
-                self.executable = candidate
-                return True
-            except (CalledProcessError, OSError):
-                self.log.debug("%r is not installed", candidate)
-                continue
-        return False
-
-    def install(self):
-        raise ToolError("Automatic installation of nodejs is not implemented. Install it manually")
 
 
 class NPM(RequiredTool):

--- a/bzt/modules/services.py
+++ b/bzt/modules/services.py
@@ -25,10 +25,9 @@ import json
 
 from bzt import NormalShutdown, ToolError, TaurusConfigError
 from bzt.engine import Service, HavingInstallableTools
-from bzt.modules.selenium import Node
 from bzt.six import get_stacktrace, urlopen, URLError
 from bzt.utils import get_full_path, shutdown_process, shell_exec, RequiredTool
-from bzt.utils import replace_in_config, JavaVM
+from bzt.utils import replace_in_config, JavaVM, Node
 
 
 class Unpacker(Service):

--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -843,6 +843,30 @@ class TclLibrary(RequiredTool):
             self.log.warning("No Tcl library was found")
 
 
+class Node(RequiredTool):
+    def __init__(self, parent_logger):
+        super(Node, self).__init__("Node.js", "")
+        self.log = parent_logger.getChild(self.__class__.__name__)
+        self.executable = None
+
+    def check_if_installed(self):
+        node_candidates = ["node", "nodejs"]
+        for candidate in node_candidates:
+            try:
+                self.log.debug("Trying %r", candidate)
+                output = subprocess.check_output([candidate, '--version'], stderr=subprocess.STDOUT)
+                self.log.debug("%s output: %s", candidate, output)
+                self.executable = candidate
+                return True
+            except (CalledProcessError, OSError):
+                self.log.debug("%r is not installed", candidate)
+                continue
+        return False
+
+    def install(self):
+        raise ToolError("Automatic installation of nodejs is not implemented. Install it manually")
+
+
 class MirrorsManager(object):
     def __init__(self, base_link, parent_logger):
         self.base_link = base_link


### PR DESCRIPTION
It's used by both `selenium.py` and `services.py`, but they shouldn't depend on one another.