### PR TITLE
Ensure that loaded configurations are dicts or throw `TaurusConfigError` otherwise

### DIFF
--- a/site/dat/docs/changes/ensure-configuration-is-dist.change
+++ b/site/dat/docs/changes/ensure-configuration-is-dist.change
@@ -1,0 +1,1 @@
+Ensure that loaded configuration is dict, throw appropriate exception otherwise


### PR DESCRIPTION
Taurus currently throws 'TaurusInternalException' when loading non-dict YAML/JSON configs. This PR fixes that.