### PR TITLE
Environment variable initialization

### DIFF
--- a/bzt/modules/selenium.py
+++ b/bzt/modules/selenium.py
@@ -65,6 +65,7 @@ class SeleniumExecutor(AbstractSeleniumExecutor, WidgetProvider, FileLister, Hav
 
     def __init__(self):
         super(SeleniumExecutor, self).__init__()
+        self.env = Environment(self.log)
         self.end_time = None
         self.runner = None
         self.script = None


### PR DESCRIPTION
Currently the tests do not fall because the code that used it was removed, however on my fork of taurus it is used and the last change generate an error.
The initialization solves the problem of env in null.