### PR TITLE
Task/wap 8626/replace config flag with yml flag

### DIFF
--- a/bzt/modules/blazemeter.py
+++ b/bzt/modules/blazemeter.py
@@ -1195,7 +1195,7 @@ class CloudCollectionTest(BaseCloudTest):
         for key in list(config.keys()):
             fields = ("scenarios", ScenarioExecutor.EXEC, Service.SERV,
                       CloudProvisioning.LOC, CloudProvisioning.LOC_WEIGHTED,
-                      CloudProvisioning.DEDICATED_IPS_ENABLED)
+                      CloudProvisioning.DEDICATED_IPS)
             if key not in fields:
                 config.pop(key)
             elif not config[key]:
@@ -1389,7 +1389,7 @@ class CloudProvisioning(MasterProvisioning, WidgetProvider):
 
     LOC = "locations"
     LOC_WEIGHTED = "locations-weighted"
-    DEDICATED_IPS_ENABLED = "dedicated-ips-enabled"
+    DEDICATED_IPS = "dedicated-ips"
 
     def __init__(self):
         super(CloudProvisioning, self).__init__()

--- a/bzt/modules/blazemeter.py
+++ b/bzt/modules/blazemeter.py
@@ -1194,7 +1194,8 @@ class CloudCollectionTest(BaseCloudTest):
 
         for key in list(config.keys()):
             fields = ("scenarios", ScenarioExecutor.EXEC, Service.SERV,
-                      CloudProvisioning.LOC, CloudProvisioning.LOC_WEIGHTED)
+                      CloudProvisioning.LOC, CloudProvisioning.LOC_WEIGHTED,
+                      CloudProvisioning.DEDICATED_IPS_ENABLED)
             if key not in fields:
                 config.pop(key)
             elif not config[key]:
@@ -1388,6 +1389,7 @@ class CloudProvisioning(MasterProvisioning, WidgetProvider):
 
     LOC = "locations"
     LOC_WEIGHTED = "locations-weighted"
+    DEDICATED_IPS_ENABLED = "dedicated-ips-enabled"
 
     def __init__(self):
         super(CloudProvisioning, self).__init__()

--- a/bzt/modules/blazemeter.py
+++ b/bzt/modules/blazemeter.py
@@ -29,10 +29,10 @@ from ssl import SSLError
 
 import os
 import yaml
+from bzt import TaurusInternalException, TaurusConfigError, TaurusException, TaurusNetworkError, NormalShutdown
 from requests.exceptions import ReadTimeout
 from urwid import Pile, Text
 
-from bzt import TaurusInternalException, TaurusConfigError, TaurusException, TaurusNetworkError, NormalShutdown
 from bzt.bza import User, Session, Test
 from bzt.engine import Reporter, Provisioning, ScenarioExecutor, Configuration, Service, Singletone
 from bzt.modules.aggregator import DataPoint, KPISet, ConsolidatingAggregator, ResultsProvider, AggregatorListener
@@ -912,7 +912,6 @@ class ProjectFinder(object):
         router = test_class(self.user, test, project, test_name, default_location, self.log)
         router._workspaces = self.workspaces
         router.cloud_mode = self.settings.get("cloud-mode", None)
-        router.dedicated_ips = self.settings.get("dedicated-ips", False)
         return router
 
     def _default_or_create_project(self, proj_name):
@@ -949,7 +948,6 @@ class BaseCloudTest(object):
         self.master = None
         self._workspaces = None
         self.cloud_mode = None
-        self.dedicated_ips = False
 
     @abstractmethod
     def prepare_locations(self, executors, engine_config):
@@ -1096,9 +1094,7 @@ class CloudTaurusTest(BaseCloudTest):
 
         taurus_config = yaml.dump(taurus_config, default_flow_style=False, explicit_start=True, canonical=False)
         self._test.upload_files(taurus_config, rfiles)
-
-        props = {'configuration': {'executionType': self.cloud_mode, 'dedicatedIpsEnabled': self.dedicated_ips}}
-        self._test.update_props(props)
+        self._test.update_props({'configuration': {'executionType': self.cloud_mode}})
 
     def launch_test(self):
         self.log.info("Initiating cloud test with %s ...", self._test.address)
@@ -1228,12 +1224,8 @@ class CloudCollectionTest(BaseCloudTest):
             raise TaurusInternalException()  # TODO: build unit test to catch this situation
 
         collection_draft = self._user.collection_draft(self._test_name, taurus_config, rfiles)
-        for item in collection_draft['items']:
-            item['test']['configuration']['dedicatedIpsEnabled'] = self.dedicated_ips
-            test = Test(self._user, {'id': item['test']['id']})
-            props = {'configuration': {'dedicatedIpsEnabled': self.dedicated_ips}}
-            test.update_props(props)
         if self._test is None:
