### PR TITLE
Allow fractional hatch rates when locustio is executor.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ install:
     pip install -r requirements.txt
     pip install codecov nose-exclude locustio
   fi
+- if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install mock; fi
 - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pip install molotov; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
     pip install -r requirements.txt
     pip install codecov nose-exclude locustio
   fi
-- if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install mock; fi
+- if [[ `python -c "import sys; print(sys.version_info < (3, 3))"`='True' ]]; then pip install mock; fi;
 - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pip install molotov; fi
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - choco install firefox -version 54.0
   - "%PYTHON%\\python.exe -m pip install pip --upgrade"
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
-  - "%PYTHON%\\python.exe -m pip install locustio nose-exclude coverage codecov"
+  - "%PYTHON%\\python.exe -m pip install locustio nose-exclude coverage codecov mock"
   - set PATH=C:\Ruby22\bin;%PATH%
   - gem install rspec
 

--- a/bzt/modules/locustio.py
+++ b/bzt/modules/locustio.py
@@ -82,7 +82,7 @@ class LocustIOExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInsta
         load = self.get_load()
         concurrency = load.concurrency or 1
         if load.ramp_up:
-            hatch = concurrency / load.ramp_up
+            hatch = concurrency / float(load.ramp_up)
         else:
             hatch = concurrency
 

--- a/bzt/modules/locustio.py
+++ b/bzt/modules/locustio.py
@@ -82,7 +82,7 @@ class LocustIOExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInsta
         load = self.get_load()
         concurrency = load.concurrency or 1
         if load.ramp_up:
-            hatch = math.ceil(concurrency / load.ramp_up)
+            hatch = concurrency / load.ramp_up
         else:
             hatch = concurrency
 
@@ -97,7 +97,7 @@ class LocustIOExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInsta
         args = [sys.executable, wrapper, '-f', self.script]
         args += ['--logfile=%s' % self.log_file]
         args += ["--no-web", "--only-summary", ]
-        args += ["--clients=%d" % concurrency, "--hatch-rate=%d" % hatch]
+        args += ["--clients=%d" % concurrency, "--hatch-rate=%f" % hatch]
         if load.iterations:
             args.append("--num-request=%d" % load.iterations)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ colorlog
 cssselect
 ipaddress; python_version < '3.0'
 lxml>=3.8.0
-mock; python_version < '3.3'
 nose
 progressbar33
 psutil>=5,!=5.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ colorlog
 cssselect
 ipaddress; python_version < '3.0'
 lxml>=3.8.0
+mock; python_version < '3.3'
 nose
 progressbar33
 psutil>=5,!=5.3.0

--- a/site/dat/docs/changes/feat-allow-fractional-hatch-rate-locustio.change
+++ b/site/dat/docs/changes/feat-allow-fractional-hatch-rate-locustio.change
@@ -1,0 +1,1 @@
+Allow a fractional hatch-rate when using locustio as executor.


### PR DESCRIPTION
- Remove use of math.ceil that clamps fractional hatch rates to 1.
- Ensure hatch rate is formatted with default Python float specifier.
- Add a unit test to verify the float argument is passed to executor.
- Adds Python 2/3 compatible use of unittest.mock / mock library.

This PR resolves [this Taurus issue thread](https://groups.google.com/forum/#!topic/codename-taurus/shqHzbPyxlo).