### PR TITLE
Move common request model to a toplevel module

### DIFF
--- a/bzt/engine.py
+++ b/bzt/engine.py
@@ -36,7 +36,7 @@ from yaml.representer import SafeRepresenter
 
 import bzt
 from bzt import ManualShutdown, get_configs_dir, TaurusConfigError, TaurusInternalException
-from bzt.requests_model import HTTPRequest, RequestsParser
+from bzt.requests_model import RequestsParser
 from bzt.six import build_opener, install_opener, urlopen, numeric_types, iteritems
 from bzt.six import string_types, text_type, PY2, UserDict, parse, ProxyHandler, reraise
 from bzt.utils import PIPE, shell_exec, get_full_path, ExceptionalDownloader, get_uniq_name

--- a/bzt/engine.py
+++ b/bzt/engine.py
@@ -36,6 +36,7 @@ from yaml.representer import SafeRepresenter
 
 import bzt
 from bzt import ManualShutdown, get_configs_dir, TaurusConfigError, TaurusInternalException
+from bzt.requests_model import HTTPRequest, RequestsParser
 from bzt.six import build_opener, install_opener, urlopen, numeric_types, iteritems
 from bzt.six import string_types, text_type, PY2, UserDict, parse, ProxyHandler, reraise
 from bzt.utils import PIPE, shell_exec, get_full_path, ExceptionalDownloader, get_uniq_name
@@ -1058,59 +1059,8 @@ class Scenario(UserDict, object):
         :type require_url: bool
         :rtype: list[HTTPRequest]
         """
-        requests = self.get("requests", [])
-        for key in range(len(requests)):
-            req = ensure_is_dict(requests, key, "url")
-            if not require_url and "url" not in req:
-                req["url"] = None
-            yield HTTPRequest(config=req, scenario=self, engine=self.engine)
-
-
-class Request(object):
-    def __init__(self, config):
-        self.config = config
-
-
-class HTTPRequest(Request):
-    def __init__(self, config, scenario, engine):
-        self.engine = engine
-        self.log = self.engine.log.getChild(self.__class__.__name__)
-        super(HTTPRequest, self).__init__(config)
-        self.scenario = scenario
-        msg = "Option 'url' is mandatory for request but not found in %s" % config
-        self.url = self.config.get("url", TaurusConfigError(msg))
-        self.label = self.config.get("label", self.url)
-        self.method = self.config.get("method", "GET")
-
-        # TODO: add method to join dicts/lists from scenario/request level?
-        self.headers = self.config.get("headers", {})
-
-        self.keepalive = self.config.get('keepalive', None)
-        self.timeout = self.config.get('timeout', None)
-        self.think_time = self.config.get('think-time', None)
-        self.follow_redirects = self.config.get('follow-redirects', None)
-        self.body = self.__get_body()
-
-    def priority_option(self, name, default=None):
-        val = self.config.get(name, None)
-        if val is None:
-            val = self.scenario.get(name, None)
-        if val is None and default is not None:
-            val = default
-        return val
-
-    def __get_body(self):
-        body = self.config.get('body', None)
-        body_file = self.config.get('body-file', None)
-        if body_file:
-            if body:
-                self.log.warning('body and body-file fields are found, only first will take effect')
-            else:
-                body_file_path = self.engine.find_file(body_file)
-                with open(body_file_path) as fhd:
-                    body = fhd.read()
-
-        return body
+        requests_parser = RequestsParser(self, self.engine)
+        return requests_parser.extract_requests(require_url=require_url)
 
 
 class HavingInstallableTools(object):

--- a/bzt/engine.py
+++ b/bzt/engine.py
@@ -1057,7 +1057,7 @@ class Scenario(UserDict, object):
         Generator object to read requests
 
         :type require_url: bool
-        :rtype: list[HTTPRequest]
+        :rtype: list[bzt.requests_model.Request]
         """
         requests_parser = RequestsParser(self, self.engine)
         return requests_parser.extract_requests(require_url=require_url)

