### PR TITLE
Use JMeter-2.13-compatible name for 'bytes' option for trace writing

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -155,8 +155,14 @@ class JMeterExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInstall
             else:
                 raise TaurusConfigError("You must specify either a JMX file or list of requests to run JMeter")
 
-        if isinstance(self.engine.aggregator, FunctionalAggregator):
-            self.settings.merge({"xml-jtl-flags": {"connectTime": True, "sentBytes": True}})
+        if self.engine.aggregator.is_functional:
+            flags = {"connectTime": True}
+            version = str(self.settings.get("version", self.JMETER_VER))
+            if version.startswith("2"):
+                flags["bytes"] = True
+            else:
+                flags["sentBytes"] = True
+            self.settings.merge({"xml-jtl-flags": flags})
 
         load = self.get_load()
 

--- a/site/dat/docs/changes/fix-jmeter-2.13-functional-mode.change
+++ b/site/dat/docs/changes/fix-jmeter-2.13-functional-mode.change
@@ -1,0 +1,1 @@
+Fix usage of JMeter 2.13 in functional mode

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -48,8 +48,8 @@ class TestJMeterExecutor(BZTestCase):
         self.obj = get_jmeter()
 
     def tearDown(self):
-        # if self.obj.modified_jmx and os.path.exists(self.obj.modified_jmx):
-        #     os.remove(self.obj.modified_jmx)
+        if self.obj.modified_jmx and os.path.exists(self.obj.modified_jmx):
+            os.remove(self.obj.modified_jmx)
         super(TestJMeterExecutor, self).tearDown()
 
     def configure(self, config):

--- a/tests/modules/test_JMeterExecutor.py
+++ b/tests/modules/test_JMeterExecutor.py
@@ -48,8 +48,8 @@ class TestJMeterExecutor(BZTestCase):
         self.obj = get_jmeter()
 
     def tearDown(self):
-        if self.obj.modified_jmx and os.path.exists(self.obj.modified_jmx):
-            os.remove(self.obj.modified_jmx)
+        # if self.obj.modified_jmx and os.path.exists(self.obj.modified_jmx):
+        #     os.remove(self.obj.modified_jmx)
         super(TestJMeterExecutor, self).tearDown()
 
     def configure(self, config):
@@ -1949,7 +1949,7 @@ class TestJMeterExecutor(BZTestCase):
         varnames = dataset.find('stringProp[@name="variableNames"]')
         self.assertEqual(varnames.text, "a,b,c")
 
-    def test_functional_mode_flag(self):
+    def test_func_mode_jmeter_2_13(self):
         self.obj.engine.aggregator.is_functional = True
         self.obj.execution.merge({
             'scenario': {
@@ -1958,12 +1958,34 @@ class TestJMeterExecutor(BZTestCase):
                 ],
             }
         })
-        self.obj.execution.merge(self.obj.engine.config)
+        self.obj.settings.merge({"version": "2.13"})
         self.obj.prepare()
         xml_tree = etree.fromstring(open(self.obj.modified_jmx, "rb").read())
         functional_switch = xml_tree.find('.//TestPlan/boolProp[@name="TestPlan.functional_mode"]')
-        self.assertIsNotNone(functional_switch)
         self.assertEqual(functional_switch.text, "true")
+        connect_time_flag = xml_tree.find('.//ResultCollector/objProp/value/connectTime')
+        self.assertEqual(connect_time_flag.text, "true")
+        bytes_flag = xml_tree.find('.//ResultCollector/objProp/value/bytes')  # 'bytes' in JMeter 2.13
+        self.assertEqual(bytes_flag.text, "true")
+
+    def test_func_mode_jmeter_3_xx(self):
+        self.obj.engine.aggregator.is_functional = True
+        self.obj.execution.merge({
+            'scenario': {
+                "requests": [
+                    "http://example.com/",
+                ],
+            }
+        })
+        self.obj.settings.merge({"version": "3.2"})
+        self.obj.prepare()
+        xml_tree = etree.fromstring(open(self.obj.modified_jmx, "rb").read())
+        functional_switch = xml_tree.find('.//TestPlan/boolProp[@name="TestPlan.functional_mode"]')
+        self.assertEqual(functional_switch.text, "true")
+        connect_time_flag = xml_tree.find('.//ResultCollector/objProp/value/connectTime')
+        self.assertEqual(connect_time_flag.text, "true")
+        bytes_flag = xml_tree.find('.//ResultCollector/objProp/value/sentBytes')  # 'sentBytes' since JMeter 3
+        self.assertEqual(bytes_flag.text, "true")
 
     def test_functional_reader_pass(self):
         engine_obj = EngineEmul()


### PR DESCRIPTION
This fixes usage of JMeter 2.13 in functional mode