### PR TITLE
Fix/executor startup logging

### DIFF
--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -211,8 +211,8 @@ class CLI(object):
             configs.extend(jmx_shorthands)
 
             if not self.options.verbose:
-                self.engine.post_startup_hook = self._level_down_logging
-                self.engine.pre_shutdown_hook = self._level_up_logging
+                self.engine.logging_level_down = self._level_down_logging
+                self.engine.logging_level_up = self._level_up_logging
 
             self.__configure(configs)
             self.__move_log_to_artifacts()

--- a/bzt/engine.py
+++ b/bzt/engine.py
@@ -83,8 +83,8 @@ class Engine(object):
         self.prepared = []
         self.started = []
         self.default_cwd = None
-        self.post_startup_hook = lambda: None
-        self.pre_shutdown_hook = lambda: None
+        self.logging_level_down = lambda: None
+        self.logging_level_up = lambda: None
 
     def configure(self, user_configs, read_config_files=True):
         """
@@ -180,7 +180,7 @@ class Engine(object):
         exc_info = None
         try:
             self._startup()
-            self.post_startup_hook()
+            self.logging_level_down()
             self._wait()
         except BaseException as exc:
             self.log.debug("%s:\n%s", exc, traceback.format_exc())
@@ -189,7 +189,7 @@ class Engine(object):
         finally:
             self.log.warning("Please wait for graceful shutdown...")
             try:
-                self.pre_shutdown_hook()
+                self.logging_level_up()
                 self._shutdown()
             except BaseException as exc:
                 self.log.debug("%s:\n%s", exc, traceback.format_exc())

--- a/bzt/modules/provisioning.py
+++ b/bzt/modules/provisioning.py
@@ -36,6 +36,7 @@ class Local(Provisioning):
     def __init__(self):
         super(Local, self).__init__()
         self.finished_modules = []
+        self.start_time = None
 
     def _get_start_shift(self, shift):
         if not shift:
@@ -90,6 +91,7 @@ class Local(Provisioning):
         prev_executor = None
         for executor in self.executors:
             if executor in self.engine.prepared and executor not in self.engine.started:  # needs to start
+                self.engine.pre_shutdown_hook()
                 if isinstance(executor.delay, numeric_types):
                     timed_start = time.time() >= self.start_time + executor.delay
                 else:
@@ -102,6 +104,7 @@ class Local(Provisioning):
                         self.log.info("Starting next sequential execution: %s", executor)
                     executor.startup()
                     self.engine.started.append(executor)
+                self.engine.post_startup_hook()
 
             prev_executor = executor
 

--- a/bzt/modules/provisioning.py
+++ b/bzt/modules/provisioning.py
@@ -91,7 +91,7 @@ class Local(Provisioning):
         prev_executor = None
         for executor in self.executors:
             if executor in self.engine.prepared and executor not in self.engine.started:  # needs to start
-                self.engine.pre_shutdown_hook()
+                self.engine.logging_level_up()
                 if isinstance(executor.delay, numeric_types):
                     timed_start = time.time() >= self.start_time + executor.delay
                 else:
@@ -104,7 +104,7 @@ class Local(Provisioning):
                         self.log.info("Starting next sequential execution: %s", executor)
                     executor.startup()
                     self.engine.started.append(executor)
-                self.engine.post_startup_hook()
+                self.engine.logging_level_down()
 
             prev_executor = executor
 

--- a/site/dat/docs/Installation.md
+++ b/site/dat/docs/Installation.md
@@ -154,8 +154,8 @@ Use `uname -a` to verify the system if it's 32 bit or 64 bit machine. [http://ww
 Get corresponding EPEL (Extra Package for Enterprise Linux) for CentOS (Community Enterprise OS) 7, and enable it.
 
 ```bash
-wget http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
-sudo rpm -ivh epel-release-7-9.noarch.rpm
+wget http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-10.noarch.rpm
+sudo rpm -ivh epel-release-7-10.noarch.rpm
 ```
 
 [http://www.tecmint.com/how-to-enable-epel-repository-for-rhel-centos-6-5/](http://www.tecmint.com/how-to-enable-epel-repository-for-rhel-centos-6-5/)


### PR DESCRIPTION
Currently, there is no executor startup logged into bzt.log. But it has crucial details on which subprocess were started. This PR fixes it by leveling up logging for executor startup.