### PR TITLE
fix generation of loop controller for JMeter

### DIFF
--- a/bzt/jmx/base.py
+++ b/bzt/jmx/base.py
@@ -507,7 +507,9 @@ class JMX(object):
                              elementType="LoopController",
                              guiclass="LoopControlPanel",
                              testclass="LoopController")
-        loop.append(JMX._bool_prop("LoopController.continue_forever", False))  # always false except of root LC
+
+        # 'true' causes endless execution of TG in non-gui mode
+        loop.append(JMX._bool_prop("LoopController.continue_forever", False))
         loop.append(JMX._string_prop("LoopController.loops", iterations))
         trg.append(loop)
 
@@ -1073,7 +1075,9 @@ class JMX(object):
             iterations = loops
         controller = etree.Element("LoopController", guiclass="LoopControlPanel", testclass="LoopController",
                                    testname="Loop Controller")
-        controller.append(JMX._bool_prop("LoopController.continue_forever", False))  # always false except of root LC
+
+        # 'false' means controller can be called only one time (by parent)
+        controller.append(JMX._bool_prop("LoopController.continue_forever", True))
         controller.append(JMX._string_prop("LoopController.loops", str(iterations)))
         return controller
 

--- a/tests/modules/jmeter/test_JMeterExecutor.py
+++ b/tests/modules/jmeter/test_JMeterExecutor.py
@@ -1560,7 +1560,7 @@ class TestJMeterExecutor(BZTestCase):
         loops = xml_tree.find(".//LoopController/stringProp[@name='LoopController.loops']")
         self.assertEqual(loops.text, "10")
         forever = xml_tree.find(".//LoopController/boolProp[@name='LoopController.continue_forever']")
-        self.assertEqual(forever.text, "false")
+        self.assertEqual(forever.text, "true")
 
     def test_request_logic_loop_forever(self):
         self.configure({
@@ -1574,8 +1574,17 @@ class TestJMeterExecutor(BZTestCase):
         xml_tree = etree.fromstring(open(self.obj.modified_jmx, "rb").read())
         controller = xml_tree.find(".//LoopController")
         self.assertIsNotNone(controller)
-        forever = xml_tree.find(".//LoopController/boolProp[@name='LoopController.continue_forever']")
-        self.assertEqual(forever.text, "false")
+
+        fprops = xml_tree.findall(".//boolProp[@name='LoopController.continue_forever']")
+        for fprop in fprops:
+            pptag = fprop.getparent().getparent().tag
+            if pptag == "ThreadGroup":
+                self.assertEqual("false", fprop.text)
+            elif pptag == "hashTree":
+                self.assertEqual("true", fprop.text)
+            else:
+                self.fail()
+
         loops = xml_tree.find(".//LoopController/stringProp[@name='LoopController.loops']")
         self.assertEqual(loops.text, "-1")
 


### PR DESCRIPTION
* Value of 'continue_forever' depends of place it's faced:
in ThreadGroup loop controller it must be 'false' to prevent endless cycle,
but included LoopController can't be called twice unless it has 'true'
* fix tests