### PR TITLE
Fix a crash when using Python 3 and reporting to BM with token

### DIFF
--- a/bzt/bza.py
+++ b/bzt/bza.py
@@ -61,7 +61,11 @@ class BZAObject(dict):
         headers["X-Client-Version"] = VERSION
 
         if isinstance(self.token, string_types) and ':' in self.token:
-            headers['Authorization'] = 'Basic ' + base64.b64encode(self.token)
+            token = self.token
+            if isinstance(token, text_type):
+                token = token.encode('ascii')
+            token = base64.b64encode(token).decode('ascii')
+            headers['Authorization'] = 'Basic ' + token
         elif self.token:
             headers["X-Api-Key"] = self.token
 

--- a/site/dat/docs/changes/fix-py3-bza-token-crash.change
+++ b/site/dat/docs/changes/fix-py3-bza-token-crash.change
@@ -1,0 +1,1 @@
+Fix a crash when using Python 3 and reporting to BM with token

--- a/tests/test_bza.py
+++ b/tests/test_bza.py
@@ -1,0 +1,14 @@
+#encoding: utf-8
+from unittest import skipUnless
+
+from bzt.bza import User
+from bzt.six import PY3, text_type
+from tests import BZTestCase
+
+
+class TestBZAClient(BZTestCase):
+    @skipUnless(PY3, "Py3-only test")
+    def test_bza_py3_unicode_token(self):
+        user = User()
+        user.token = text_type("something:something")
+        user.ping()

--- a/tests/test_bza.py
+++ b/tests/test_bza.py
@@ -3,11 +3,18 @@ from unittest import skipUnless
 from bzt.bza import User
 from bzt.six import PY3, text_type
 from tests import BZTestCase
+from tests.mocks import BZMock
 
 
 class TestBZAClient(BZTestCase):
     @skipUnless(PY3, "Py3-only test")
     def test_bza_py3_unicode_token(self):
+        mock = BZMock()
+        mock.mock_get.update({
+            'https://a.blazemeter.com/api/v4/web/version': {"result": {}},
+        })
+
         user = User()
+        mock.apply(user)
         user.token = text_type("something:something")
         user.ping()

--- a/tests/test_bza.py
+++ b/tests/test_bza.py
@@ -1,4 +1,3 @@
-#encoding: utf-8
 from unittest import skipUnless
 
 from bzt.bza import User


### PR DESCRIPTION
Python3-specific, `b64encode(str)` requires bytestring to be passed inside, while we were passing normal unicode string.