### PR TITLE
make kpi listener flags same as jmeter 4.0 default result log file

### DIFF
--- a/bzt/jmx/base.py
+++ b/bzt/jmx/base.py
@@ -186,11 +186,14 @@ class JMX(object):
             "responseHeaders": False,
             "requestHeaders": False,
             "responseDataOnError": False,
-            "saveAssertionResultsFailureMessage": False,
+            "saveAssertionResultsFailureMessage": True,
             "bytes": True,
             "hostname": True,
             "threadCounts": True,
-            "url": False
+            "url": False,
+            "sentBytes": True,
+            "connectTime": True,
+            "idleTime": True,
         }
 
         return JMX.__jtl_writer(filename, "KPI Writer", flags)


### PR DESCRIPTION
Some people run taurus on servers that can only access the intranet, and it would be nice if kpi.jtl can be used to generate jmeter dashboard.

It's unlikely that adding the missing flags would affect performance, as logs are written to page cache first, unless `jmeter.save.saveservice.autoflush=true`.

PS: 
I don't understand the reason setting `jmeter.save.saveservice.autoflush: 'true'` in `resources/base-config.yml`. When load testing APIs, people usually don't set any think time. In this case, the overhead of millions of flushes are horrible.

```
# AutoFlush on each line written in XML or CSV output
# Setting this to true will result in less test results data loss in case of Crash
# but with impact on performances, particularly for intensive tests (low or no pauses)
# Since JMeter 2.10, this is false by default
jmeter.save.saveservice.autoflush=false
```

I always set `jmeter.save.saveservice.autoflush: false` in my .bzt-rc file and everything is fine.