### PR TITLE
Make windows installer use Python 3 by default

### DIFF
--- a/build-windows-installer.sh
+++ b/build-windows-installer.sh
@@ -23,7 +23,7 @@ BASE_BUILD_FILE=$(basename "$BUILD_FILE")
 
 # create NSIS script
 cat << EOF > "$BUILD_DIR/taurus.nsi"
-[% extends "pyapp_w_pylauncher.nsi" %]
+[% extends "pyapp_installpy.nsi" %]
 
 [% block install_commands %]
 [[ super() ]]
@@ -151,7 +151,7 @@ entry_point=bzt.jmx2yaml:main
 entry_point=bzt.soapui2yaml:main
 
 [Python]
-version=2.7.12
+version=3.5.3
 bitness=64
 
 [Include]

--- a/setup.py
+++ b/setup.py
@@ -48,9 +48,7 @@ class InstallWithHook(install, object):
 requires = ['pyyaml', 'psutil > 3, != 5.1.1', 'colorlog', 'colorama',
             'cssselect', 'urwid', 'six', 'nose',
             'selenium<=3.3.0', 'progressbar33', 'pyvirtualdisplay', 'requests>=2.11.1', "apiritif>=0.3",
-            'astunparse']
-
-requires += ['lxml == 3.6.0'] if platform.system() == 'Windows' else ['lxml >= 3.6.0']
+            'astunparse', 'lxml >= 3.8.0']
 
 if sys.version_info.major < 3:
     requires += ['ipaddress']  # backport of 'ipaddress' module to Python 2


### PR DESCRIPTION
Also, bump `lxml` version to `3.8.0`, as it is a wheel-based distribution and it installs and works well on Windows.