### PR TITLE
Be able, in gatling executor, to give our own dir_prefix

### DIFF
--- a/bzt/modules/gatling.py
+++ b/bzt/modules/gatling.py
@@ -306,7 +306,7 @@ class GatlingExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInstal
                 msg += "to run Gatling tool (%s)" % self.execution.get('scenario')
                 raise TaurusConfigError(msg)
 
-        self.dir_prefix = 'gatling-%s' % id(self)
+        self.dir_prefix = self.settings.get('dir_prefix', 'gatling-%s' % id(self))
         self.reader = DataLogReader(self.engine.artifacts_dir, self.log, self.dir_prefix)
         if isinstance(self.engine.aggregator, ConsolidatingAggregator):
             self.engine.aggregator.add_underling(self.reader)

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -7,6 +7,7 @@
  - don't use `window_maximize` in generated python script due to problems with virtual display
  - use `-r -l` options for `ab` executor, make its exit code to not fail test
  - add JMX path to `jmeter.classpath` property
+ - add gatling reports prefix to `dir_prefix` setting
 
 ## 1.9.6 <sup>27 sep 2017</sup>
  - add `pytest` executor type
@@ -47,7 +48,7 @@
  - add `junit-xml` support for functional mode
  - fix doublequoting error in JTL reader
  - recover from invalid characters in JTL files
- - fix CSV quotation crash in Locust module 
+ - fix CSV quotation crash in Locust module
  - fix NPE with junit runner and null script
  - fix RSpec functional mode tests
  - fix Selenium concurrency and VU count for cloud provisioning
@@ -65,7 +66,7 @@
  - fix crash `-v` used on Windows with nose executor
  - minor fixes around PBench executor
  - fix functional mode breaks on JMeter 2.13
- 
+
 ## 1.9.3 <sup>2 jun 2017</sup>
  - fix failure with JMeter cookie manager and "null"
  - install JMeter into per-version directories
@@ -111,7 +112,7 @@
 ## 1.9.0 <sup>16 apr 2017</sup>
  - per-technology executors are extracted from selenium executor
  - experimental release of `apiritif` framework scripts
- - use BZA workspace's `enabled` flag to filter 
+ - use BZA workspace's `enabled` flag to filter
  - don't install `10-base.json` into `/etc/bzt.d` as step towards wheel dist
  - proxy2jmx now uses new-style API client
  - fix handling samples with empty RC in console dashboard

--- a/site/dat/docs/Gatling.md
+++ b/site/dat/docs/Gatling.md
@@ -157,6 +157,10 @@ scenarios:
  -  `version`: "2.3.0"
     Gatling version, 2.3.0 by default
 
+ -  `dir_prefix`: "gatling-%s"
+    Gatling report prefix. Used by taurus to find gatling reports.
+    If you use gatling property "gatling.core.outputDirectoryBaseName", you may use also this setting.
+
  - `properties`: dictionary for tuning of gatling tool behaviour (see list of available parameters in gatling
  documentation) and sending your own variables into Scala program:
 


### PR DESCRIPTION
I have an issue with Jenkins, see my question here: [set-gatling-report-name-in-jenkins-pipeline-througt-taurus](https://stackoverflow.com/questions/46663423/set-gatling-report-name-in-jenkins-pipeline-througt-taurus)

When I provide a 'gatling.core.outputDirectoryBaseName' to gatling, it is not taking into account by taurus to retrieve simulation.log then fails.

With my pull request, if I give a `dir_prefix` in gatling configuration module, it is used to retrieve simulation.log