### PR TITLE
Fix `rt` when exporting datapoints as JSON

### DIFF
--- a/bzt/modules/aggregator.py
+++ b/bzt/modules/aggregator.py
@@ -56,8 +56,10 @@ class RespTimesCounter(JSONConvertable):
         return self.histogram.get_value_counts()
 
     def __json__(self):
-        counts = self.get_counts()
-        return counts
+        return {
+            float(rt) / 1000: count
+            for rt, count in iteritems(self.histogram.get_value_counts())
+        }
 
 
 class KPISet(BetterDict):

--- a/site/dat/docs/changes/fix-exporting-datapoints-as-json.change
+++ b/site/dat/docs/changes/fix-exporting-datapoints-as-json.change
@@ -1,0 +1,1 @@
+Fix `rt` field when exporting datapoints to JSON (convert msecs to secs)

--- a/tests/modules/test_defaultAggregator.py
+++ b/tests/modules/test_defaultAggregator.py
@@ -1,6 +1,8 @@
+import json
 import logging
 import time
 
+from bzt.utils import to_json
 from tests import BZTestCase, r, rc, err
 
 from bzt.modules.aggregator import ResultsReader, DataPoint, KPISet
@@ -120,3 +122,31 @@ class TestDefaultAggregator(BZTestCase):
         points = list(mock.datapoints())
         points = list(mock.datapoints())
         self.assertTrue(mock.buffer_len < buffer_len)
+
+    def test_json(self):
+        obj = self.obj
+
+        mock = MockReader()
+        mock.buffer_scale_idx = '100.0'
+        mock.data.append((1, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((2, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((2, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((3, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((3, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((4, "", 1, r(), r(), r(), 200, None, '', 0))
+        mock.data.append((4, "", 1, r(), r(), r(), 200, None, '', 0))
+
+        obj.add_listener(mock)
+
+        for point in mock.datapoints(True):
+            pass
+
+        for point in mock.results:
+            serialized = json.loads(to_json(point))
+            rt_keys = serialized["current"][""]["rt"].keys()
+            for key in rt_keys:
+                rt = float(key)
+                self.assertGreaterEqual(rt, 1.0)
+                self.assertLessEqual(rt, 2.0)
+
+


### PR DESCRIPTION
Translate from miliseconds to seconds