### PR TITLE
Replace Python 3.3 with 3.6 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ matrix:
   - os: linux
     python: 2.7
   - os: linux
-    python: 3.3
-  - os: linux
     python: 3.4
   - os: linux
     python: 3.5
+  - os: linux
+    python: 3.6
   - os: osx
     language: generic
 


### PR DESCRIPTION
Python 3.3 is EOL anyway, there's no point in supporting it.