### PR TITLE
fix win/mac verbose logging in nose tester

### DIFF
--- a/bzt/modules/proxy2jmx.py
+++ b/bzt/modules/proxy2jmx.py
@@ -17,7 +17,6 @@ limitations under the License.
 """
 
 import shutil
-import sys
 from os.path import join, isfile
 
 import os
@@ -26,7 +25,7 @@ from bzt import TaurusConfigError, TaurusInternalException
 from bzt.bza import BZAProxy
 from bzt.engine import Service, Singletone
 from bzt.modules.selenium import AbstractSeleniumExecutor
-from bzt.utils import is_windows, get_full_path
+from bzt.utils import is_windows, is_linux, get_full_path
 
 
 class Proxy2JMX(Service, Singletone):
@@ -58,9 +57,8 @@ class Proxy2JMX(Service, Singletone):
         self.log.info('Starting BlazeMeter recorder...')
 
         labels = []
-        is_linux = 'linux' in sys.platform.lower()
         additional_env = {}
-        if is_linux:
+        if is_linux():
             self.log.info('Set proxy for selenium: %s', self.proxy_addr)
             additional_env.update({'http_proxy': self.proxy_addr,  # set vars anyway for case
                                   'https_proxy': self.proxy_addr,  # linux system can't say correct name

--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -17,7 +17,6 @@ import ast
 import copy
 import os
 import re
-import select
 import sys
 from abc import abstractmethod
 from collections import OrderedDict
@@ -114,11 +113,11 @@ class NoseTester(SubprocessedExecutor, HavingInstallableTools):
 
     def post_process(self):
         super(NoseTester, self).post_process()
-        self.__log_lines(True)
+        self.__log_lines()
 
-    def __log_lines(self, force=False):
+    def __log_lines(self):
         lines = []
-        for line in self._tailer.get_lines(force):
+        for line in self._tailer.get_lines():
             if not IGNORED_LINE.match(line):
                 lines.append(line)
 
@@ -384,17 +383,10 @@ class FileTailer(NoneTailer):
     def __init__(self, filename):
         super(FileTailer, self).__init__()
         self._fds = open(filename)
-        self._poller = select.poll()
-        self._poller.register(self._fds)
 
-    def get_lines(self, force=False):
-        readable = self._poller.poll(0)
-        for _, _ in readable:
-            yield self._fds.readline().rstrip()
-
-        if force:
-            for line in self._fds.readlines():
-                yield line.rstrip()
+    def get_lines(self):
+        for line in self._fds.readlines():
+            yield line.rstrip()
 
     def __del__(self):
         if self._fds:

--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -30,7 +30,7 @@ from bzt.modules import SubprocessedExecutor
 from bzt.requests_model import HTTPRequest
 from bzt.six import parse, string_types, iteritems
 from bzt.utils import get_full_path, TclLibrary, RequiredTool, PythonGenerator, dehumanize_time
-from bzt.utils import BetterDict, ensure_is_dict, is_linux
+from bzt.utils import BetterDict, ensure_is_dict
 
 IGNORED_LINE = re.compile(r"[^,]+,Total:\d+ Passed:\d+ Failed:\d+")
 
@@ -104,7 +104,7 @@ class NoseTester(SubprocessedExecutor, HavingInstallableTools):
         nose_command_line += [self.script]
         self._start_subprocess(nose_command_line)
 
-        if self.__is_verbose() and is_linux():
+        if self.__is_verbose():
             self._tailer = FileTailer(self.stdout_file)
 
     def check(self):

--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -31,7 +31,7 @@ from bzt.modules import SubprocessedExecutor
 from bzt.requests_model import HTTPRequest
 from bzt.six import parse, string_types, iteritems
 from bzt.utils import get_full_path, TclLibrary, RequiredTool, PythonGenerator, dehumanize_time
-from bzt.utils import BetterDict, ensure_is_dict
+from bzt.utils import BetterDict, ensure_is_dict, is_linux
 
 IGNORED_LINE = re.compile(r"[^,]+,Total:\d+ Passed:\d+ Failed:\d+")
 
@@ -105,7 +105,7 @@ class NoseTester(SubprocessedExecutor, HavingInstallableTools):
         nose_command_line += [self.script]
         self._start_subprocess(nose_command_line)
 
-        if self.__is_verbose():
+        if self.__is_verbose() and is_linux():
             self._tailer = FileTailer(self.stdout_file)
 
     def check(self):

--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -373,7 +373,7 @@ from selenium.webdriver.support.wait import WebDriverWait
 
 
 class NoneTailer(object):
-    def get_lines(self, force=False):
+    def get_lines(self):
         if False:
             yield ''
         return

--- a/bzt/modules/selenium.py
+++ b/bzt/modules/selenium.py
@@ -210,6 +210,7 @@ class SeleniumExecutor(AbstractSeleniumExecutor, WidgetProvider, FileLister):
 
     def post_process(self):
         self.virtual_display_service.post_process()
+        self.runner.post_process()
 
         if os.path.exists("geckodriver.log"):
             self.engine.existing_artifact("geckodriver.log", True)

--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -958,6 +958,10 @@ def is_windows():
     return platform.system() == 'Windows'
 
 
+def is_linux():
+    return 'linux' in sys.platform.lower()
+
+
 EXE_SUFFIX = ".bat" if is_windows() else ".sh"
 
 

--- a/tests/modules/test_proxy2jmx.py
+++ b/tests/modules/test_proxy2jmx.py
@@ -1,12 +1,11 @@
 import os
-import sys
 import json
 import shutil
 
 from bzt import TaurusConfigError
 from bzt.modules.proxy2jmx import Proxy2JMX, BZAProxy
 from bzt.modules.selenium import SeleniumExecutor
-from bzt.utils import is_windows, get_full_path
+from bzt.utils import is_windows, is_linux, get_full_path
 from tests import BZTestCase
 from tests.mocks import EngineEmul
 from os.path import join
@@ -179,8 +178,7 @@ class TestProxy2JMX(BZTestCase):
 
         self.obj.prepare()
         self.obj.engine.provisioning.executors = [SeleniumExecutor()]
-        is_linux = 'linux' in sys.platform.lower()
-        if is_linux:
+        if is_linux():
             self._check_linux()
         elif is_windows():
             self._check_windows()


### PR DESCRIPTION
fix for the following issue:
Taurus fails under mac/win in verbose logging mode because of limitation of select python module. (poll is supported only on linux)