### PR TITLE
Allow a dictionary where get does not assign a value internally

### DIFF
--- a/bzt/engine.py
+++ b/bzt/engine.py
@@ -1143,6 +1143,12 @@ class Scenario(UserDict, object):
         self.engine = engine
         self.data = scenario
 
+    def get_noset(self, key, default=defaultdict):
+        if hasattr(self.data, "get_noset"):
+            return self.data.get_noset(key, default)
+        else:
+            return self.get(key, default=defaultdict)
+
     def get(self, key, default=defaultdict):
         """
 

--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -169,12 +169,30 @@ class BetterDict(defaultdict):
     def __init__(self, **kwargs):
         super(BetterDict, self).__init__(**kwargs)
 
+    def get_noset(self, key, default=defaultdict):
+        if default == defaultdict:
+            default = BetterDict()
+
+        if isinstance(default, BaseException) and key not in self:
+            raise default
+
+        value = super(BetterDict, self).get(key, default)
+
+        if isinstance(value, string_types):
+            if isinstance(value, str):  # this is a trick for python v2/v3 compatibility
+                return value
+            else:
+                return text_type(value)
+        else:
+            return value
+
     def get(self, key, default=defaultdict):
         """
         Change get with setdefault
 
         :type key: object
         :type default: object
+        :type no_set: boolean
         """
         if default == defaultdict:
             default = BetterDict()


### PR DESCRIPTION
Hi guys, this PR is just for review, it's something that I found when wanting to implement a practical solution to consult cascading data in the dictionary without modify the internal data of the dict.

Currently a value is assigned in the use of get of the dictionaries (Is it an antipattern?) https://github.com/Blazemeter/taurus/blob/master/bzt/utils.py#L185,
this causes inconveniences for those who need to use the get in a
traditional way.

The current mechanism would allow those who use it in the traditional
way to have an alternative without having to be castrating the
dictionary, and this would not allow breaking the current logic
programmed around these dictionaries.

Evaluate in the future if the anti-pattern used in the dictionary where
a value set is made internally if someone requests a get should not be
used in another method other than get.

Currently with these changes that I propose (currently in my fork) I can make queries like the following (without alter the dict)

browser = self.scenario.get_noset("browser", self.execution.get_noset("browser", None))

The bad thing about the current taurus dict use of the get is that by only consulting the existence with a default it defines its default and the next query that is made will return as it exists, when in fact only its existence had been consulted (and lost the real definition).

I do not request to change the current use of the dictionaries because I know that it can bring collateral effects in the whole project, I ask to incorporate a method that is equal to "the get" but not to make the set inside.

Please, tell me what you think so I see if I continue in future proposals to use this method or incorporate an alternative without incorporating an extra method to the current dictionary.
