### PR TITLE
Include thread group name and thread id into functional report data

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1122,6 +1122,10 @@ class FuncJTLReader(FunctionalResultsReader):
         resp_headers = sample_elem.findtext("responseHeader") or ""
         req_cookies = sample_elem.findtext("cookies") or ""
 
+        thread_id = sample_elem.get("tn")
+        split = thread_id.split("-")
+        thread_group = "-".join(split[:-1])
+
         sample_extras = {
             "responseCode": sample_elem.get("rc"),
             "responseMessage": sample_elem.get("rm"),
@@ -1132,6 +1136,9 @@ class FuncJTLReader(FunctionalResultsReader):
             "requestSize": int(sample_elem.get("sby") or 0),
             "requestMethod": method,
             "requestURI": uri,
+
+            "threadId": thread_id,
+            "threadGroup": thread_group,
 
             "assertions": self._extract_sample_assertions(sample_elem),
             "requestHeaders": self._parse_http_headers(req_headers),

--- a/site/dat/docs/changes/jmeter-func-report-thread-id.change
+++ b/site/dat/docs/changes/jmeter-func-report-thread-id.change
@@ -1,0 +1,1 @@
+Include thread group name and thread id in functional report data

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -1941,6 +1941,7 @@ class TestJMeterExecutor(BZTestCase):
             'requestHeaders', 'requestMethod', 'requestSize', 'requestURI',
             'responseBody', 'responseBodySize', 'responseCode', 'responseHeaders',
             'responseMessage', 'responseSize',
+            "threadId", "threadGroup",
         ]
         for field in set(fields) - set(FuncJTLReader.FILE_EXTRACTED_FIELDS):
             self.assertIn(field, sample.extras)


### PR DESCRIPTION
New fields: `threadGroup` and `threadId`.