### PR TITLE
Infrastructure: fix setup.py script for pip >= 10.0.0, add long description to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ setup(
     name="bzt",
     version=bzt.VERSION,
     description='Taurus Tool for Continuous Testing',
+    long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
     author='Andrey Pokhilko',
     author_email='andrey@blazemeter.com',
     url='http://gettaurus.org/',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,11 @@ import bzt
 
 
 # thanks to pip there are two :incompatible ways to parse requirements.txt
-if hasattr(pip, '__version__') and LooseVersion(str(pip.__version__)) >= LooseVersion('7.0'):
+if hasattr(pip, '__version__') and LooseVersion(str(pip.__version__)) >= LooseVersion('10.0.0'):
+    # new versions of pip require a session
+    from pip._internal import req, download
+    requirements = req.parse_requirements('requirements.txt', session=download.PipSession())
+elif hasattr(pip, '__version__') and LooseVersion(str(pip.__version__)) >= LooseVersion('7.0'):
     # new versions of pip require a session
     requirements = pip.req.parse_requirements('requirements.txt', session=pip.download.PipSession())
 else:


### PR DESCRIPTION
Since the release of new PyPI interface, `bzt`'s page lacks project description. This is controlled by a `long_description` parameter in setup.py. This PR proposes using our README file as a project description in PyPI.

Also, this PR fixes `setup.py build` command for pip>=10.0.0, as we're using pip's internal API and it got changed again. 