+
             self.log.debug("Creating cloud collection test")
             self._test = self._project.create_multi_test(collection_draft)
         else:

--- a/examples/jmeter/stepping.yml
+++ b/examples/jmeter/stepping.yml
@@ -13,7 +13,6 @@ execution:
 scenarios:
   simple:
     think-time: 500ms
-    timeout: 1500ms
     requests:
     - http://blazedemo.com
     - url: http://blazedemo.com/vacation.html

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.9.2 <sup>14 may 2017</sup>
+## 1.9.2
  - fix grinder having 100% errors
  - extract apiritif into standalone PyPi project
  - improve console message in case of BZA failed response

--- a/site/dat/docs/Cloud.md
+++ b/site/dat/docs/Cloud.md
@@ -175,6 +175,15 @@ services:
   - pip install -r requirements.txt
 ```
 
+## Enabling Dedicated IPs Feature
+
+When your account in BlazeMeter allows you to use "Dedicated IPs" feature, you can enable it by setting in config file:
+```yaml
+modules:
+  blazemeter:
+    dedicated-ips: true
+```
+
 ## Worker Number Info
 
 There is a way to obtain worker index which can be used to coordinate distributed test data. For example, you can make sure that different workers will use different user logins or CSV file parts. To achieve that, you get some `env` variables for `shellexec` modules and some `properties` for `jmeter` module:
@@ -192,15 +201,3 @@ Please note that for `cloud` provisioning actual Taurus execution will be done o
   * only following config sections are passed into cloud: `scenarios`, `execution`, `services`
   * `shellexec` module has `artifacts-dir` set as `default-cwd`
   * cloud workers execute Taurus under isolated [virtualenv](https://virtualenv.readthedocs.org/en/latest/)
-
-## Dedicated Ips
-
-If you wish to use dedicated ips, ensure that you have enough of them assigned to the Blazemeter workspace you are using.
-Dedicated ips must be in "idle" (available) state in order to get attached to your test engines.
-For each location, dedicated ips will only be used if enough are available for all the engines/sessions.
-Defaults to false.
-
-Example:
-```yaml
-dedicated-ips: true
-```

--- a/site/dat/docs/Cloud.md
+++ b/site/dat/docs/Cloud.md
@@ -175,15 +175,6 @@ services:
   - pip install -r requirements.txt
 ```
 
-## Enabling Dedicated IPs Feature
-
-When your account in BlazeMeter allows you to use "Dedicated IPs" feature, you can enable it by setting in config file:
-```yaml
-modules:
-  blazemeter:
-    dedicated-ips: true
-```
-
 ## Worker Number Info
 
 There is a way to obtain worker index which can be used to coordinate distributed test data. For example, you can make sure that different workers will use different user logins or CSV file parts. To achieve that, you get some `env` variables for `shellexec` modules and some `properties` for `jmeter` module:

--- a/site/dat/docs/Cloud.md
+++ b/site/dat/docs/Cloud.md
@@ -192,3 +192,15 @@ Please note that for `cloud` provisioning actual Taurus execution will be done o
   * only following config sections are passed into cloud: `scenarios`, `execution`, `services`
   * `shellexec` module has `artifacts-dir` set as `default-cwd`
   * cloud workers execute Taurus under isolated [virtualenv](https://virtualenv.readthedocs.org/en/latest/)
+
+## Dedicated Ips
+
+If you wish to use dedicated ips, ensure that you have enough of them assigned to the Blazemeter workspace you are using.
+Dedicated ips must be in "idle" (available) state in order to get attached to your test engines.
+For each location, dedicated ips will only be used if enough are available for all the engines/sessions.
+Defaults to false.
+
+Example:
+```yaml
+dedicated-ips: true
+```

--- a/tests/modules/test_cloudProvisioning.py
+++ b/tests/modules/test_cloudProvisioning.py
@@ -485,7 +485,7 @@ class TestCloudProvisioning(BZTestCase):
             }
         )
 
-        self.obj.settings.merge({"delete-test-files": False, "use-deprecated-api": False})
+        self.obj.settings.merge({"delete-test-files": False, "use-deprecated-api": False, 'dedicated-ips': True})
 
         self.obj.prepare()
         self.assertIsInstance(self.obj.router, CloudCollectionTest)

--- a/tests/modules/test_cloudProvisioning.py
+++ b/tests/modules/test_cloudProvisioning.py
@@ -1,9 +1,9 @@
 import json
+import os
 import shutil
 import tempfile
 import time
 
