### PR TITLE
Add `headless` switch for selenium-based tests (Chrome and Firefox)

### DIFF
--- a/site/dat/docs/Nose.md
+++ b/site/dat/docs/Nose.md
@@ -53,6 +53,7 @@ Sample request scenario:
 scenarios:
   request_example:
     browser: Firefox  # available browsers are: ["Firefox", "Chrome", "Ie", "Opera"]
+    headless: true  # available only for Chrome/Firefox and only on Selenium 3.8.0+, disabled by default
     timeout: 10  #  global scenario timeout for connecting, receiving results, 30 seconds by default
     think-time: 1s500ms  # global scenario delay between each request
     default-address: http://demo.blazemeter.com  # specify a base address, so you can use short urls in requests

--- a/site/dat/docs/changes/add-headless-switch-for-selenium.change
+++ b/site/dat/docs/changes/add-headless-switch-for-selenium.change
@@ -1,0 +1,1 @@
+Add `headless` switch for selenium-based tests (Chrome and Firefox)

--- a/tests/modules/selenium/test_python.py
+++ b/tests/modules/selenium/test_python.py
@@ -320,6 +320,77 @@ class TestSeleniumScriptBuilder(SeleniumTestCase):
 
         self.assertEqual(gen_contents, sample_contents)
 
+    def test_headless_default(self):
+        self.configure({
+            "execution": [{
+                "executor": "selenium",
+                "scenario": "loc_sc"}],
+            "scenarios": {
+                "loc_sc": {
+                    "browser": "Chrome",
+                    "requests": ["http://blazedemo.com/"]
+                }}})
+
+        self.obj.prepare()
+        with open(self.obj.script) as generated:
+            gen_contents = generated.read()
+
+        self.assertNotIn("options.set_headless()", gen_contents)
+
+    def test_headless_chrome(self):
+        self.configure({
+            "execution": [{
+                "executor": "selenium",
+                "scenario": "loc_sc"}],
+            "scenarios": {
+                "loc_sc": {
+                    "browser": "Chrome",
+                    "headless": True,
+                    "requests": ["http://blazedemo.com/"]
+                }}})
+
+        self.obj.prepare()
+        with open(self.obj.script) as generated:
+            gen_contents = generated.read()
+
+        self.assertIn("options.set_headless()", gen_contents)
+
+    def test_headless_firefox(self):
+        self.configure({
+            "execution": [{
+                "executor": "selenium",
+                "scenario": "loc_sc"}],
+            "scenarios": {
+                "loc_sc": {
+                    "browser": "Firefox",
+                    "headless": True,
+                    "requests": ["http://blazedemo.com/"]
+                }}})
+
+        self.obj.prepare()
+        with open(self.obj.script) as generated:
+            gen_contents = generated.read()
+
+        self.assertIn("options.set_headless()", gen_contents)
+
+    def test_headless_safari(self):
+        self.configure({
+            "execution": [{
+                "executor": "selenium",
+                "scenario": "loc_sc"}],
+            "scenarios": {
+                "loc_sc": {
+                    "browser": "Opera",
+                    "headless": True,
+                    "requests": ["http://blazedemo.com/"]
+                }}})
+
+        self.obj.prepare()
+        with open(self.obj.script) as generated:
+            gen_contents = generated.read()
+
+        self.assertNotIn("options.set_headless()", gen_contents)
+
 
 class TestApiritifScriptGenerator(BZTestCase):
     def setUp(self):


### PR DESCRIPTION
This one should probably be merged after #767.