### PR TITLE
add text, fix HierarchicHTTPRequest initialization

### DIFF
--- a/bzt/requests_model.py
+++ b/bzt/requests_model.py
@@ -92,6 +92,9 @@ class HierarchicHTTPRequest(HTTPRequest):
             path = str(file_dict.get("path", path_exc))
             if '${' not in path:    # exclude varables
                 path = get_full_path(self.engine.find_file(path))   # prepare full path for jmx
+            else:
+                msg = "Path '%s' contains variable and can't be expanded. Don't use relative paths in 'upload-files'!"
+                self.log.warning(msg % path)
 
             file_dict["path"] = path
 

--- a/bzt/requests_model.py
+++ b/bzt/requests_model.py
@@ -90,7 +90,7 @@ class HierarchicHTTPRequest(HTTPRequest):
 
             path_exc = TaurusConfigError("Items from upload-files must specify path to file")
             path = str(file_dict.get("path", path_exc))
-            if not path.startswith('$'):    # exclude varables
+            if '${' not in path:    # exclude varables
                 path = get_full_path(self.engine.find_file(path))   # prepare full path for jmx
 
             file_dict["path"] = path

--- a/bzt/requests_model.py
+++ b/bzt/requests_model.py
@@ -89,7 +89,12 @@ class HierarchicHTTPRequest(HTTPRequest):
                 raise TaurusConfigError("Items from upload-files must specify parameter name")
 
             path_exc = TaurusConfigError("Items from upload-files must specify path to file")
-            file_dict["path"] = get_full_path(self.engine.find_file(file_dict.get("path", path_exc)))
+            path = str(file_dict.get("path", path_exc))
+            if not path.startswith('$'):    # exclude varables
+                path = get_full_path(self.engine.find_file(path))   # prepare full path for jmx
+
+            file_dict["path"] = path
+
             mime = mimetypes.guess_type(file_dict["path"])[0] or "application/octet-stream"
             file_dict.get('mime-type', mime)
         self.content_encoding = self.config.get('content-encoding', None)

--- a/bzt/requests_model.py
+++ b/bzt/requests_model.py
@@ -90,7 +90,7 @@ class HierarchicHTTPRequest(HTTPRequest):
 
             path_exc = TaurusConfigError("Items from upload-files must specify path to file")
             path = str(file_dict.get("path", path_exc))
-            if '${' not in path:    # exclude varables
+            if '${' not in path:    # exclude variables
                 path = get_full_path(self.engine.find_file(path))   # prepare full path for jmx
             else:
                 msg = "Path '%s' contains variable and can't be expanded. Don't use relative paths in 'upload-files'!"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -45,7 +45,7 @@ def __dir__():
 root_dir = __dir__() + '/../'
 os.chdir(root_dir)
 
-RESOURCES_DIR = __dir__() + "/resources/"
+RESOURCES_DIR = os.path.join(__dir__(), 'resources') + os.path.sep
 BUILD_DIR = __dir__() + "/../build/tmp/"
 TEST_DIR = __dir__() + "/../build/test/"
 BASE_CONFIG = __dir__() + "/../bzt/resources/base-config.yml"

--- a/tests/modules/jmeter/test_JMeterExecutor.py
+++ b/tests/modules/jmeter/test_JMeterExecutor.py
@@ -1945,7 +1945,7 @@ class TestJMeterExecutor(BZTestCase):
         norm = ['${some_var}',
                 os.path.join(RESOURCES_DIR, 'jmeter', 'body-file.dat'),
                 os.path.join(RESOURCES_DIR, 'jmeter', 'unicode-file')]
-        self.assertEqual(paths, norm, "norm[1]: '%s'\RES_DIR: '%s'" % (norm[1], RESOURCES_DIR))
+        self.assertEqual(paths, norm)
 
     def test_data_sources_jmx_gen_loop(self):
         self.configure({

--- a/tests/modules/jmeter/test_JMeterExecutor.py
+++ b/tests/modules/jmeter/test_JMeterExecutor.py
@@ -1945,7 +1945,7 @@ class TestJMeterExecutor(BZTestCase):
         norm = ['${some_var}',
                 os.path.join(RESOURCES_DIR, 'jmeter', 'body-file.dat'),
                 os.path.join(RESOURCES_DIR, 'jmeter', 'unicode-file')]
-        self.assertEqual(paths, norm)
+        self.assertEqual(paths, norm, "norm[1]: '%s'\RES_DIR: '%s'" % (norm[1], RESOURCES_DIR))
 
     def test_data_sources_jmx_gen_loop(self):
         self.configure({

--- a/tests/modules/jmeter/test_JMeterExecutor.py
+++ b/tests/modules/jmeter/test_JMeterExecutor.py
@@ -1943,8 +1943,8 @@ class TestJMeterExecutor(BZTestCase):
         paths = [_file.find('stringProp[@name="File.path"]').text for _file in files]
         paths.sort()
         norm = ['${some_var}',
-                '/home/taras/Projects/taurus/tests/resources/jmeter/body-file.dat',
-                '/home/taras/Projects/taurus/tests/resources/jmeter/unicode-file']
+                os.path.join(RESOURCES_DIR, 'jmeter', 'body-file.dat'),
+                os.path.join(RESOURCES_DIR, 'jmeter', 'unicode-file')]
         self.assertEqual(paths, norm)
 
     def test_data_sources_jmx_gen_loop(self):


### PR DESCRIPTION
 * addition to #5eb06892:
   if JMeter variable is faced (in upload-file path) we mustn't expand it to absolute path