### PR TITLE
Support incremental UTF-8 decoding in FileReader for buffered reads

### DIFF
--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -471,7 +471,7 @@ class FileReader(object):
             self.log.warning("Content encoding of '%s' doesn't match %s", self.name, self.cp)
             self.cp = self.SYS_ENCODING
             self.log.warning("Proposed code page: %s", self.cp)
-            return line.decode(self.cp)
+            return line.decode(self.cp, 'ignore')
 
     def get_lines(self, size=-1, last_pass=False):
         if self.is_ready():

--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -16,6 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import codecs
 import copy
 import csv
 import fnmatch
@@ -435,6 +436,8 @@ class FileReader(object):
         # it turns all regular file checks off, see is_ready()
         self.name = filename
         self.cp = 'utf-8'  # default code page is utf-8
+        self.decoder = codecs.lookup(self.cp).incrementaldecoder()
+        self.fallback_decoder = codecs.lookup(self.SYS_ENCODING).incrementaldecoder(errors='ignore')
         self.offset = 0
 
     def _readlines(self, hint=None):
@@ -466,14 +469,16 @@ class FileReader(object):
             self.name = self.fds.name
             return True
 
-    def _decode(self, line):
+    def _decode(self, line, last_pass=False):
         try:
-            return line.decode(self.cp)
+            return self.decoder.decode(line, final=last_pass)
         except UnicodeDecodeError:
             self.log.warning("Content encoding of '%s' doesn't match %s", self.name, self.cp)
             self.cp = self.SYS_ENCODING
+            self.decoder = self.fallback_decoder
+            self.decoder.reset()
             self.log.warning("Proposed code page: %s", self.cp)
-            return line.decode(self.cp, 'ignore')
+            return self.decoder.decode(line, final=last_pass)
 
     def get_lines(self, size=-1, last_pass=False):
         if self.is_ready():
@@ -483,7 +488,7 @@ class FileReader(object):
             self.fds.seek(self.offset)
             for line in self._readlines(hint=size):
                 self.offset += len(line)
-                yield self._decode(line)
+                yield self._decode(line, last_pass)
 
     def get_line(self):
         line = ""
@@ -504,7 +509,7 @@ class FileReader(object):
             _bytes = self.fds.read(size)
             self.offset += len(_bytes)
             if decode:
-                return self._decode(_bytes)
+                return self._decode(_bytes, last_pass)
             else:
                 return _bytes
 

--- a/site/dat/docs/changes/fix-jmeter-trace-jtl-unicode-decode.change
+++ b/site/dat/docs/changes/fix-jmeter-trace-jtl-unicode-decode.change
@@ -1,0 +1,1 @@
+Properly recover if JMeter has written non-UTF8 chars into JTL

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -114,3 +114,7 @@ class TestFileReader(BZTestCase):
                 self.obj.fds.close()
 
             os.remove(gen_file_name)
+
+    def test_decode_crash(self):
+        self.configure(join(RESOURCES_DIR, 'jmeter', 'jtl', 'unicode.jtl'))
+        self.obj.get_bytes(size=180)  # shouldn't crash with UnicodeDecodeError


### PR DESCRIPTION
A way to reproduce this issue: `bzt examples/jmeter/existing.jmx -func` on either Python 2 or Python 3.