### PR TITLE
Fix rounding of test durations for Robot

### DIFF
--- a/bzt/resources/robot_runner.py
+++ b/bzt/resources/robot_runner.py
@@ -68,7 +68,7 @@ class TaurusListener:
         sample.test_case = name
         sample.test_suite = self._current_suite
         sample.start_time = time.mktime(datetime.strptime(attrs['starttime'], '%Y%m%d %H:%M:%S.%f').timetuple())
-        sample.duration = attrs['elapsedtime'] / 1000
+        sample.duration = float(attrs['elapsedtime']) / 1000
         if attrs['status'] == 'PASS':
             sample.status = 'PASSED'
         else:

--- a/site/dat/docs/changes/fix-robot-rounded-times-on-python2.change
+++ b/site/dat/docs/changes/fix-robot-rounded-times-on-python2.change
@@ -1,0 +1,1 @@
+Fix Python2 + Robot issue with test durations rounded to seconds


### PR DESCRIPTION
Python2-only, kind of hard to reproduce.