-import os
 import yaml
 
 from bzt import TaurusConfigError, TaurusException, NormalShutdown
@@ -367,48 +367,9 @@ class TestCloudProvisioning(BZTestCase):
             },
             post={
                 'https://a.blazemeter.com/api/v4/web/elfinder/taurus_%s' % id(self.obj.user.token): {},
-                'https://a.blazemeter.com/api/v4/multi-tests/taurus-import': {
-                    "api_version": 4,
-                    "error": None,
-                    "result": {
-                        "id": None,
-                        "name": "Taurus Collection",
-                        "collectionType": "taurus",
-                        "items": [
-                            {
-                                "testId": 5619096,
-                                "test": {
-                                    "id": 1,
-                                    "name": "us-east-1 / some",
-                                    "userId": 346988,
-                                    "created": 1495459777,
-                                    "updated": 1495459777,
-                                    "configuration": {
-                                        "location": "us-east-1",
-                                        "consoleSize": "m3.large",
-                                        "enginesSize": "m3.large",
-                                        "type": "taurus session",
-                                        "indexOffset": 0,
-                                        "collectionIndexOffset": 0,
-                                        "concurrency": 10,
-                                        "delayedStart": False,
-                                        "dedicatedIpsEnabled": False,
-                                        "javaVersion": "1.8",
-                                        "plugins": {
-                                            "taurus": {
-                                                "filename": "taurus.json"
-                                            }
-                                        }
-                                    }
-                                },
-                                "location": "us-east-1"
-                            }
-                        ],
-                        "filesToSplit": [],
-                        "dataFiles": [],
-                        "projectId": 179074
-                    }
-                },
+                'https://a.blazemeter.com/api/v4/multi-tests/taurus-import': {"result": {
+                    "name": "Taurus Collection", "items": []
+                }},
                 'https://a.blazemeter.com/api/v4/multi-tests': {"result": {"id": 1}},
                 'https://a.blazemeter.com/api/v4/multi-tests/1/start?delayedStart=true': {"result": {"id": 1}}
             }
@@ -424,8 +385,6 @@ class TestCloudProvisioning(BZTestCase):
         self.obj.check()
         self.obj.shutdown()
         self.obj.post_process()
-        data = json.loads(self.mock.requests[11]['data'])
-        self.assertFalse(data['items'][0]['test']['configuration']['dedicatedIpsEnabled'])
 
     def test_create_project(self):
         self.configure(engine_cfg={ScenarioExecutor.EXEC: {"executor": "mock"}}, )
@@ -519,19 +478,17 @@ class TestCloudProvisioning(BZTestCase):
             post={
                 'https://a.blazemeter.com/api/v4/web/elfinder/taurus_%s' % id(self.obj.user.token): {},
                 'https://a.blazemeter.com/api/v4/multi-tests/taurus-import': {"result": {
-                    "name": "Taurus Collection", "items": [{"test": {"id": 1, "configuration": {}}}]
+                    "name": "Taurus Collection", "items": []
                 }},
                 'https://a.blazemeter.com/api/v4/multi-tests/1': {},
                 'https://a.blazemeter.com/api/v4/multi-tests': {"result": {}}
             }
         )
 
-        self.obj.settings.merge({"delete-test-files": False, "use-deprecated-api": False, 'dedicated-ips': True})
+        self.obj.settings.merge({"delete-test-files": False, "use-deprecated-api": False})
 
         self.obj.prepare()
         self.assertIsInstance(self.obj.router, CloudCollectionTest)
-        data = json.loads(self.mock.requests[11]['data'])
-        self.assertTrue(data['items'][0]['test']['configuration']['dedicatedIpsEnabled'])
 
     def test_toplevel_locations(self):
         self.obj.user.token = object()
@@ -881,10 +838,10 @@ class TestCloudProvisioning(BZTestCase):
                 'file-in-home-15.xml',  # 21 (testng-xml)
                 'file-in-home-16.java',  # 21 (script)
                 'bd_scenarios.js',  # 22 (script)
-                'file-in-home-17.js',  # 23 (sript)
+                'file-in-home-17.js',   # 23 (sript)
                 'example_spec.rb',  # 24 (script)
                 'file-in-home-18.rb',  # 25 (sript)
-                'file-in-home-19.jar'  # global testng settings (additional-classpath)
+                'file-in-home-19.jar'   # global testng settings (additional-classpath)
             })
         finally:
             os.environ['HOME'] = back_home


### PR DESCRIPTION
The previous attempt to enable dedicated ips resulted in multiple issues on bza side.

The api call to taurus-import is what creates the tests and therefore it is the preferred place to introduce this flag, which means that it needs to come from the yml file.