### PR TITLE
A couple of fixes for Selenium runners

### DIFF
--- a/bzt/modules/javascript.py
+++ b/bzt/modules/javascript.py
@@ -54,7 +54,7 @@ class MochaTester(SubprocessedExecutor, HavingInstallableTools):
 
         self.tools_dir = get_full_path(self.settings.get("tools-dir", self.tools_dir))
         self.install_required_tools()
-        self.reporting_setup(suffix='ldjson')
+        self.reporting_setup(suffix='.ldjson')
 
     def install_required_tools(self):
         tools = []

--- a/bzt/modules/ruby.py
+++ b/bzt/modules/ruby.py
@@ -43,7 +43,7 @@ class RSpecTester(SubprocessedExecutor, HavingInstallableTools):
         if not self._script:
             raise TaurusConfigError("Script not passed to runner %s" % self)
 
-        self.reporting_setup(suffix='ldjson')
+        self.reporting_setup(suffix='.ldjson')
 
     def install_required_tools(self):
         tools = []

--- a/bzt/modules/ruby.py
+++ b/bzt/modules/ruby.py
@@ -34,13 +34,13 @@ class RSpecTester(SubprocessedExecutor, HavingInstallableTools):
         self.plugin_path = os.path.join(get_full_path(__file__, step_up=2),
                                         "resources",
                                         "rspec_taurus_plugin.rb")
-        self._script = None
+        self.script = None
 
     def prepare(self):
         super(RSpecTester, self).prepare()
         self.install_required_tools()
-        self._script = self.get_script_path()
-        if not self._script:
+        self.script = self.get_script_path()
+        if not self.script:
             raise TaurusConfigError("Script not passed to runner %s" % self)
 
         self.reporting_setup(suffix='.ldjson')
@@ -65,7 +65,7 @@ class RSpecTester(SubprocessedExecutor, HavingInstallableTools):
             "--report-file",
             self.report_file,
             "--test-suite",
-            self._script
+            self.script
         ]
         load = self.get_load()
         if load.iterations:

--- a/bzt/resources/rspec_taurus_plugin.rb
+++ b/bzt/resources/rspec_taurus_plugin.rb
@@ -47,7 +47,7 @@ class TaurusFormatter
             :status => "PASSED",
             :error_msg => nil,
             :error_trace => nil,
-            :extras => nil}
+            :extras => {}}
     # TODO: location
     @tests_passed += 1
     report_stdout item
@@ -65,7 +65,7 @@ class TaurusFormatter
             :error_msg => exception.to_s.split(" ").join(" "),
             :error_trace => exception.backtrace.nil? ? nil : exception.backtrace.join("\n"),
             :status => "FAILED",
-            :extras => nil}
+            :extras => {}}
     @report << item.to_json << "\n"
     report_stdout item
   end
@@ -80,7 +80,7 @@ class TaurusFormatter
             :status => "SKIPPED",
             :error_msg => nil,
             :error_trace => nil,
-            :extras => nil}
+            :extras => {}}
     @report << item.to_json << "\n"
     @tests_passed += 1
     report_stdout item

--- a/site/dat/docs/changes/fix-rspec-for-cloud-functional-tests.change
+++ b/site/dat/docs/changes/fix-rspec-for-cloud-functional-tests.change
@@ -1,0 +1,1 @@
+Fix RSpec for cloud functional tests

--- a/tests/modules/selenium/test_ruby.py
+++ b/tests/modules/selenium/test_ruby.py
@@ -85,3 +85,27 @@ class TestSeleniumRSpecRunner(SeleniumTestCase):
         dummy += '.bat' if is_windows() else ''
         self.obj.settings.merge({"interpreter": dummy})
         self.obj.prepare()
+
+    def test_rspec_report_extras(self):
+        # NOTE: cloud functional tests rely on sample['extras'] being a dict
+        # this test verifies it
+        self.configure({
+            'execution': {
+                'iterations': 1,
+                'scenario': {'script': __dir__() + '/../../resources/selenium/ruby/example_spec.rb'},
+                'executor': 'selenium'
+            },
+        })
+        self.obj.settings.merge(self.obj.engine.config.get("modules").get("selenium"))
+        self.obj.prepare()
+        self.obj.startup()
+        while not self.obj.check():
+            time.sleep(1)
+        self.obj.shutdown()
+        self.assertTrue(os.path.exists(self.obj.runner.report_file))
+        lines = open(self.obj.runner.report_file).readlines()
+        self.assertEqual(len(lines), 3)
+        for line in lines:
+            sample = json.loads(line)
+            self.assertIsNotNone(sample['extras'])
+            self.assertIsInstance(sample['extras'], dict)


### PR DESCRIPTION
1. Save report files to `.ldjson` files (minor fix)
2. Fix RSpec's Selenium widget handling that was crashing the test
3. Ensure that `sample['extras']` is a dictionary, as for all other Selenium-targeted executors.

The last one could also be fixed at `taurus-cloud` side of things.