--- a/bzt/modules/ab.py
+++ b/bzt/modules/ab.py
@@ -25,6 +25,7 @@ from bzt import TaurusConfigError, ToolError
 from bzt.engine import ScenarioExecutor, HavingInstallableTools
 from bzt.modules.aggregator import ConsolidatingAggregator, ResultsReader
 from bzt.modules.console import WidgetProvider, ExecutorWidget
+from bzt.requests_model import HTTPRequest
 from bzt.six import iteritems
 from bzt.utils import shell_exec, shutdown_process, RequiredTool, dehumanize_time
 
@@ -69,6 +70,12 @@ class ApacheBenchmarkExecutor(ScenarioExecutor, WidgetProvider, HavingInstallabl
             self.widget = ExecutorWidget(self, "ab: " + label.split('/')[1])
         return self.widget
 
+    def __first_http_request(self):
+        for request in self.scenario.get_requests():
+            if isinstance(request, HTTPRequest):
+                return request
+        return None
+
     def startup(self):
         args = [self.tool_path]
         load = self.get_load()
@@ -89,12 +96,14 @@ class ApacheBenchmarkExecutor(ScenarioExecutor, WidgetProvider, HavingInstallabl
         for key, val in iteritems(self.scenario.get_headers()):
             args += ['-H', "%s: %s" % (key, val)]
 
-        requests = list(self.scenario.get_requests())
+        requests = self.scenario.get_requests()
         if not requests:
             raise TaurusConfigError("You must specify at least one request for ab")
         if len(requests) > 1:
             self.log.warning("ab doesn't support multiple requests. Only first one will be used.")
-        request = requests[0]
+        request = self.__first_http_request()
+        if request is None:
+            raise TaurusConfigError("ab supports only HTTP requests, while scenario doesn't have any")
 
         # add request-specific headers
         for header in request.headers:

--- a/bzt/modules/gatling.py
+++ b/bzt/modules/gatling.py
@@ -24,6 +24,7 @@ from bzt import TaurusConfigError, ToolError
 from bzt.engine import ScenarioExecutor, Scenario, FileLister, HavingInstallableTools
 from bzt.modules.aggregator import ConsolidatingAggregator, ResultsReader
 from bzt.modules.console import WidgetProvider, ExecutorWidget
+from bzt.requests_model import HTTPRequest
 from bzt.utils import BetterDict, TclLibrary, EXE_SUFFIX, dehumanize_time, get_full_path
 from bzt.utils import unzip, shell_exec, RequiredTool, JavaVM, shutdown_process, ensure_is_dict, is_windows
 
@@ -59,6 +60,11 @@ class GatlingScriptBuilder(object):
     def _get_exec(self):
         exec_str = ''
         for req in self.scenario.get_requests():
+            if not isinstance(req, HTTPRequest):
+                msg = "Gatling simulation generator doesn't support '%s' blocks, skipping"
+                self.log.warning(msg, req.NAME)
+                continue
+
             if len(exec_str) > 0:
                 exec_str += '.'
 

--- a/bzt/modules/grinder.py
+++ b/bzt/modules/grinder.py
@@ -20,11 +20,12 @@ import re
 import subprocess
 import time
 
+from bzt import TaurusConfigError, ToolError
 from bzt.engine import ScenarioExecutor, Scenario, FileLister, HavingInstallableTools
 from bzt.modules.aggregator import ConsolidatingAggregator, ResultsReader
 from bzt.modules.console import WidgetProvider, ExecutorWidget
+from bzt.requests_model import HTTPRequest
 from bzt.six import iteritems
-from bzt import TaurusConfigError, ToolError
 from bzt.utils import shell_exec, MirrorsManager, dehumanize_time, get_full_path, PythonGenerator
 from bzt.utils import unzip, RequiredTool, JavaVM, shutdown_process, TclLibrary
 
@@ -504,6 +505,11 @@ from HTTPClient import NVPair
         main_method = self.gen_method_definition("__call__", ["self"], indent=4)
 
         for req in self.scenario.get_requests():
+            if not isinstance(req, HTTPRequest):
+                msg = "Grinder script generator doesn't support '%s' blocks, skipping"
+                self.log.warning(msg, req.NAME)
+                continue
+
             method = req.method.upper()
             url = req.url
             local_headers = req.headers

--- a/bzt/modules/locustio.py
+++ b/bzt/modules/locustio.py
@@ -29,6 +29,7 @@ from bzt.engine import ScenarioExecutor, FileLister, Scenario, HavingInstallable
 from bzt.modules.aggregator import ConsolidatingAggregator, ResultsProvider, DataPoint, KPISet
 from bzt.modules.console import WidgetProvider, ExecutorWidget
 from bzt.modules.jmeter import JTLReader
+from bzt.requests_model import HTTPRequest
 from bzt.six import PY3, iteritems
 from bzt.utils import shutdown_process, RequiredTool, BetterDict, dehumanize_time
 from bzt.utils import get_full_path, ensure_is_dict, PythonGenerator
@@ -338,6 +339,11 @@ from locust import HttpLocust, TaskSet, task
             global_headers['Connection'] = 'close'
 
         for req in self.scenario.get_requests():
+            if not isinstance(req, HTTPRequest):
+                msg = "Locust script generator doesn't support '%s' blocks, skipping"
+                self.log.warning(msg, req.NAME)
+                continue
+
             method = req.method.lower()
             if method not in ('get', 'delete', 'head', 'options', 'path', 'put', 'post'):
                 raise TaurusConfigError("Wrong Locust request type: %s" % method)

--- a/bzt/modules/pbench.py
+++ b/bzt/modules/pbench.py
@@ -34,6 +34,7 @@ from bzt import resources, TaurusConfigError, ToolError, TaurusInternalException
 from bzt.engine import ScenarioExecutor, FileLister, Scenario, HavingInstallableTools
 from bzt.modules.aggregator import ResultsReader, DataPoint, KPISet, ConsolidatingAggregator
 from bzt.modules.console import WidgetProvider, ExecutorWidget
+from bzt.requests_model import HTTPRequest
 from bzt.six import string_types, urlencode, iteritems, parse, StringIO, b, viewvalues
 from bzt.utils import RequiredTool, IncrementableProgressBar
 from bzt.utils import shell_exec, shutdown_process, BetterDict, dehumanize_time
@@ -289,6 +290,11 @@ class PBenchTool(object):
         num_requests = 0
         with open(self.payload_file, 'w') as fds:
             for request in requests:
+                if not isinstance(request, HTTPRequest):
+                    msg = "PBench payload generator doesn't support '%s' blocks, skipping"
+                    self.log.warning(msg, request.NAME)
+                    continue
+
                 http = self._build_request(request, scenario)
                 fds.write("%s %s\r\n%s\r\n" % (len(http), request.label.replace(' ', '_'), http))
                 num_requests += 1

--- a/bzt/modules/selenium.py
+++ b/bzt/modules/selenium.py
@@ -1204,7 +1204,7 @@ from selenium.webdriver.support.wait import WebDriverWait
 
         counter = 0
         methods = {}
-        requests = self.scenario.get_requests(False)
+        requests = self.scenario.get_requests(require_url=False)
         default_address = self.scenario.get("default-address", None)
 
         for req in requests:

--- a/bzt/modules/siege.py
+++ b/bzt/modules/siege.py
@@ -25,6 +25,7 @@ from bzt import TaurusConfigError, ToolError
 from bzt.engine import ScenarioExecutor, Scenario, FileLister, HavingInstallableTools
 from bzt.modules.aggregator import ConsolidatingAggregator, ResultsReader
 from bzt.modules.console import WidgetProvider, ExecutorWidget
+from bzt.requests_model import HTTPRequest
 from bzt.six import iteritems
 from bzt.utils import shell_exec, shutdown_process, RequiredTool, dehumanize_time
 
@@ -87,9 +88,15 @@ class SiegeExecutor(ScenarioExecutor, WidgetProvider, HavingInstallableTools, Fi
         user_vars = self.scenario.get('variables')
         user_vars = ["%s=%s" % (key, val) for (key, val) in iteritems(user_vars)]
 
+        url_list = []
+        for req in self.scenario.get_requests():
+            if not isinstance(req, HTTPRequest):
+                msg = "Siege executor doesn't support '%s' blocks, skipping"
+                self.log.warning(msg, req.NAME)
+                continue
+            url_list.append(req.url)
+
         with open(url_file_name, 'w') as url_file:
-            url_list = list(self.scenario.get_requests())
-            url_list = [req.url for req in url_list]
             url_file.writelines('\n'.join(user_vars + url_list))
             url_file.close()
         return url_file_name

--- a/bzt/modules/tsung.py
+++ b/bzt/modules/tsung.py
@@ -26,6 +26,7 @@ from bzt import TaurusConfigError, ToolError, TaurusInternalException
 from bzt.engine import FileLister, Scenario, ScenarioExecutor, HavingInstallableTools
 from bzt.modules.aggregator import ConsolidatingAggregator, ResultsReader
 from bzt.modules.console import WidgetProvider, ExecutorWidget
+from bzt.requests_model import HTTPRequest
 from bzt.six import etree, parse, iteritems
 from bzt.utils import shell_exec, shutdown_process, RequiredTool, dehumanize_time, which
 
@@ -328,15 +329,21 @@ class TsungConfig(object):
         clients.append(client)
         return clients
 
+    def __first_http_request(self, scenario):
+        for request in scenario.get_requests():
+            if isinstance(request, HTTPRequest):
+                return request
+        return None
+
     def __gen_servers(self, scenario):
         default_address = scenario.get("default-address", None)
         if default_address:
             base_addr = parse.urlparse(default_address)
         else:
-            requests = list(scenario.get_requests())
-            if not requests:
+            first_request = self.__first_http_request(scenario)
+            if not first_request:
                 raise TaurusConfigError("Tsung: you must specify requests in scenario")
-            base_addr = parse.urlparse(requests[0].url)
+            base_addr = parse.urlparse(first_request.url)
             self.log.debug("default-address was not specified, using %s instead", base_addr.hostname)
 
         servers = etree.Element("servers")
@@ -401,6 +408,11 @@ class TsungConfig(object):
         sessions = etree.Element("sessions")
         session = etree.Element("session", name="taurus_requests", probability="100", type="ts_http")
         for request in scenario.get_requests():
+            if not isinstance(request, HTTPRequest):
+                msg = "Tsung config generator doesn't support '%s' blocks, skipping"
+                self.log.warning(msg, request.NAME)
+                continue
+
             request_elem = etree.Element("request")
             http_elem = etree.Element("http", url=request.url, method=request.method, version="1.1")
             if request.body:

--- a/bzt/requests_model.py
+++ b/bzt/requests_model.py
@@ -193,10 +193,10 @@ class RequestsParser(object):
         for key in range(len(raw_requests)):  # pylint: disable=consider-using-enumerate
             if not isinstance(raw_requests[key], dict):
                 req = ensure_is_dict(raw_requests, key, "url")
-                if not require_url and "url" not in req:
-                    req["url"] = None
             else:
                 req = raw_requests[key]
+            if not require_url and "url" not in req:
+                req["url"] = None
             requests.append(self.__parse_request(req))
         return requests
 

--- a/bzt/requests_model.py
+++ b/bzt/requests_model.py
@@ -1,0 +1,298 @@
+import mimetypes
+import re
+
+from bzt import TaurusConfigError, TaurusInternalException
+from bzt.utils import ensure_is_dict, dehumanize_time
+
+
+class Request(object):
+    def __init__(self, config):
+        self.config = config
+
+
+class HTTPRequest(Request):
+    def __init__(self, config, scenario, engine):
+        self.engine = engine
+        self.log = self.engine.log.getChild(self.__class__.__name__)
+        super(HTTPRequest, self).__init__(config)
+        self.scenario = scenario
+        msg = "Option 'url' is mandatory for request but not found in %s" % config
+        self.url = self.config.get("url", TaurusConfigError(msg))
+        self.label = self.config.get("label", self.url)
+        self.method = self.config.get("method", "GET")
+
+        # TODO: add method to join dicts/lists from scenario/request level?
+        self.headers = self.config.get("headers", {})
+
+        self.keepalive = self.config.get('keepalive', None)
+        self.timeout = self.config.get('timeout', None)
+        self.think_time = self.config.get('think-time', None)
+        self.follow_redirects = self.config.get('follow-redirects', None)
+        self.body = self.__get_body()
+
+    def priority_option(self, name, default=None):
+        val = self.config.get(name, None)
+        if val is None:
+            val = self.scenario.get(name, None)
+        if val is None and default is not None:
+            val = default
+        return val
+
+    def __get_body(self):
+        body = self.config.get('body', None)
+        body_file = self.config.get('body-file', None)
+        if body_file:
+            if body:
+                self.log.warning('body and body-file fields are found, only first will take effect')
+            else:
+                body_file_path = self.engine.find_file(body_file)
+                with open(body_file_path) as fhd:
+                    body = fhd.read()
+
+        return body
+
+
+class HierarchicHTTPRequest(HTTPRequest):
+    def __init__(self, config, scenario, engine):
+        super(HierarchicHTTPRequest, self).__init__(config, scenario, engine)
+        self.upload_files = self.config.get("upload-files", [])
+        for file_dict in self.upload_files:
+            file_dict.get("param", TaurusConfigError("Items from upload-files must specify parameter name"))
+            path = file_dict.get('path', TaurusConfigError("Items from upload-files must specify path to file"))
+            mime = mimetypes.guess_type(path)[0] or "application/octet-stream"
+            file_dict.get('mime-type', mime)
+        self.content_encoding = self.config.get('content-encoding', None)
+
+
+class IfBlock(Request):
+    def __init__(self, condition, then_clause, else_clause, config):
+        super(IfBlock, self).__init__(config)
+        self.condition = condition
+        self.then_clause = then_clause
+        self.else_clause = else_clause
+
+    def __repr__(self):
+        then_clause = [repr(req) for req in self.then_clause]
+        else_clause = [repr(req) for req in self.else_clause]
+        return "IfBlock(condition=%s, then=%s, else=%s)" % (self.condition, then_clause, else_clause)
+
+
+class LoopBlock(Request):
+    def __init__(self, loops, requests, config):
+        super(LoopBlock, self).__init__(config)
+        self.loops = loops
+        self.requests = requests
+
+    def __repr__(self):
+        requests = [repr(req) for req in self.requests]
+        return "LoopBlock(loops=%s, requests=%s)" % (self.loops, requests)
+
+
+class WhileBlock(Request):
+    def __init__(self, condition, requests, config):
+        super(WhileBlock, self).__init__(config)
+        self.condition = condition
+        self.requests = requests
+
+    def __repr__(self):
+        requests = [repr(req) for req in self.requests]
+        return "WhileBlock(condition=%s, requests=%s)" % (self.condition, requests)
+
+
+class ForEachBlock(Request):
+    def __init__(self, input_var, loop_var, requests, config):
+        super(ForEachBlock, self).__init__(config)
+        self.input_var = input_var
+        self.loop_var = loop_var
+        self.requests = requests
+
+    def __repr__(self):
+        requests = [repr(req) for req in self.requests]
+        fmt = "ForEachBlock(input=%s, loop_var=%s, requests=%s)"
+        return fmt % (self.input_var, self.loop_var, requests)
+
+
+class TransactionBlock(Request):
+    def __init__(self, name, requests, config):
+        super(TransactionBlock, self).__init__(config)
+        self.name = name
+        self.requests = requests
+
+    def __repr__(self):
+        requests = [repr(req) for req in self.requests]
+        fmt = "TransactionBlock(name=%s, requests=%s)"
+        return fmt % (self.name, requests)
+
+
+class IncludeScenarioBlock(Request):
+    def __init__(self, scenario_name, config):
+        super(IncludeScenarioBlock, self).__init__(config)
+        self.scenario_name = scenario_name
+
+
+class RequestsParser(object):
+    def __init__(self, scenario, engine):
+        self.engine = engine
+        self.scenario = scenario
+
+    def __parse_request(self, req):
+        if 'if' in req:
+            condition = req.get("if")
+
+            # TODO: apply some checks to `condition`?
+            then_clause = req.get("then", TaurusConfigError("'then' clause is mandatory for 'if' blocks"))
+            then_requests = self.__parse_requests(then_clause)
+            else_clause = req.get("else", [])
+            else_requests = self.__parse_requests(else_clause)
+            return IfBlock(condition, then_requests, else_requests, req)
+        elif 'loop' in req:
+            loops = req.get("loop")
+            do_block = req.get("do", TaurusConfigError("'do' option is mandatory for 'loop' blocks"))
+            do_requests = self.__parse_requests(do_block)
+            return LoopBlock(loops, do_requests, req)
+        elif 'while' in req:
+            condition = req.get("while")
+            do_block = req.get("do", TaurusConfigError("'do' option is mandatory for 'while' blocks"))
+            do_requests = self.__parse_requests(do_block)
+            return WhileBlock(condition, do_requests, req)
+        elif 'foreach' in req:
+            iteration_str = req.get("foreach")
+            match = re.match(r'(.+) in (.+)', iteration_str)
+            if not match:
+                msg = "'foreach' value should be in format '<elementName> in <collection>' but '%s' found"
+                raise TaurusConfigError(msg % iteration_str)
+            loop_var, input_var = match.groups()
+            do_block = req.get("do", TaurusConfigError("'do' field is mandatory for 'foreach' blocks"))
+            do_requests = self.__parse_requests(do_block)
+            return ForEachBlock(input_var, loop_var, do_requests, req)
+        elif 'transaction' in req:
+            name = req.get('transaction')
+            do_block = req.get('do', TaurusConfigError("'do' field is mandatory for transaction blocks"))
+            do_requests = self.__parse_requests(do_block)
+            return TransactionBlock(name, do_requests, req)
+        elif 'include-scenario' in req:
+            name = req.get('include-scenario')
+            return IncludeScenarioBlock(name, req)
+        elif 'action' in req:
+            action = req.get('action')
+            if action not in ('pause', 'stop', 'stop-now', 'continue'):
+                raise TaurusConfigError("Action should be either 'pause', 'stop', 'stop-now' or 'continue'")
+            target = req.get('target', 'current-thread')
+            if target not in ('current-thread', 'all-threads'):
+                msg = "Target for action should be either 'current-thread' or 'all-threads' but '%s' found"
+                raise TaurusConfigError(msg % target)
+            duration = req.get('pause-duration', None)
+            if duration is not None:
+                duration = dehumanize_time(duration)
+            return ActionBlock(action, target, duration, req)
+        else:
+            return HierarchicHTTPRequest(req, self.scenario, self.engine)
+
+    def __parse_requests(self, raw_requests, require_url=True):
+        requests = []
+        for key in range(len(raw_requests)):  # pylint: disable=consider-using-enumerate
+            if not isinstance(raw_requests[key], dict):
+                req = ensure_is_dict(raw_requests, key, "url")
+                if not require_url and "url" not in req:
+                    req["url"] = None
+            else:
+                req = raw_requests[key]
+            requests.append(self.__parse_request(req))
+        return requests
+
+    def extract_requests(self, require_url=True):
+        requests = self.scenario.get("requests", [])
+        return self.__parse_requests(requests, require_url=require_url)
+
+
+class ActionBlock(Request):
+    def __init__(self, action, target, duration, config):
+        super(ActionBlock, self).__init__(config)
+        self.action = action
+        self.target = target
+        self.duration = duration
+
+
+class RequestVisitor(object):
+    def __init__(self):
+        self.path = []
+
+    def clear_path_cache(self):
+        self.path = []
+
+    def record_path(self, path):
+        self.path.append(path)
+
+    def visit(self, node):
+        class_name = node.__class__.__name__.lower()
+        visitor = getattr(self, 'visit_' + class_name, None)
+        if visitor is not None:
+            return visitor(node)
+        raise TaurusInternalException("Visitor for class %s not found" % class_name)
+
+
+class ResourceFilesCollector(RequestVisitor):
+    def __init__(self, executor):
+        """
+        :param executor: JMeterExecutor
+        """
+        super(ResourceFilesCollector, self).__init__()
+        self.executor = executor
+
+    def visit_hierarchichttprequest(self, request):
+        files = []
+        body_file = request.config.get('body-file')
+        if body_file:
+            files.append(body_file)
+        if 'jsr223' in request.config:
+            jsrs = request.config.get('jsr223')
+            if isinstance(jsrs, dict):
+                jsrs = [jsrs]
+            for jsr in jsrs:
+                if 'script-file' in jsr:
+                    files.append(jsr.get('script-file'))
+        return files
+
+    def visit_ifblock(self, block):
+        files = []
+        for request in block.then_clause:
+            files.extend(self.visit(request))
+        for request in block.else_clause:
+            files.extend(self.visit(request))
+        return files
+
+    def visit_loopblock(self, block):
+        files = []
+        for request in block.requests:
+            files.extend(self.visit(request))
+        return files
+
+    def visit_whileblock(self, block):
+        files = []
+        for request in block.requests:
+            files.extend(self.visit(request))
+        return files
+
+    def visit_foreachblock(self, block):
+        files = []
+        for request in block.requests:
+            files.extend(self.visit(request))
+        return files
+
+    def visit_transactionblock(self, block):
+        files = []
+        for request in block.requests:
+            files.extend(self.visit(request))
+        return files
+
+    def visit_includescenarioblock(self, block):
+        scenario_name = block.scenario_name
+        if scenario_name in self.path:
+            msg = "Mutual recursion detected in include-scenario blocks (scenario %s)"
+            raise TaurusConfigError(msg % scenario_name)
+        self.record_path(scenario_name)
+        scenario = self.executor.get_scenario(name=block.scenario_name)
+        return self.executor.res_files_from_scenario(scenario)
+
+    def visit_actionblock(self, _):
+        return []

--- a/bzt/requests_model.py
+++ b/bzt/requests_model.py
@@ -6,11 +6,15 @@ from bzt.utils import ensure_is_dict, dehumanize_time
 
 
 class Request(object):
+    NAME = "request"
+
     def __init__(self, config):
         self.config = config
 
 
 class HTTPRequest(Request):
+    NAME = "request"
+
     def __init__(self, config, scenario, engine):
         self.engine = engine
         self.log = self.engine.log.getChild(self.__class__.__name__)
@@ -65,6 +69,8 @@ class HierarchicHTTPRequest(HTTPRequest):
 
 
 class IfBlock(Request):
+    NAME = "if"
+
     def __init__(self, condition, then_clause, else_clause, config):
         super(IfBlock, self).__init__(config)
         self.condition = condition
@@ -78,6 +84,8 @@ class IfBlock(Request):
 
 
 class LoopBlock(Request):
+    NAME = "loop"
+
     def __init__(self, loops, requests, config):
         super(LoopBlock, self).__init__(config)
         self.loops = loops
@@ -89,6 +97,8 @@ class LoopBlock(Request):
 
 
 class WhileBlock(Request):
+    NAME = "while"
+
     def __init__(self, condition, requests, config):
         super(WhileBlock, self).__init__(config)
         self.condition = condition
@@ -100,6 +110,8 @@ class WhileBlock(Request):
 
 
 class ForEachBlock(Request):
+    NAME = "foreach"
+
     def __init__(self, input_var, loop_var, requests, config):
         super(ForEachBlock, self).__init__(config)
         self.input_var = input_var
@@ -113,6 +125,8 @@ class ForEachBlock(Request):
 
 
 class TransactionBlock(Request):
+    NAME = "transaction"
+
     def __init__(self, name, requests, config):
         super(TransactionBlock, self).__init__(config)
         self.name = name
@@ -125,6 +139,8 @@ class TransactionBlock(Request):
 
 
 class IncludeScenarioBlock(Request):
+    NAME = "include-scenario"
+
     def __init__(self, scenario_name, config):
         super(IncludeScenarioBlock, self).__init__(config)
         self.scenario_name = scenario_name


### PR DESCRIPTION
Checklist:
- [x] move JMeter's requests to a toplevel module
- [x] double check all executors that perform script/config generation:
  - [x] JMeter
  - [x] AB
  - [x] Gatling
  - [x] Grinder
  - [x] Locust.io
  - [x] PBench
  - [x] Selenium
  - [x] Siege
  - [x] Tsung
- [x] Make executors that support only plain requests complain when seeing unsupported request block types (`include-scenario`, `if`, etc)