### PR TITLE
Remove excessive code from Apiritif executor

### DIFF
--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -235,7 +235,6 @@ import apiritif
                 test_method.append(self.gen_new_line(indent=0))
 
         test_class.append(test_method)
-        return {}
 
     def _add_url_request(self, default_address, req, test_method):
         parsed_url = parse.urlparse(req.url)
@@ -825,7 +824,6 @@ log.setLevel(logging.DEBUG)
 
     def build_source_code(self):
         self.tree = self.build_tree()
-        return {}
 
     def save(self, filename):
         with open(filename, 'wt') as fds:

--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -55,8 +55,6 @@ class ApiritifNoseExecutor(SubprocessedExecutor):
             else:
                 raise TaurusConfigError("Nothing to test, no requests were provided in scenario")
 
-        self.reporting_setup(suffix=".ldjson")
-
     def __tests_from_requests(self):
         filename = self.engine.create_artifact("test_requests", ".py")
         test_mode = self.execution.get("test-mode", None) or "apiritif"

--- a/tests/modules/selenium/test_SeleniumExecutor.py
+++ b/tests/modules/selenium/test_SeleniumExecutor.py
@@ -136,40 +136,6 @@ class TestSeleniumStuff(SeleniumTestCase):
         resources = self.obj.resource_files()
         self.assertEqual(0, len(resources))
 
-    def test_labels_translation(self):
-        self.configure({
-            "scenarios": {
-                "req_sel": {
-                    "requests": [
-                        "http://blazedemo.com",
-                        {
-                            'url': 'http://blazemeter.com',
-                            'label': 'Main Page'
-                        }]}}})
-        self.obj.execution.merge({
-            "scenario": "req_sel"})
-        self.obj.prepare()
-        name1 = 'test_00000_http_blazedemo_com'
-        name2 = 'test_00001_Main_Page'
-        name3 = 'test_00002_just_for_lulz'
-        reader = self.obj.runner.reader
-        reader.report_reader.json_reader = LDJSONReaderEmul()
-        reader.report_reader.json_reader.data.extend([
-            {
-                'test_case': name1, 'start_time': 1472049887, 'duration': 1.0, 'status': 'PASSED',
-                'test_suite': 'Tests', 'error_msg': None, 'error_trace': None, 'extras': None,
-            }, {
-                'test_case': name2, 'start_time': 1472049888, 'duration': 1.0, 'status': 'PASSED',
-                'test_suite': 'Tests', 'error_msg': None, 'error_trace': None, 'extras': None,
-            }, {
-                'test_case': name3, 'start_time': 1472049889, 'duration': 1.0, 'status': 'PASSED',
-                'test_suite': 'Tests', 'error_msg': None, 'error_trace': None, 'extras': None,
-            }])
-        res = list(reader._read())
-        self.assertIn('http_blazedemo_com', res[0])
-        self.assertIn('Main_Page', res[1])
-        self.assertIn('just_for_lulz', res[2])
-
     def test_dont_copy_local_script_to_artifacts(self):
         "ensures that .java file is not copied into artifacts-dir"
         filename = "BlazeDemo.java"


### PR DESCRIPTION
It doesn't need it, as it creates result readers dynamically based on reading apiritif's log.