### PR TITLE
Added match-no and use-namespaces support to extract-xpath

### DIFF
--- a/bzt/jmx/base.py
+++ b/bzt/jmx/base.py
@@ -911,7 +911,7 @@ class JMX(object):
         return element
 
     @staticmethod
-    def _get_xpath_extractor(varname, xpath, default, validate_xml, ignore_whitespace, use_tolerant_parser):
+    def _get_xpath_extractor(varname, xpath, default, validate_xml, ignore_whitespace, match_no, use_namespaces, use_tolerant_parser):
         """
         :type varname: str
         :type xpath: str
@@ -930,6 +930,8 @@ class JMX(object):
         element.append(JMX._string_prop("XPathExtractor.default", default))
         element.append(JMX._bool_prop("XPathExtractor.validate", validate_xml))
         element.append(JMX._bool_prop("XPathExtractor.whitespace", ignore_whitespace))
+        element.append(JMX._string_prop("XPathExtractor.matchNumber", match_no))
+        element.append(JMX._bool_prop("XPathExtractor.namespace", use_namespaces))
         element.append(JMX._bool_prop("XPathExtractor.tolerant", use_tolerant_parser))
         return element
 

--- a/bzt/jmx/tools.py
+++ b/bzt/jmx/tools.py
@@ -508,6 +508,8 @@ class JMeterScenarioBuilder(JMX):
                                                      cfg.get('default', 'NOT_FOUND'),
                                                      cfg.get('validate-xml', False),
                                                      cfg.get('ignore-whitespace', True),
+                                                     cfg.get("match-no", "0"),
+                                                     cfg.get('use-namespaces', False),
                                                      cfg.get('use-tolerant-parser', False)))
             children.append(etree.Element("hashTree"))
 

--- a/bzt/jmx/tools.py
+++ b/bzt/jmx/tools.py
@@ -508,7 +508,7 @@ class JMeterScenarioBuilder(JMX):
                                                      cfg.get('default', 'NOT_FOUND'),
                                                      cfg.get('validate-xml', False),
                                                      cfg.get('ignore-whitespace', True),
-                                                     cfg.get("match-no", "0"),
+                                                     cfg.get("match-no", "-1"),
                                                      cfg.get('use-namespaces', False),
                                                      cfg.get('use-tolerant-parser', False)))
             children.append(etree.Element("hashTree"))

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -347,6 +347,8 @@ scenarios:
           default: NOT_FOUND
           validate-xml: false
           ignore-whitespace: true
+          match-no: -1
+          use-namespaces: false
           use-tolerant-parser: false
 ```
 

--- a/site/dat/docs/changes/add-match-no-and-use-namespaces-support-to-extract-xpath.change
+++ b/site/dat/docs/changes/add-match-no-and-use-namespaces-support-to-extract-xpath.change
@@ -1,0 +1,1 @@
+Add match-no and use-namespaces support to extract-xpath


### PR DESCRIPTION
According to problems reported in the forum around match-no and use-namespaces inside extract-xpath.

Set match-no for extract-xpath
https://groups.google.com/forum/#!topic/codename-taurus/sl80kijq2yE
Set namespace for extract-xpath
https://groups.google.com/forum/#!topic/codename-taurus/4s70OXcu7b8

I attached the PR that would allow you to configure these extra-xpath properties.
