### PR TITLE
Use pre-aggregating readers in Apiritif to unify reader interface

### DIFF
--- a/bzt/modules/__init__.py
+++ b/bzt/modules/__init__.py
@@ -49,18 +49,17 @@ class ReportableExecutor(ScenarioExecutor):
 
         self.report_file = self.report_file.replace(os.path.sep, '/')
 
-        if not self.register_reader:
-            self.log.debug("Skipping reader setup for executor %s", self)
-            return
-
         if self.engine.is_functional_mode():
             self.reader = FuncSamplesReader(self.report_file, self.engine, self.log)
-            if isinstance(self.engine.aggregator, FunctionalAggregator):
-                self.engine.aggregator.add_underling(self.reader)
         else:
             self.reader = LoadSamplesReader(self.report_file, self.log)
-            if isinstance(self.engine.aggregator, ConsolidatingAggregator):
-                self.engine.aggregator.add_underling(self.reader)
+
+        if not self.register_reader:
+            self.log.debug("Skipping reader registration for executor %s", self)
+            return
+
+        if isinstance(self.engine.aggregator, (ConsolidatingAggregator, FunctionalAggregator)):
+            self.engine.aggregator.add_underling(self.reader)
 
 
 class SubprocessedExecutor(ReportableExecutor, FileLister, SelfDiagnosable, WidgetProvider):

--- a/site/dat/docs/changes/fix-concurrent-apiritif-reporting.change
+++ b/site/dat/docs/changes/fix-concurrent-apiritif-reporting.change
@@ -1,0 +1,1 @@
+Fix reporting for concurrent apiritif

--- a/tests/modules/selenium/test_python.py
+++ b/tests/modules/selenium/test_python.py
@@ -5,7 +5,8 @@ import time
 from bzt import TaurusConfigError
 from bzt.engine import ScenarioExecutor
 from bzt.modules.functional import FuncSamplesReader, LoadSamplesReader, FunctionalAggregator
-from bzt.modules.python import ApiritifNoseExecutor, PyTestExecutor, RobotExecutor
+from bzt.modules.python import ApiritifNoseExecutor, PyTestExecutor, RobotExecutor, ApiritifLoadReader, \
+    ApiritifFuncReader
 from tests import BZTestCase, RESOURCES_DIR
 from tests.mocks import EngineEmul
 from tests.modules.selenium import SeleniumTestCase
@@ -835,6 +836,27 @@ class TestApiritifScriptGenerator(BZTestCase):
         self.obj.log.info(test_script)
         self.assertIn("'/?rs={}'.format(apiritif.random_string(3))", test_script)
         self.assertIn("'/?rs={}'.format(apiritif.random_string(4, 'abcdef'))", test_script)
+
+    def test_load_reader(self):
+        reader = ApiritifLoadReader(self.obj.log)
+        items = list(reader._read())
+        self.assertEqual(len(items), 0)
+        reader.register_file(RESOURCES_DIR + "jmeter/jtl/tranctl.jtl")
+        items = list(reader._read())
+        self.assertEqual(len(items), 2)
+        reader.register_file(RESOURCES_DIR + "jmeter/jtl/tranctl.jtl")
+        reader.register_file(RESOURCES_DIR + "jmeter/jtl/tranctl.jtl")
+        items = list(reader._read())
+        self.assertEqual(len(items), 4)
+
+    def test_func_reader(self):
+        reader = ApiritifFuncReader(self.obj.engine, self.obj.log)
+        items = list(reader.read())
+        self.assertEqual(len(items), 0)
+        reader.register_file(RESOURCES_DIR + "apiritif/transactions.ldjson")
+        reader.register_file(RESOURCES_DIR + "apiritif/transactions.ldjson")
+        items = list(reader.read())
+        self.assertEqual(len(items), 12)
 
 
 class TestPyTestExecutor(BZTestCase):


### PR DESCRIPTION
Need that to simplify fixing of concurrent Selenium tests.

Also, it's a good refactoring. With this patch applied, Apiritif executor is no different from other executors and has a single reader object, just like any other executor.