### PR TITLE
Swagger2YAML enhancements

### DIFF
--- a/bzt/swagger2yaml.py
+++ b/bzt/swagger2yaml.py
@@ -416,14 +416,16 @@ class SwaggerConverter(object):
             }
 
             if base_path:
-                path = self.join_base_with_endpoint_url("${basePath}", path)
+                route = self.join_base_with_endpoint_url("${basePath}", path)
+            else:
+                route = path
 
             requests = []
             for method in Swagger.METHODS:
                 operation = getattr(path_obj, method)
                 if operation is not None:
                     self.log.debug("Handling method %s", method.upper())
-                    request = self._extract_request(path, path_obj, method, operation)
+                    request = self._extract_request(route, path_obj, method, operation)
 
                     if operation.security:
                         self._add_local_security(request, operation.security, scenario)

--- a/bzt/swagger2yaml.py
+++ b/bzt/swagger2yaml.py
@@ -403,7 +403,7 @@ class SwaggerConverter(object):
         base_path = self.swagger.get_base_path()
         scenarios = OrderedDict()
         global_vars = {
-            "defaultAddress": default_address
+            "default-address": default_address
         }
         if base_path:
             global_vars["default-path"] = base_path
@@ -413,7 +413,7 @@ class SwaggerConverter(object):
 
             scenario_name = path
             scenario = {
-                "default-address": "${defaultAddress}",
+                "default-address": "${default-address}",
                 "variables": {},
             }
 

--- a/bzt/swagger2yaml.py
+++ b/bzt/swagger2yaml.py
@@ -348,12 +348,14 @@ class SwaggerConverter(object):
         base_path = self.swagger.get_base_path()
         requests = []
         scenario = {
-            "default-address": default_address,
+            "default-address": "${default-address}",
             "variables": {},
         }
-        global_vars = {}
+        global_vars = {
+            "default-address": default_address,
+        }
         if base_path:
-            global_vars["basePath"] = base_path
+            global_vars["default-path"] = base_path
 
         if global_security:
             self._add_global_security(scenario, global_security, global_vars)
@@ -365,7 +367,7 @@ class SwaggerConverter(object):
                 if operation is not None:
                     self.log.debug("Handling method %s", method.upper())
                     if base_path:
-                        route = "${basePath}" + path
+                        route = "${default-path}" + path
                     else:
                         route = path
                     request = self._extract_request(route, path_obj, method, operation)
@@ -404,7 +406,7 @@ class SwaggerConverter(object):
             "defaultAddress": default_address
         }
         if base_path:
-            global_vars["basePath"] = base_path
+            global_vars["default-path"] = base_path
 
         for path, path_obj in iteritems(paths):
             self.log.info("Handling path %s", path)
@@ -416,7 +418,7 @@ class SwaggerConverter(object):
             }
 
             if base_path:
-                route = "${basePath}" + path
+                route = "${default-path}" + path
             else:
                 route = path
 

--- a/bzt/swagger2yaml.py
+++ b/bzt/swagger2yaml.py
@@ -365,7 +365,7 @@ class SwaggerConverter(object):
                 if operation is not None:
                     self.log.debug("Handling method %s", method.upper())
                     if base_path:
-                        route = self.join_base_with_endpoint_url("${basePath}", path)
+                        route = "${basePath}" + path
                     else:
                         route = path
                     request = self._extract_request(route, path_obj, method, operation)
@@ -416,7 +416,7 @@ class SwaggerConverter(object):
             }
 
             if base_path:
-                route = self.join_base_with_endpoint_url("${basePath}", path)
+                route = "${basePath}" + path
             else:
                 route = path
 

--- a/site/dat/docs/Swagger.md
+++ b/site/dat/docs/Swagger.md
@@ -11,14 +11,12 @@ Supported command-line options:
   - `-v, --verbose` - prints all logging messages to console
   - `-j, --json` - use json format instead of yaml
   - `-o FILE\_NAME, --out=FILE\_NAME` - change output file name, by default is input file name + `.yml` in current directory
-  - `-a, --all-http-methods` - extract all combinations of paths and HTTP methods.
+  - `--scenarios-from-paths` - generate a scenario per path (instead of generating a single scenario). disabled by default.
+  - `--parameter-interpolation` - setup interpolation for templated parameters. Valid values are 'values', 'variables', 'none'. Default is 'values'.
   
-By default Taurus will extract only GET requests. `--all-http-methods` switch can be used to extract all kinds of requests
-from Swagger spec.
-
 Usage:
   - `swagger2yaml swagger.json` - convert Swagger spec
-  - `swagger2yaml swagger.json -a -o swagger-converted.yml` - convert Swagger spec, extracting all HTTP requests, and save it to a specific file
+  - `swagger2yaml swagger.json -o swagger-converted.yml --scenarios-from-paths` - convert Swagger spec, extracting all HTTP requests, and save it to a specific file
 
 Notes about Swagger to YAML translation process:
 1. The whole spec is converted into single scenario

--- a/site/dat/docs/Swagger.md
+++ b/site/dat/docs/Swagger.md
@@ -16,7 +16,7 @@ Supported command-line options:
   
 Usage:
   - `swagger2yaml swagger.json` - convert Swagger spec
-  - `swagger2yaml swagger.json -o swagger-converted.yml --scenarios-from-paths` - convert Swagger spec, extracting all HTTP requests, and save it to a specific file
+  - `swagger2yaml swagger.json -o swagger-converted.yml --scenarios-from-paths` - convert Swagger spec, creating a scenario per path, and save it to a specific file
 
 Notes about Swagger to YAML translation process:
 1. The whole spec is converted into single scenario

--- a/site/dat/docs/changes/swagger2yaml-auth.change
+++ b/site/dat/docs/changes/swagger2yaml-auth.change
@@ -1,0 +1,1 @@
+Support auth (basic and API keys) for Swagger2YAML

--- a/site/dat/docs/changes/swagger2yaml-base-path-variable.change
+++ b/site/dat/docs/changes/swagger2yaml-base-path-variable.change
@@ -1,0 +1,1 @@
+Swagger2YAML: Move base path to variable

--- a/site/dat/docs/changes/swagger2yaml-no-interpolation.change
+++ b/site/dat/docs/changes/swagger2yaml-no-interpolation.change
@@ -1,0 +1,1 @@
+Support disabling explicit interpolation of parameters/headers

--- a/tests/resources/swagger/auth-basic-converted.yaml
+++ b/tests/resources/swagger/auth-basic-converted.yaml
@@ -5,13 +5,14 @@ execution:
   scenario: BZM-API
 scenarios:
   BZM-API:
-    default-address: https://a.blazemeter.com
+    default-address: ${default-address}
     headers:
       Authorization: Basic ${__base64Encode(${auth})}
     requests:
-    - url: ${basePath}/tests
+    - url: ${default-path}/tests
 settings:
   env:
     auth: USER:PASSWORD
-    basePath: /api/v4
+    default-address: https://a.blazemeter.com
+    default-path: /api/v4
 

--- a/tests/resources/swagger/auth-basic-converted.yaml
+++ b/tests/resources/swagger/auth-basic-converted.yaml
@@ -1,0 +1,15 @@
+---
+execution:
+- concurrency: 1
+  hold-for: 1m
+  scenario: BZM-API
+scenarios:
+  BZM-API:
+    default-address: https://a.blazemeter.com
+    headers:
+      Authorization: 'Basic ${__base64Encode(${auth})}'
+    variables:
+      auth: USER:PASSWORD
+    requests:
+    - url: /api/v4/tests
+

--- a/tests/resources/swagger/auth-basic-converted.yaml
+++ b/tests/resources/swagger/auth-basic-converted.yaml
@@ -9,7 +9,7 @@ scenarios:
     headers:
       Authorization: Basic ${__base64Encode(${auth})}
     requests:
-    - url: /${basePath}/tests
+    - url: ${basePath}/tests
 settings:
   env:
     auth: USER:PASSWORD

--- a/tests/resources/swagger/auth-basic-converted.yaml
+++ b/tests/resources/swagger/auth-basic-converted.yaml
@@ -7,9 +7,9 @@ scenarios:
   BZM-API:
     default-address: https://a.blazemeter.com
     headers:
-      Authorization: 'Basic ${__base64Encode(${auth})}'
+      Authorization: Basic ${__base64Encode(${auth})}
     variables:
       auth: USER:PASSWORD
+      basePath: /api/v4
     requests:
-    - url: /api/v4/tests
-
+    - url: /${basePath}/tests

--- a/tests/resources/swagger/auth-basic-converted.yaml
+++ b/tests/resources/swagger/auth-basic-converted.yaml
@@ -8,8 +8,10 @@ scenarios:
     default-address: https://a.blazemeter.com
     headers:
       Authorization: Basic ${__base64Encode(${auth})}
-    variables:
-      auth: USER:PASSWORD
-      basePath: /api/v4
     requests:
     - url: /${basePath}/tests
+settings:
+  env:
+    auth: USER:PASSWORD
+    basePath: /api/v4
+

--- a/tests/resources/swagger/auth-basic-local-converted.yaml
+++ b/tests/resources/swagger/auth-basic-local-converted.yaml
@@ -1,0 +1,18 @@
+---
+execution:
+- concurrency: 1
+  hold-for: 1m
+  scenario: BZM-API
+scenarios:
+  BZM-API:
+    default-address: https://a.blazemeter.com
+    requests:
+    - headers:
+        Authorization: Basic ${__base64Encode(${auth})}
+      url: /${basePath}/tests
+    variables:
+      auth: USER:PASSWORD
+settings:
+  env:
+    basePath: /api/v4
+

--- a/tests/resources/swagger/auth-basic-local-converted.yaml
+++ b/tests/resources/swagger/auth-basic-local-converted.yaml
@@ -5,14 +5,15 @@ execution:
   scenario: BZM-API
 scenarios:
   BZM-API:
-    default-address: https://a.blazemeter.com
+    default-address: ${default-address}
     requests:
     - headers:
         Authorization: Basic ${__base64Encode(${auth})}
-      url: ${basePath}/tests
+      url: ${default-path}/tests
     variables:
       auth: USER:PASSWORD
 settings:
   env:
-    basePath: /api/v4
+    default-address: https://a.blazemeter.com
+    default-path: /api/v4
 

--- a/tests/resources/swagger/auth-basic-local-converted.yaml
+++ b/tests/resources/swagger/auth-basic-local-converted.yaml
@@ -9,7 +9,7 @@ scenarios:
     requests:
     - headers:
         Authorization: Basic ${__base64Encode(${auth})}
-      url: /${basePath}/tests
+      url: ${basePath}/tests
     variables:
       auth: USER:PASSWORD
 settings:

--- a/tests/resources/swagger/auth-basic-local.json
+++ b/tests/resources/swagger/auth-basic-local.json
@@ -1,0 +1,548 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "BZM API",
+    "description": "BZM API",
+    "version": "0.0.1"
+  },
+  "host": "a.blazemeter.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/api/v4",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/tests": {
+      "get": {
+        "tags": [
+          "test"
+        ],
+        "summary": "list Tests",
+        "security": [
+          {"myBasic": []}
+        ],
+        "parameters": [
+          {
+            "$ref": "#/parameters/querySkip"
+          },
+          {
+            "$ref": "#/parameters/queryLimit"
+          },
+          {
+            "$ref": "#/parameters/querySort"
+          },
+          {
+            "$ref": "#/parameters/filterByProjectId"
+          },
+          {
+            "$ref": "#/parameters/filterByWorkspaceId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ApiResponseResultPaginated"
+                },
+                {
+                  "properties": {
+                    "result": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Test"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "schema": {
+              "$ref": "#/definitions/ApiResponseError"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "TestPlugins": {
+      "type": "object",
+      "properties": {
+        "modStatus": {
+          "type": "string"
+        }
+      }
+    },
+    "Configuration": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string"
+        },
+        "consoleSize": {
+          "type": "string"
+        },
+        "enginesSize": {
+          "type": "string"
+        },
+        "calculatedDuration": {
+          "type": "integer"
+        },
+        "indexOffset": {
+          "type": "integer"
+        },
+        "collectionIndexOffset": {
+          "type": "integer"
+        },
+        "serversCount": {
+          "type": "integer"
+        },
+        "concurrency": {
+          "type": "integer"
+        },
+        "delayedStart": {
+          "type": "boolean"
+        },
+        "dedicatedIpsEnabled": {
+          "type": "boolean"
+        },
+        "javaVersion": {
+          "type": "string"
+        },
+        "canControlRampup": {
+          "type": "boolean"
+        },
+        "targetThreads": {
+          "type": "integer"
+        },
+        "overrideLocationId": {
+          "type": "string"
+        },
+        "isSandbox": {
+          "type": "boolean"
+        },
+        "execution": {
+          "type": "string"
+        },
+        "enableJMeterProperties": {
+          "type": "boolean"
+        },
+        "plugins": {
+          "$ref": "#/definitions/TestPlugins"
+        }
+      }
+    },
+    "Test": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "draftId": {
+          "type": "string"
+        },
+        "isNewTest": {
+          "type": "boolean"
+        },
+        "lastRunTime": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "oldVersionId": {
+          "type": "integer"
+        },
+        "userId": {
+          "type": "integer"
+        },
+        "createdUsing": {
+          "type": "string"
+        },
+        "project": {
+          "$ref": "#/definitions/Project"
+        },
+        "lastUpdatedBy": {
+          "$ref": "#/definitions/UserInternal"
+        },
+        "configuration": {
+          "$ref": "#/definitions/Configuration"
+        }
+      }
+    },
+    "UserInternal": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "email": {
+          "type": "string"
+        },
+        "access": {
+          "type": "integer"
+        },
+        "login": {
+          "type": "integer"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "company": {
+          "type": "string"
+        },
+        "timezone": {
+          "type": "integer"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "apiKey": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "herokuAppName": {
+          "type": "string"
+        },
+        "maxApiKeyExpiry": {
+          "type": "integer"
+        },
+        "personalWorkspace": {
+          "$ref": "#/definitions/Workspace"
+        },
+        "defaultProject": {
+          "$ref": "#/definitions/Project"
+        }
+      }
+    },
+    "Project": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string"
+        },
+        "workspace": {
+          "$ref": "#/definitions/Workspace"
+        }
+      }
+    },
+    "Workspace": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string"
+        },
+        "salesForceId": {
+          "type": "string"
+        },
+        "dedicatedIpsEnabled": {
+          "type": "boolean"
+        },
+        "privateLocationsEnabled": {
+          "type": "boolean"
+        },
+        "performanceLabsEnabled": {
+          "type": "boolean"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Member"
+          }
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "accountName": {
+          "type": "string"
+        }
+      }
+    },
+    "Member": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "user": {
+          "$ref": "#/definitions/UserInternal"
+        }
+      }
+    },
+    "ApiResponse": {
+      "type": "object",
+      "required": [
+        "api_version"
+      ],
+      "properties": {
+        "api_version": {
+          "type": "integer"
+        }
+      }
+    },
+    "ApiResponseResult": {
+      "type": "object",
+      "required": [
+        "result"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApiResponse"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "ApiResponseResultPaginated": {
+      "type": "object",
+      "required": [
+        "total",
+        "limit",
+        "skip"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApiResponseResult"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "total": {
+              "type": "integer"
+            },
+            "limit": {
+              "type": "integer"
+            },
+            "skip": {
+              "type": "integer"
+            }
+          }
+        }
+      ]
+    },
+    "ApiResponseError": {
+      "type": "object",
+      "required": [
+        "error"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApiResponse"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "type": "integer"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "Report": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "integer"
+        },
+        "publicToken": {
+          "type": "string"
+        },
+        "ended": {
+          "type": "integer"
+        },
+        "lastUpdate": {
+          "type": "integer"
+        },
+        "delayedStartReady": {
+          "type": "boolean"
+        },
+        "runnerUserId": {
+          "type": "integer"
+        },
+        "passed": {
+          "type": "boolean"
+        },
+        "canControlRampup": {
+          "type": "boolean"
+        },
+        "targetThreads": {
+          "type": "integer"
+        },
+        "parallelTestsInWorkspace": {
+          "type": "integer"
+        },
+        "parallelTestsInAccount": {
+          "type": "integer"
+        },
+        "isSandbox": {
+          "type": "boolean"
+        },
+        "isPrivateData": {
+          "type": "boolean"
+        },
+        "executionMode": {
+          "type": "string"
+        },
+        "test": {
+          "$ref": "#/definitions/Test"
+        },
+        "project": {
+          "$ref": "#/definitions/Project"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "querySkip": {
+      "name": "skip",
+      "in": "query",
+      "description": "number of items to skip",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    },
+    "queryLimit": {
+      "name": "limit",
+      "in": "query",
+      "description": "limit quota of items",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    },
+    "querySort": {
+      "name": "sort",
+      "in": "query",
+      "description": "sort items by fields (array of fields)",
+      "required": false,
+      "type": "string"
+    },
+    "querySearch": {
+      "name": "search",
+      "in": "query",
+      "description": "items to show by fields (array of fields)",
+      "required": false,
+      "type": "string"
+    },
+    "filterByProjectId": {
+      "name": "projectId",
+      "description": "filter by Project ID",
+      "in": "query",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    },
+    "filterByWorkspaceId": {
+      "name": "workspaceId",
+      "description": "filter by Workspace ID",
+      "in": "query",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    },
+    "pathTestId": {
+      "name": "testId",
+      "in": "path",
+      "required": true,
+      "type": "integer",
+      "format": "int32"
+    },
+    "pathReportId": {
+      "name": "reportId",
+      "in": "path",
+      "required": true,
+      "type": "integer",
+      "format": "int32"
+    },
+    "queryDelayedStart": {
+      "name": "delayedStart",
+      "description": "start new report with delay",
+      "in": "query",
+      "required": false,
+      "type": "boolean"
+    },
+    "queryFunctionalExecution": {
+      "name": "functionalExecution",
+      "description": "start new report as functional",
+      "in": "query",
+      "required": false,
+      "type": "boolean",
+      "default": true
+    },
+    "filterByTestId": {
+      "name": "testId",
+      "description": "filter by test ID",
+      "in": "query",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    }
+  },
+  "securityDefinitions": {
+    "myBasic": {
+      "type": "basic"
+    }
+  }
+}

--- a/tests/resources/swagger/auth-basic.json
+++ b/tests/resources/swagger/auth-basic.json
@@ -1,0 +1,548 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "BZM API",
+    "description": "BZM API",
+    "version": "0.0.1"
+  },
+  "host": "a.blazemeter.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/api/v4",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {"myBasic": []}
+  ],
+  "paths": {
+    "/tests": {
+      "get": {
+        "tags": [
+          "test"
+        ],
+        "summary": "list Tests",
+        "parameters": [
+          {
+            "$ref": "#/parameters/querySkip"
+          },
+          {
+            "$ref": "#/parameters/queryLimit"
+          },
+          {
+            "$ref": "#/parameters/querySort"
+          },
+          {
+            "$ref": "#/parameters/filterByProjectId"
+          },
+          {
+            "$ref": "#/parameters/filterByWorkspaceId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ApiResponseResultPaginated"
+                },
+                {
+                  "properties": {
+                    "result": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Test"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "schema": {
+              "$ref": "#/definitions/ApiResponseError"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "TestPlugins": {
+      "type": "object",
+      "properties": {
+        "modStatus": {
+          "type": "string"
+        }
+      }
+    },
+    "Configuration": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string"
+        },
+        "consoleSize": {
+          "type": "string"
+        },
+        "enginesSize": {
+          "type": "string"
+        },
+        "calculatedDuration": {
+          "type": "integer"
+        },
+        "indexOffset": {
+          "type": "integer"
+        },
+        "collectionIndexOffset": {
+          "type": "integer"
+        },
+        "serversCount": {
+          "type": "integer"
+        },
+        "concurrency": {
+          "type": "integer"
+        },
+        "delayedStart": {
+          "type": "boolean"
+        },
+        "dedicatedIpsEnabled": {
+          "type": "boolean"
+        },
+        "javaVersion": {
+          "type": "string"
+        },
+        "canControlRampup": {
+          "type": "boolean"
+        },
+        "targetThreads": {
+          "type": "integer"
+        },
+        "overrideLocationId": {
+          "type": "string"
+        },
+        "isSandbox": {
+          "type": "boolean"
+        },
+        "execution": {
+          "type": "string"
+        },
+        "enableJMeterProperties": {
+          "type": "boolean"
+        },
+        "plugins": {
+          "$ref": "#/definitions/TestPlugins"
+        }
+      }
+    },
+    "Test": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "draftId": {
+          "type": "string"
+        },
+        "isNewTest": {
+          "type": "boolean"
+        },
+        "lastRunTime": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "oldVersionId": {
+          "type": "integer"
+        },
+        "userId": {
+          "type": "integer"
+        },
+        "createdUsing": {
+          "type": "string"
+        },
+        "project": {
+          "$ref": "#/definitions/Project"
+        },
+        "lastUpdatedBy": {
+          "$ref": "#/definitions/UserInternal"
+        },
+        "configuration": {
+          "$ref": "#/definitions/Configuration"
+        }
+      }
+    },
+    "UserInternal": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "email": {
+          "type": "string"
+        },
+        "access": {
+          "type": "integer"
+        },
+        "login": {
+          "type": "integer"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "company": {
+          "type": "string"
+        },
+        "timezone": {
+          "type": "integer"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "apiKey": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "herokuAppName": {
+          "type": "string"
+        },
+        "maxApiKeyExpiry": {
+          "type": "integer"
+        },
+        "personalWorkspace": {
+          "$ref": "#/definitions/Workspace"
+        },
+        "defaultProject": {
+          "$ref": "#/definitions/Project"
+        }
+      }
+    },
+    "Project": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string"
+        },
+        "workspace": {
+          "$ref": "#/definitions/Workspace"
+        }
+      }
+    },
+    "Workspace": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string"
+        },
+        "salesForceId": {
+          "type": "string"
+        },
+        "dedicatedIpsEnabled": {
+          "type": "boolean"
+        },
+        "privateLocationsEnabled": {
+          "type": "boolean"
+        },
+        "performanceLabsEnabled": {
+          "type": "boolean"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Member"
+          }
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "accountName": {
+          "type": "string"
+        }
+      }
+    },
+    "Member": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "user": {
+          "$ref": "#/definitions/UserInternal"
+        }
+      }
+    },
+    "ApiResponse": {
+      "type": "object",
+      "required": [
+        "api_version"
+      ],
+      "properties": {
+        "api_version": {
+          "type": "integer"
+        }
+      }
+    },
+    "ApiResponseResult": {
+      "type": "object",
+      "required": [
+        "result"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApiResponse"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "ApiResponseResultPaginated": {
+      "type": "object",
+      "required": [
+        "total",
+        "limit",
+        "skip"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApiResponseResult"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "total": {
+              "type": "integer"
+            },
+            "limit": {
+              "type": "integer"
+            },
+            "skip": {
+              "type": "integer"
+            }
+          }
+        }
+      ]
+    },
+    "ApiResponseError": {
+      "type": "object",
+      "required": [
+        "error"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApiResponse"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "type": "integer"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "Report": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "integer"
+        },
+        "publicToken": {
+          "type": "string"
+        },
+        "ended": {
+          "type": "integer"
+        },
+        "lastUpdate": {
+          "type": "integer"
+        },
+        "delayedStartReady": {
+          "type": "boolean"
+        },
+        "runnerUserId": {
+          "type": "integer"
+        },
+        "passed": {
+          "type": "boolean"
+        },
+        "canControlRampup": {
+          "type": "boolean"
+        },
+        "targetThreads": {
+          "type": "integer"
+        },
+        "parallelTestsInWorkspace": {
+          "type": "integer"
+        },
+        "parallelTestsInAccount": {
+          "type": "integer"
+        },
+        "isSandbox": {
+          "type": "boolean"
+        },
+        "isPrivateData": {
+          "type": "boolean"
+        },
+        "executionMode": {
+          "type": "string"
+        },
+        "test": {
+          "$ref": "#/definitions/Test"
+        },
+        "project": {
+          "$ref": "#/definitions/Project"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "querySkip": {
+      "name": "skip",
+      "in": "query",
+      "description": "number of items to skip",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    },
+    "queryLimit": {
+      "name": "limit",
+      "in": "query",
+      "description": "limit quota of items",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    },
+    "querySort": {
+      "name": "sort",
+      "in": "query",
+      "description": "sort items by fields (array of fields)",
+      "required": false,
+      "type": "string"
+    },
+    "querySearch": {
+      "name": "search",
+      "in": "query",
+      "description": "items to show by fields (array of fields)",
+      "required": false,
+      "type": "string"
+    },
+    "filterByProjectId": {
+      "name": "projectId",
+      "description": "filter by Project ID",
+      "in": "query",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    },
+    "filterByWorkspaceId": {
+      "name": "workspaceId",
+      "description": "filter by Workspace ID",
+      "in": "query",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    },
+    "pathTestId": {
+      "name": "testId",
+      "in": "path",
+      "required": true,
+      "type": "integer",
+      "format": "int32"
+    },
+    "pathReportId": {
+      "name": "reportId",
+      "in": "path",
+      "required": true,
+      "type": "integer",
+      "format": "int32"
+    },
+    "queryDelayedStart": {
+      "name": "delayedStart",
+      "description": "start new report with delay",
+      "in": "query",
+      "required": false,
+      "type": "boolean"
+    },
+    "queryFunctionalExecution": {
+      "name": "functionalExecution",
+      "description": "start new report as functional",
+      "in": "query",
+      "required": false,
+      "type": "boolean",
+      "default": true
+    },
+    "filterByTestId": {
+      "name": "testId",
+      "description": "filter by test ID",
+      "in": "query",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    }
+  },
+  "securityDefinitions": {
+    "myBasic": {
+      "type": "basic"
+    }
+  }
+}

--- a/tests/resources/swagger/auth-key-as-param-converted.yaml
+++ b/tests/resources/swagger/auth-key-as-param-converted.yaml
@@ -5,14 +5,15 @@ execution:
   scenario: BZM-API
 scenarios:
   BZM-API:
-    default-address: https://a.blazemeter.com
+    default-address: ${default-address}
     requests:
     - body:
         api_key: ${myApiKey}
-      url: ${basePath}/tests
+      url: ${default-path}/tests
     variables:
       myApiKey: TOKEN
 settings:
   env:
-    basePath: /api/v4
+    default-address: https://a.blazemeter.com
+    default-path: /api/v4
 

--- a/tests/resources/swagger/auth-key-as-param-converted.yaml
+++ b/tests/resources/swagger/auth-key-as-param-converted.yaml
@@ -7,9 +7,10 @@ scenarios:
   BZM-API:
     default-address: https://a.blazemeter.com
     variables:
+      basePath: /api/v4
       myApiKey: TOKEN
     requests:
-    - url: /api/v4/tests
-      body:
+    - body:
         api_key: ${myApiKey}
+      url: /${basePath}/tests
 

--- a/tests/resources/swagger/auth-key-as-param-converted.yaml
+++ b/tests/resources/swagger/auth-key-as-param-converted.yaml
@@ -9,7 +9,7 @@ scenarios:
     requests:
     - body:
         api_key: ${myApiKey}
-      url: /${basePath}/tests
+      url: ${basePath}/tests
     variables:
       myApiKey: TOKEN
 settings:

--- a/tests/resources/swagger/auth-key-as-param-converted.yaml
+++ b/tests/resources/swagger/auth-key-as-param-converted.yaml
@@ -1,0 +1,15 @@
+---
+execution:
+- concurrency: 1
+  hold-for: 1m
+  scenario: BZM-API
+scenarios:
+  BZM-API:
+    default-address: https://a.blazemeter.com
+    variables:
+      myApiKey: TOKEN
+    requests:
+    - url: /api/v4/tests
+      body:
+        api_key: ${myApiKey}
+

--- a/tests/resources/swagger/auth-key-as-param-converted.yaml
+++ b/tests/resources/swagger/auth-key-as-param-converted.yaml
@@ -6,11 +6,13 @@ execution:
 scenarios:
   BZM-API:
     default-address: https://a.blazemeter.com
-    variables:
-      basePath: /api/v4
-      myApiKey: TOKEN
     requests:
     - body:
         api_key: ${myApiKey}
       url: /${basePath}/tests
+    variables:
+      myApiKey: TOKEN
+settings:
+  env:
+    basePath: /api/v4
 

--- a/tests/resources/swagger/auth-key-as-param.json
+++ b/tests/resources/swagger/auth-key-as-param.json
@@ -1,0 +1,550 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "BZM API",
+    "description": "BZM API",
+    "version": "0.0.1"
+  },
+  "host": "a.blazemeter.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/api/v4",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {"myApiKey": []}
+  ],
+  "paths": {
+    "/tests": {
+      "get": {
+        "tags": [
+          "test"
+        ],
+        "summary": "list Tests",
+        "parameters": [
+          {
+            "$ref": "#/parameters/querySkip"
+          },
+          {
+            "$ref": "#/parameters/queryLimit"
+          },
+          {
+            "$ref": "#/parameters/querySort"
+          },
+          {
+            "$ref": "#/parameters/filterByProjectId"
+          },
+          {
+            "$ref": "#/parameters/filterByWorkspaceId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ApiResponseResultPaginated"
+                },
+                {
+                  "properties": {
+                    "result": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Test"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "schema": {
+              "$ref": "#/definitions/ApiResponseError"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "TestPlugins": {
+      "type": "object",
+      "properties": {
+        "modStatus": {
+          "type": "string"
+        }
+      }
+    },
+    "Configuration": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string"
+        },
+        "consoleSize": {
+          "type": "string"
+        },
+        "enginesSize": {
+          "type": "string"
+        },
+        "calculatedDuration": {
+          "type": "integer"
+        },
+        "indexOffset": {
+          "type": "integer"
+        },
+        "collectionIndexOffset": {
+          "type": "integer"
+        },
+        "serversCount": {
+          "type": "integer"
+        },
+        "concurrency": {
+          "type": "integer"
+        },
+        "delayedStart": {
+          "type": "boolean"
+        },
+        "dedicatedIpsEnabled": {
+          "type": "boolean"
+        },
+        "javaVersion": {
+          "type": "string"
+        },
+        "canControlRampup": {
+          "type": "boolean"
+        },
+        "targetThreads": {
+          "type": "integer"
+        },
+        "overrideLocationId": {
+          "type": "string"
+        },
+        "isSandbox": {
+          "type": "boolean"
+        },
+        "execution": {
+          "type": "string"
+        },
+        "enableJMeterProperties": {
+          "type": "boolean"
+        },
+        "plugins": {
+          "$ref": "#/definitions/TestPlugins"
+        }
+      }
+    },
+    "Test": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "draftId": {
+          "type": "string"
+        },
+        "isNewTest": {
+          "type": "boolean"
+        },
+        "lastRunTime": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "oldVersionId": {
+          "type": "integer"
+        },
+        "userId": {
+          "type": "integer"
+        },
+        "createdUsing": {
+          "type": "string"
+        },
+        "project": {
+          "$ref": "#/definitions/Project"
+        },
+        "lastUpdatedBy": {
+          "$ref": "#/definitions/UserInternal"
+        },
+        "configuration": {
+          "$ref": "#/definitions/Configuration"
+        }
+      }
+    },
+    "UserInternal": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "email": {
+          "type": "string"
+        },
+        "access": {
+          "type": "integer"
+        },
+        "login": {
+          "type": "integer"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "company": {
+          "type": "string"
+        },
+        "timezone": {
+          "type": "integer"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "apiKey": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "herokuAppName": {
+          "type": "string"
+        },
+        "maxApiKeyExpiry": {
+          "type": "integer"
+        },
+        "personalWorkspace": {
+          "$ref": "#/definitions/Workspace"
+        },
+        "defaultProject": {
+          "$ref": "#/definitions/Project"
+        }
+      }
+    },
+    "Project": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string"
+        },
+        "workspace": {
+          "$ref": "#/definitions/Workspace"
+        }
+      }
+    },
+    "Workspace": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string"
+        },
+        "salesForceId": {
+          "type": "string"
+        },
+        "dedicatedIpsEnabled": {
+          "type": "boolean"
+        },
+        "privateLocationsEnabled": {
+          "type": "boolean"
+        },
+        "performanceLabsEnabled": {
+          "type": "boolean"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Member"
+          }
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "accountName": {
+          "type": "string"
+        }
+      }
+    },
+    "Member": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "user": {
+          "$ref": "#/definitions/UserInternal"
+        }
+      }
+    },
+    "ApiResponse": {
+      "type": "object",
+      "required": [
+        "api_version"
+      ],
+      "properties": {
+        "api_version": {
+          "type": "integer"
+        }
+      }
+    },
+    "ApiResponseResult": {
+      "type": "object",
+      "required": [
+        "result"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApiResponse"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "ApiResponseResultPaginated": {
+      "type": "object",
+      "required": [
+        "total",
+        "limit",
+        "skip"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApiResponseResult"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "total": {
+              "type": "integer"
+            },
+            "limit": {
+              "type": "integer"
+            },
+            "skip": {
+              "type": "integer"
+            }
+          }
+        }
+      ]
+    },
+    "ApiResponseError": {
+      "type": "object",
+      "required": [
+        "error"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApiResponse"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "type": "integer"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "Report": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "integer"
+        },
+        "publicToken": {
+          "type": "string"
+        },
+        "ended": {
+          "type": "integer"
+        },
+        "lastUpdate": {
+          "type": "integer"
+        },
+        "delayedStartReady": {
+          "type": "boolean"
+        },
+        "runnerUserId": {
+          "type": "integer"
+        },
+        "passed": {
+          "type": "boolean"
+        },
+        "canControlRampup": {
+          "type": "boolean"
+        },
+        "targetThreads": {
+          "type": "integer"
+        },
+        "parallelTestsInWorkspace": {
+          "type": "integer"
+        },
+        "parallelTestsInAccount": {
+          "type": "integer"
+        },
+        "isSandbox": {
+          "type": "boolean"
+        },
+        "isPrivateData": {
+          "type": "boolean"
+        },
+        "executionMode": {
+          "type": "string"
+        },
+        "test": {
+          "$ref": "#/definitions/Test"
+        },
+        "project": {
+          "$ref": "#/definitions/Project"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "querySkip": {
+      "name": "skip",
+      "in": "query",
+      "description": "number of items to skip",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    },
+    "queryLimit": {
+      "name": "limit",
+      "in": "query",
+      "description": "limit quota of items",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    },
+    "querySort": {
+      "name": "sort",
+      "in": "query",
+      "description": "sort items by fields (array of fields)",
+      "required": false,
+      "type": "string"
+    },
+    "querySearch": {
+      "name": "search",
+      "in": "query",
+      "description": "items to show by fields (array of fields)",
+      "required": false,
+      "type": "string"
+    },
+    "filterByProjectId": {
+      "name": "projectId",
+      "description": "filter by Project ID",
+      "in": "query",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    },
+    "filterByWorkspaceId": {
+      "name": "workspaceId",
+      "description": "filter by Workspace ID",
+      "in": "query",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    },
+    "pathTestId": {
+      "name": "testId",
+      "in": "path",
+      "required": true,
+      "type": "integer",
+      "format": "int32"
+    },
+    "pathReportId": {
+      "name": "reportId",
+      "in": "path",
+      "required": true,
+      "type": "integer",
+      "format": "int32"
+    },
+    "queryDelayedStart": {
+      "name": "delayedStart",
+      "description": "start new report with delay",
+      "in": "query",
+      "required": false,
+      "type": "boolean"
+    },
+    "queryFunctionalExecution": {
+      "name": "functionalExecution",
+      "description": "start new report as functional",
+      "in": "query",
+      "required": false,
+      "type": "boolean",
+      "default": true
+    },
+    "filterByTestId": {
+      "name": "testId",
+      "description": "filter by test ID",
+      "in": "query",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    }
+  },
+  "securityDefinitions": {
+    "myApiKey": {
+      "type": "apiKey",
+      "in": "query",
+      "name": "api_key"
+    }
+  }
+}

--- a/tests/resources/swagger/auth-key-converted.yaml
+++ b/tests/resources/swagger/auth-key-converted.yaml
@@ -9,7 +9,7 @@ scenarios:
     headers:
       api_key: ${myApiKey}
     requests:
-    - url: /${basePath}/tests
+    - url: ${basePath}/tests
 settings:
   env:
     basePath: /api/v4

--- a/tests/resources/swagger/auth-key-converted.yaml
+++ b/tests/resources/swagger/auth-key-converted.yaml
@@ -1,0 +1,15 @@
+---
+execution:
+- concurrency: 1
+  hold-for: 1m
+  scenario: BZM-API
+scenarios:
+  BZM-API:
+    default-address: https://a.blazemeter.com
+    headers:
+      api_key: ${myApiKey}
+    variables:
+      myApiKey: TOKEN
+    requests:
+    - url: /api/v4/tests
+

--- a/tests/resources/swagger/auth-key-converted.yaml
+++ b/tests/resources/swagger/auth-key-converted.yaml
@@ -5,13 +5,14 @@ execution:
   scenario: BZM-API
 scenarios:
   BZM-API:
-    default-address: https://a.blazemeter.com
+    default-address: ${default-address}
     headers:
       api_key: ${myApiKey}
     requests:
-    - url: ${basePath}/tests
+    - url: ${default-path}/tests
 settings:
   env:
-    basePath: /api/v4
+    default-address: https://a.blazemeter.com
+    default-path: /api/v4
     myApiKey: TOKEN
 

--- a/tests/resources/swagger/auth-key-converted.yaml
+++ b/tests/resources/swagger/auth-key-converted.yaml
@@ -9,7 +9,8 @@ scenarios:
     headers:
       api_key: ${myApiKey}
     variables:
+      basePath: /api/v4
       myApiKey: TOKEN
     requests:
-    - url: /api/v4/tests
+    - url: /${basePath}/tests
 

--- a/tests/resources/swagger/auth-key-multiscenarios-converted.yaml
+++ b/tests/resources/swagger/auth-key-multiscenarios-converted.yaml
@@ -9,7 +9,7 @@ scenarios:
     headers:
       api_key: ${myApiKey}
     requests:
-    - url: /${basePath}/tests
+    - url: ${basePath}/tests
 settings:
   env:
     basePath: /api/v4

--- a/tests/resources/swagger/auth-key-multiscenarios-converted.yaml
+++ b/tests/resources/swagger/auth-key-multiscenarios-converted.yaml
@@ -2,10 +2,10 @@
 execution:
 - concurrency: 1
   hold-for: 1m
-  scenario: BZM-API
+  scenario: /tests
 scenarios:
-  BZM-API:
-    default-address: https://a.blazemeter.com
+  /tests:
+    default-address: ${defaultAddress}
     headers:
       api_key: ${myApiKey}
     requests:
@@ -13,5 +13,5 @@ scenarios:
 settings:
   env:
     basePath: /api/v4
+    defaultAddress: https://a.blazemeter.com
     myApiKey: TOKEN
-

--- a/tests/resources/swagger/auth-key-multiscenarios-converted.yaml
+++ b/tests/resources/swagger/auth-key-multiscenarios-converted.yaml
@@ -5,14 +5,14 @@ execution:
   scenario: /tests
 scenarios:
   /tests:
-    default-address: ${defaultAddress}
+    default-address: ${default-address}
     headers:
       api_key: ${myApiKey}
     requests:
     - url: ${default-path}/tests
 settings:
   env:
+    default-address: https://a.blazemeter.com
     default-path: /api/v4
-    defaultAddress: https://a.blazemeter.com
     myApiKey: TOKEN
 

--- a/tests/resources/swagger/auth-key-multiscenarios-converted.yaml
+++ b/tests/resources/swagger/auth-key-multiscenarios-converted.yaml
@@ -9,9 +9,10 @@ scenarios:
     headers:
       api_key: ${myApiKey}
     requests:
-    - url: ${basePath}/tests
+    - url: ${default-path}/tests
 settings:
   env:
-    basePath: /api/v4
+    default-path: /api/v4
     defaultAddress: https://a.blazemeter.com
     myApiKey: TOKEN
+

--- a/tests/resources/swagger/auth-key.json
+++ b/tests/resources/swagger/auth-key.json
@@ -1,0 +1,550 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "BZM API",
+    "description": "BZM API",
+    "version": "0.0.1"
+  },
+  "host": "a.blazemeter.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/api/v4",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {"myApiKey": []}
+  ],
+  "paths": {
+    "/tests": {
+      "get": {
+        "tags": [
+          "test"
+        ],
+        "summary": "list Tests",
+        "parameters": [
+          {
+            "$ref": "#/parameters/querySkip"
+          },
+          {
+            "$ref": "#/parameters/queryLimit"
+          },
+          {
+            "$ref": "#/parameters/querySort"
+          },
+          {
+            "$ref": "#/parameters/filterByProjectId"
+          },
+          {
+            "$ref": "#/parameters/filterByWorkspaceId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ApiResponseResultPaginated"
+                },
+                {
+                  "properties": {
+                    "result": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Test"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "schema": {
+              "$ref": "#/definitions/ApiResponseError"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "TestPlugins": {
+      "type": "object",
+      "properties": {
+        "modStatus": {
+          "type": "string"
+        }
+      }
+    },
+    "Configuration": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string"
+        },
+        "consoleSize": {
+          "type": "string"
+        },
+        "enginesSize": {
+          "type": "string"
+        },
+        "calculatedDuration": {
+          "type": "integer"
+        },
+        "indexOffset": {
+          "type": "integer"
+        },
+        "collectionIndexOffset": {
+          "type": "integer"
+        },
+        "serversCount": {
+          "type": "integer"
+        },
+        "concurrency": {
+          "type": "integer"
+        },
+        "delayedStart": {
+          "type": "boolean"
+        },
+        "dedicatedIpsEnabled": {
+          "type": "boolean"
+        },
+        "javaVersion": {
+          "type": "string"
+        },
+        "canControlRampup": {
+          "type": "boolean"
+        },
+        "targetThreads": {
+          "type": "integer"
+        },
+        "overrideLocationId": {
+          "type": "string"
+        },
+        "isSandbox": {
+          "type": "boolean"
+        },
+        "execution": {
+          "type": "string"
+        },
+        "enableJMeterProperties": {
+          "type": "boolean"
+        },
+        "plugins": {
+          "$ref": "#/definitions/TestPlugins"
+        }
+      }
+    },
+    "Test": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "draftId": {
+          "type": "string"
+        },
+        "isNewTest": {
+          "type": "boolean"
+        },
+        "lastRunTime": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "oldVersionId": {
+          "type": "integer"
+        },
+        "userId": {
+          "type": "integer"
+        },
+        "createdUsing": {
+          "type": "string"
+        },
+        "project": {
+          "$ref": "#/definitions/Project"
+        },
+        "lastUpdatedBy": {
+          "$ref": "#/definitions/UserInternal"
+        },
+        "configuration": {
+          "$ref": "#/definitions/Configuration"
+        }
+      }
+    },
+    "UserInternal": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "email": {
+          "type": "string"
+        },
+        "access": {
+          "type": "integer"
+        },
+        "login": {
+          "type": "integer"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "company": {
+          "type": "string"
+        },
+        "timezone": {
+          "type": "integer"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "apiKey": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "herokuAppName": {
+          "type": "string"
+        },
+        "maxApiKeyExpiry": {
+          "type": "integer"
+        },
+        "personalWorkspace": {
+          "$ref": "#/definitions/Workspace"
+        },
+        "defaultProject": {
+          "$ref": "#/definitions/Project"
+        }
+      }
+    },
+    "Project": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string"
+        },
+        "workspace": {
+          "$ref": "#/definitions/Workspace"
+        }
+      }
+    },
+    "Workspace": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string"
+        },
+        "salesForceId": {
+          "type": "string"
+        },
+        "dedicatedIpsEnabled": {
+          "type": "boolean"
+        },
+        "privateLocationsEnabled": {
+          "type": "boolean"
+        },
+        "performanceLabsEnabled": {
+          "type": "boolean"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "members": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Member"
+          }
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "accountName": {
+          "type": "string"
+        }
+      }
+    },
+    "Member": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "user": {
+          "$ref": "#/definitions/UserInternal"
+        }
+      }
+    },
+    "ApiResponse": {
+      "type": "object",
+      "required": [
+        "api_version"
+      ],
+      "properties": {
+        "api_version": {
+          "type": "integer"
+        }
+      }
+    },
+    "ApiResponseResult": {
+      "type": "object",
+      "required": [
+        "result"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApiResponse"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "ApiResponseResultPaginated": {
+      "type": "object",
+      "required": [
+        "total",
+        "limit",
+        "skip"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApiResponseResult"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "total": {
+              "type": "integer"
+            },
+            "limit": {
+              "type": "integer"
+            },
+            "skip": {
+              "type": "integer"
+            }
+          }
+        }
+      ]
+    },
+    "ApiResponseError": {
+      "type": "object",
+      "required": [
+        "error"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApiResponse"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "error": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "type": "integer"
+                },
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "Report": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "integer"
+        },
+        "publicToken": {
+          "type": "string"
+        },
+        "ended": {
+          "type": "integer"
+        },
+        "lastUpdate": {
+          "type": "integer"
+        },
+        "delayedStartReady": {
+          "type": "boolean"
+        },
+        "runnerUserId": {
+          "type": "integer"
+        },
+        "passed": {
+          "type": "boolean"
+        },
+        "canControlRampup": {
+          "type": "boolean"
+        },
+        "targetThreads": {
+          "type": "integer"
+        },
+        "parallelTestsInWorkspace": {
+          "type": "integer"
+        },
+        "parallelTestsInAccount": {
+          "type": "integer"
+        },
+        "isSandbox": {
+          "type": "boolean"
+        },
+        "isPrivateData": {
+          "type": "boolean"
+        },
+        "executionMode": {
+          "type": "string"
+        },
+        "test": {
+          "$ref": "#/definitions/Test"
+        },
+        "project": {
+          "$ref": "#/definitions/Project"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "querySkip": {
+      "name": "skip",
+      "in": "query",
+      "description": "number of items to skip",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    },
+    "queryLimit": {
+      "name": "limit",
+      "in": "query",
+      "description": "limit quota of items",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    },
+    "querySort": {
+      "name": "sort",
+      "in": "query",
+      "description": "sort items by fields (array of fields)",
+      "required": false,
+      "type": "string"
+    },
+    "querySearch": {
+      "name": "search",
+      "in": "query",
+      "description": "items to show by fields (array of fields)",
+      "required": false,
+      "type": "string"
+    },
+    "filterByProjectId": {
+      "name": "projectId",
+      "description": "filter by Project ID",
+      "in": "query",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    },
+    "filterByWorkspaceId": {
+      "name": "workspaceId",
+      "description": "filter by Workspace ID",
+      "in": "query",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    },
+    "pathTestId": {
+      "name": "testId",
+      "in": "path",
+      "required": true,
+      "type": "integer",
+      "format": "int32"
+    },
+    "pathReportId": {
+      "name": "reportId",
+      "in": "path",
+      "required": true,
+      "type": "integer",
+      "format": "int32"
+    },
+    "queryDelayedStart": {
+      "name": "delayedStart",
+      "description": "start new report with delay",
+      "in": "query",
+      "required": false,
+      "type": "boolean"
+    },
+    "queryFunctionalExecution": {
+      "name": "functionalExecution",
+      "description": "start new report as functional",
+      "in": "query",
+      "required": false,
+      "type": "boolean",
+      "default": true
+    },
+    "filterByTestId": {
+      "name": "testId",
+      "description": "filter by test ID",
+      "in": "query",
+      "required": false,
+      "type": "integer",
+      "format": "int32"
+    }
+  },
+  "securityDefinitions": {
+    "myApiKey": {
+      "type": "apiKey",
+      "in": "header",
+      "name": "api_key"
+    }
+  }
+}

--- a/tests/resources/swagger/bzm-api-converted.yaml
+++ b/tests/resources/swagger/bzm-api-converted.yaml
@@ -19,32 +19,32 @@ scenarios:
   /reports:
     default-address: ${defaultAddress}
     requests:
-    - url: /${basePath}/reports
+    - url: ${basePath}/reports
   /reports/1:
     default-address: ${defaultAddress}
     requests:
-    - url: /${basePath}/reports/1
+    - url: ${basePath}/reports/1
   /tests:
     default-address: ${defaultAddress}
     requests:
-    - url: /${basePath}/tests
+    - url: ${basePath}/tests
     - method: POST
-      url: /${basePath}/tests
+      url: ${basePath}/tests
   /tests/1:
     default-address: ${defaultAddress}
     requests:
-    - url: /${basePath}/tests/1
+    - url: ${basePath}/tests/1
     - method: PUT
-      url: /${basePath}/tests/1
+      url: ${basePath}/tests/1
     - method: DELETE
-      url: /${basePath}/tests/1
+      url: ${basePath}/tests/1
     - method: PATCH
-      url: /${basePath}/tests/1
+      url: ${basePath}/tests/1
   /tests/1/start:
     default-address: ${defaultAddress}
     requests:
     - method: POST
-      url: /${basePath}/tests/1/start
+      url: ${basePath}/tests/1/start
 settings:
   env:
     basePath: /api/v4

--- a/tests/resources/swagger/bzm-api-converted.yaml
+++ b/tests/resources/swagger/bzm-api-converted.yaml
@@ -19,34 +19,34 @@ scenarios:
   /reports:
     default-address: ${defaultAddress}
     requests:
-    - url: ${basePath}/reports
+    - url: ${default-path}/reports
   /reports/1:
     default-address: ${defaultAddress}
     requests:
-    - url: ${basePath}/reports/1
+    - url: ${default-path}/reports/1
   /tests:
     default-address: ${defaultAddress}
     requests:
-    - url: ${basePath}/tests
+    - url: ${default-path}/tests
     - method: POST
-      url: ${basePath}/tests
+      url: ${default-path}/tests
   /tests/1:
     default-address: ${defaultAddress}
     requests:
-    - url: ${basePath}/tests/1
+    - url: ${default-path}/tests/1
     - method: PUT
-      url: ${basePath}/tests/1
+      url: ${default-path}/tests/1
     - method: DELETE
-      url: ${basePath}/tests/1
+      url: ${default-path}/tests/1
     - method: PATCH
-      url: ${basePath}/tests/1
+      url: ${default-path}/tests/1
   /tests/1/start:
     default-address: ${defaultAddress}
     requests:
     - method: POST
-      url: ${basePath}/tests/1/start
+      url: ${default-path}/tests/1/start
 settings:
   env:
-    basePath: /api/v4
+    default-path: /api/v4
     defaultAddress: https://a.blazemeter.com
 

--- a/tests/resources/swagger/bzm-api-converted.yaml
+++ b/tests/resources/swagger/bzm-api-converted.yaml
@@ -17,27 +17,21 @@ execution:
   scenario: /reports/1
 scenarios:
   /reports:
-    default-address: https://a.blazemeter.com
+    default-address: ${defaultAddress}
     requests:
     - url: /${basePath}/reports
-    variables:
-      basePath: /api/v4
   /reports/1:
-    default-address: https://a.blazemeter.com
+    default-address: ${defaultAddress}
     requests:
     - url: /${basePath}/reports/1
-    variables:
-      basePath: /api/v4
   /tests:
-    default-address: https://a.blazemeter.com
+    default-address: ${defaultAddress}
     requests:
     - url: /${basePath}/tests
     - method: POST
       url: /${basePath}/tests
-    variables:
-      basePath: /api/v4
   /tests/1:
-    default-address: https://a.blazemeter.com
+    default-address: ${defaultAddress}
     requests:
     - url: /${basePath}/tests/1
     - method: PUT
@@ -46,13 +40,13 @@ scenarios:
       url: /${basePath}/tests/1
     - method: PATCH
       url: /${basePath}/tests/1
-    variables:
-      basePath: /api/v4
   /tests/1/start:
-    default-address: https://a.blazemeter.com
+    default-address: ${defaultAddress}
     requests:
     - method: POST
       url: /${basePath}/tests/1/start
-    variables:
-      basePath: /api/v4
+settings:
+  env:
+    basePath: /api/v4
+    defaultAddress: https://a.blazemeter.com
 

--- a/tests/resources/swagger/bzm-api-converted.yaml
+++ b/tests/resources/swagger/bzm-api-converted.yaml
@@ -19,30 +19,40 @@ scenarios:
   /reports:
     default-address: https://a.blazemeter.com
     requests:
-    - url: /api/v4/reports
+    - url: /${basePath}/reports
+    variables:
+      basePath: /api/v4
   /reports/1:
     default-address: https://a.blazemeter.com
     requests:
-    - url: /api/v4/reports/1
+    - url: /${basePath}/reports/1
+    variables:
+      basePath: /api/v4
   /tests:
     default-address: https://a.blazemeter.com
     requests:
-    - url: /api/v4/tests
+    - url: /${basePath}/tests
     - method: POST
-      url: /api/v4/tests
+      url: /${basePath}/tests
+    variables:
+      basePath: /api/v4
   /tests/1:
     default-address: https://a.blazemeter.com
     requests:
-    - url: /api/v4/tests/1
+    - url: /${basePath}/tests/1
     - method: PUT
-      url: /api/v4/tests/1
+      url: /${basePath}/tests/1
     - method: DELETE
-      url: /api/v4/tests/1
+      url: /${basePath}/tests/1
     - method: PATCH
-      url: /api/v4/tests/1
+      url: /${basePath}/tests/1
+    variables:
+      basePath: /api/v4
   /tests/1/start:
     default-address: https://a.blazemeter.com
     requests:
     - method: POST
-      url: /api/v4/tests/1/start
+      url: /${basePath}/tests/1/start
+    variables:
+      basePath: /api/v4
 

--- a/tests/resources/swagger/bzm-api-converted.yaml
+++ b/tests/resources/swagger/bzm-api-converted.yaml
@@ -17,21 +17,21 @@ execution:
   scenario: /reports/1
 scenarios:
   /reports:
-    default-address: ${defaultAddress}
+    default-address: ${default-address}
     requests:
     - url: ${default-path}/reports
   /reports/1:
-    default-address: ${defaultAddress}
+    default-address: ${default-address}
     requests:
     - url: ${default-path}/reports/1
   /tests:
-    default-address: ${defaultAddress}
+    default-address: ${default-address}
     requests:
     - url: ${default-path}/tests
     - method: POST
       url: ${default-path}/tests
   /tests/1:
-    default-address: ${defaultAddress}
+    default-address: ${default-address}
     requests:
     - url: ${default-path}/tests/1
     - method: PUT
@@ -41,12 +41,12 @@ scenarios:
     - method: PATCH
       url: ${default-path}/tests/1
   /tests/1/start:
-    default-address: ${defaultAddress}
+    default-address: ${default-address}
     requests:
     - method: POST
       url: ${default-path}/tests/1/start
 settings:
   env:
+    default-address: https://a.blazemeter.com
     default-path: /api/v4
-    defaultAddress: https://a.blazemeter.com
 

--- a/tests/resources/swagger/bzm-api.json
+++ b/tests/resources/swagger/bzm-api.json
@@ -16,9 +16,6 @@
   "consumes": [
     "application/json"
   ],
-  "security": [
-    {"myApiKey": []}
-  ],
   "paths": {
     "/tests": {
       "get": {

--- a/tests/resources/swagger/bzm-api.json
+++ b/tests/resources/swagger/bzm-api.json
@@ -16,6 +16,9 @@
   "consumes": [
     "application/json"
   ],
+  "security": [
+    {"myApiKey": []}
+  ],
   "paths": {
     "/tests": {
       "get": {

--- a/tests/resources/swagger/bzm-converted-none.yaml
+++ b/tests/resources/swagger/bzm-converted-none.yaml
@@ -7,20 +7,20 @@ scenarios:
   BZM-API:
     default-address: https://a.blazemeter.com
     requests:
-    - url: /${basePath}/tests
+    - url: ${basePath}/tests
     - method: POST
-      url: /${basePath}/tests
-    - url: /${basePath}/tests/{testId}
+      url: ${basePath}/tests
+    - url: ${basePath}/tests/{testId}
     - method: PUT
-      url: /${basePath}/tests/{testId}
+      url: ${basePath}/tests/{testId}
     - method: DELETE
-      url: /${basePath}/tests/{testId}
+      url: ${basePath}/tests/{testId}
     - method: PATCH
-      url: /${basePath}/tests/{testId}
+      url: ${basePath}/tests/{testId}
     - method: POST
-      url: /${basePath}/tests/{testId}/start
-    - url: /${basePath}/reports
-    - url: /${basePath}/reports/{reportId}
+      url: ${basePath}/tests/{testId}/start
+    - url: ${basePath}/reports
+    - url: ${basePath}/reports/{reportId}
 settings:
   env:
     basePath: /api/v4

--- a/tests/resources/swagger/bzm-converted-none.yaml
+++ b/tests/resources/swagger/bzm-converted-none.yaml
@@ -7,18 +7,20 @@ scenarios:
   BZM-API:
     default-address: https://a.blazemeter.com
     requests:
-    - url: /api/v4/tests
+    - url: /${basePath}/tests
     - method: POST
-      url: /api/v4/tests
-    - url: /api/v4/tests/{testId}
+      url: /${basePath}/tests
+    - url: /${basePath}/tests/{testId}
     - method: PUT
-      url: /api/v4/tests/{testId}
+      url: /${basePath}/tests/{testId}
     - method: DELETE
-      url: /api/v4/tests/{testId}
+      url: /${basePath}/tests/{testId}
     - method: PATCH
-      url: /api/v4/tests/{testId}
+      url: /${basePath}/tests/{testId}
     - method: POST
-      url: /api/v4/tests/{testId}/start
-    - url: /api/v4/reports
-    - url: /api/v4/reports/{reportId}
+      url: /${basePath}/tests/{testId}/start
+    - url: /${basePath}/reports
+    - url: /${basePath}/reports/{reportId}
+    variables:
+      basePath: /api/v4
 

--- a/tests/resources/swagger/bzm-converted-none.yaml
+++ b/tests/resources/swagger/bzm-converted-none.yaml
@@ -21,6 +21,7 @@ scenarios:
       url: /${basePath}/tests/{testId}/start
     - url: /${basePath}/reports
     - url: /${basePath}/reports/{reportId}
-    variables:
-      basePath: /api/v4
+settings:
+  env:
+    basePath: /api/v4
 

--- a/tests/resources/swagger/bzm-converted-none.yaml
+++ b/tests/resources/swagger/bzm-converted-none.yaml
@@ -5,23 +5,24 @@ execution:
   scenario: BZM-API
 scenarios:
   BZM-API:
-    default-address: https://a.blazemeter.com
+    default-address: ${default-address}
     requests:
-    - url: ${basePath}/tests
+    - url: ${default-path}/tests
     - method: POST
-      url: ${basePath}/tests
-    - url: ${basePath}/tests/{testId}
+      url: ${default-path}/tests
+    - url: ${default-path}/tests/{testId}
     - method: PUT
-      url: ${basePath}/tests/{testId}
+      url: ${default-path}/tests/{testId}
     - method: DELETE
-      url: ${basePath}/tests/{testId}
+      url: ${default-path}/tests/{testId}
     - method: PATCH
-      url: ${basePath}/tests/{testId}
+      url: ${default-path}/tests/{testId}
     - method: POST
-      url: ${basePath}/tests/{testId}/start
-    - url: ${basePath}/reports
-    - url: ${basePath}/reports/{reportId}
+      url: ${default-path}/tests/{testId}/start
+    - url: ${default-path}/reports
+    - url: ${default-path}/reports/{reportId}
 settings:
   env:
-    basePath: /api/v4
+    default-address: https://a.blazemeter.com
+    default-path: /api/v4
 

--- a/tests/resources/swagger/bzm-converted-none.yaml
+++ b/tests/resources/swagger/bzm-converted-none.yaml
@@ -1,0 +1,24 @@
+---
+execution:
+- concurrency: 1
+  hold-for: 1m
+  scenario: BZM-API
+scenarios:
+  BZM-API:
+    default-address: https://a.blazemeter.com
+    requests:
+    - url: /api/v4/tests
+    - method: POST
+      url: /api/v4/tests
+    - url: /api/v4/tests/{testId}
+    - method: PUT
+      url: /api/v4/tests/{testId}
+    - method: DELETE
+      url: /api/v4/tests/{testId}
+    - method: PATCH
+      url: /api/v4/tests/{testId}
+    - method: POST
+      url: /api/v4/tests/{testId}/start
+    - url: /api/v4/reports
+    - url: /api/v4/reports/{reportId}
+

--- a/tests/resources/swagger/bzm-converted-values.yaml
+++ b/tests/resources/swagger/bzm-converted-values.yaml
@@ -7,18 +7,20 @@ scenarios:
   BZM-API:
     default-address: https://a.blazemeter.com
     requests:
-    - url: /api/v4/tests
+    - url: /${basePath}/tests
     - method: POST
-      url: /api/v4/tests
-    - url: /api/v4/tests/1
+      url: /${basePath}/tests
+    - url: /${basePath}/tests/1
     - method: PUT
-      url: /api/v4/tests/1
+      url: /${basePath}/tests/1
     - method: DELETE
-      url: /api/v4/tests/1
+      url: /${basePath}/tests/1
     - method: PATCH
-      url: /api/v4/tests/1
+      url: /${basePath}/tests/1
     - method: POST
-      url: /api/v4/tests/1/start
-    - url: /api/v4/reports
-    - url: /api/v4/reports/1
+      url: /${basePath}/tests/1/start
+    - url: /${basePath}/reports
+    - url: /${basePath}/reports/1
+    variables:
+      basePath: /api/v4
 

--- a/tests/resources/swagger/bzm-converted-values.yaml
+++ b/tests/resources/swagger/bzm-converted-values.yaml
@@ -7,20 +7,20 @@ scenarios:
   BZM-API:
     default-address: https://a.blazemeter.com
     requests:
-    - url: /${basePath}/tests
+    - url: ${basePath}/tests
     - method: POST
-      url: /${basePath}/tests
-    - url: /${basePath}/tests/1
+      url: ${basePath}/tests
+    - url: ${basePath}/tests/1
     - method: PUT
-      url: /${basePath}/tests/1
+      url: ${basePath}/tests/1
     - method: DELETE
-      url: /${basePath}/tests/1
+      url: ${basePath}/tests/1
     - method: PATCH
-      url: /${basePath}/tests/1
+      url: ${basePath}/tests/1
     - method: POST
-      url: /${basePath}/tests/1/start
-    - url: /${basePath}/reports
-    - url: /${basePath}/reports/1
+      url: ${basePath}/tests/1/start
+    - url: ${basePath}/reports
+    - url: ${basePath}/reports/1
 settings:
   env:
     basePath: /api/v4

--- a/tests/resources/swagger/bzm-converted-values.yaml
+++ b/tests/resources/swagger/bzm-converted-values.yaml
@@ -21,6 +21,7 @@ scenarios:
       url: /${basePath}/tests/1/start
     - url: /${basePath}/reports
     - url: /${basePath}/reports/1
-    variables:
-      basePath: /api/v4
+settings:
+  env:
+    basePath: /api/v4
 

--- a/tests/resources/swagger/bzm-converted-values.yaml
+++ b/tests/resources/swagger/bzm-converted-values.yaml
@@ -5,23 +5,24 @@ execution:
   scenario: BZM-API
 scenarios:
   BZM-API:
-    default-address: https://a.blazemeter.com
+    default-address: ${default-address}
     requests:
-    - url: ${basePath}/tests
+    - url: ${default-path}/tests
     - method: POST
-      url: ${basePath}/tests
-    - url: ${basePath}/tests/1
+      url: ${default-path}/tests
+    - url: ${default-path}/tests/1
     - method: PUT
-      url: ${basePath}/tests/1
+      url: ${default-path}/tests/1
     - method: DELETE
-      url: ${basePath}/tests/1
+      url: ${default-path}/tests/1
     - method: PATCH
-      url: ${basePath}/tests/1
+      url: ${default-path}/tests/1
     - method: POST
-      url: ${basePath}/tests/1/start
-    - url: ${basePath}/reports
-    - url: ${basePath}/reports/1
+      url: ${default-path}/tests/1/start
+    - url: ${default-path}/reports
+    - url: ${default-path}/reports/1
 settings:
   env:
-    basePath: /api/v4
+    default-address: https://a.blazemeter.com
+    default-path: /api/v4
 

--- a/tests/resources/swagger/bzm-converted-values.yaml
+++ b/tests/resources/swagger/bzm-converted-values.yaml
@@ -1,0 +1,24 @@
+---
+execution:
+- concurrency: 1
+  hold-for: 1m
+  scenario: BZM-API
+scenarios:
+  BZM-API:
+    default-address: https://a.blazemeter.com
+    requests:
+    - url: /api/v4/tests
+    - method: POST
+      url: /api/v4/tests
+    - url: /api/v4/tests/1
+    - method: PUT
+      url: /api/v4/tests/1
+    - method: DELETE
+      url: /api/v4/tests/1
+    - method: PATCH
+      url: /api/v4/tests/1
+    - method: POST
+      url: /api/v4/tests/1/start
+    - url: /api/v4/reports
+    - url: /api/v4/reports/1
+

--- a/tests/resources/swagger/bzm-converted-variables.yaml
+++ b/tests/resources/swagger/bzm-converted-variables.yaml
@@ -5,26 +5,27 @@ execution:
   scenario: BZM-API
 scenarios:
   BZM-API:
-    default-address: https://a.blazemeter.com
+    default-address: ${default-address}
     requests:
-    - url: ${basePath}/tests
+    - url: ${default-path}/tests
     - body: ${body}
       method: POST
-      url: ${basePath}/tests
-    - url: ${basePath}/tests/${testId}
+      url: ${default-path}/tests
+    - url: ${default-path}/tests/${testId}
     - body: ${body}
       method: PUT
-      url: ${basePath}/tests/${testId}
+      url: ${default-path}/tests/${testId}
     - method: DELETE
-      url: ${basePath}/tests/${testId}
+      url: ${default-path}/tests/${testId}
     - body: ${body}
       method: PATCH
-      url: ${basePath}/tests/${testId}
+      url: ${default-path}/tests/${testId}
     - method: POST
-      url: ${basePath}/tests/${testId}/start
-    - url: ${basePath}/reports
-    - url: ${basePath}/reports/${reportId}
+      url: ${default-path}/tests/${testId}/start
+    - url: ${default-path}/reports
+    - url: ${default-path}/reports/${reportId}
 settings:
   env:
-    basePath: /api/v4
+    default-address: https://a.blazemeter.com
+    default-path: /api/v4
 

--- a/tests/resources/swagger/bzm-converted-variables.yaml
+++ b/tests/resources/swagger/bzm-converted-variables.yaml
@@ -7,21 +7,23 @@ scenarios:
   BZM-API:
     default-address: https://a.blazemeter.com
     requests:
-    - url: /api/v4/tests
+    - url: /${basePath}/tests
     - body: ${body}
       method: POST
-      url: /api/v4/tests
-    - url: /api/v4/tests/${testId}
+      url: /${basePath}/tests
+    - url: /${basePath}/tests/${testId}
     - body: ${body}
       method: PUT
-      url: /api/v4/tests/${testId}
+      url: /${basePath}/tests/${testId}
     - method: DELETE
-      url: /api/v4/tests/${testId}
+      url: /${basePath}/tests/${testId}
     - body: ${body}
       method: PATCH
-      url: /api/v4/tests/${testId}
+      url: /${basePath}/tests/${testId}
     - method: POST
-      url: /api/v4/tests/${testId}/start
-    - url: /api/v4/reports
-    - url: /api/v4/reports/${reportId}
+      url: /${basePath}/tests/${testId}/start
+    - url: /${basePath}/reports
+    - url: /${basePath}/reports/${reportId}
+    variables:
+      basePath: /api/v4
 

--- a/tests/resources/swagger/bzm-converted-variables.yaml
+++ b/tests/resources/swagger/bzm-converted-variables.yaml
@@ -24,6 +24,7 @@ scenarios:
       url: /${basePath}/tests/${testId}/start
     - url: /${basePath}/reports
     - url: /${basePath}/reports/${reportId}
-    variables:
-      basePath: /api/v4
+settings:
+  env:
+    basePath: /api/v4
 

--- a/tests/resources/swagger/bzm-converted-variables.yaml
+++ b/tests/resources/swagger/bzm-converted-variables.yaml
@@ -1,0 +1,27 @@
+---
+execution:
+- concurrency: 1
+  hold-for: 1m
+  scenario: BZM-API
+scenarios:
+  BZM-API:
+    default-address: https://a.blazemeter.com
+    requests:
+    - url: /api/v4/tests
+    - body: ${body}
+      method: POST
+      url: /api/v4/tests
+    - url: /api/v4/tests/${testId}
+    - body: ${body}
+      method: PUT
+      url: /api/v4/tests/${testId}
+    - method: DELETE
+      url: /api/v4/tests/${testId}
+    - body: ${body}
+      method: PATCH
+      url: /api/v4/tests/${testId}
+    - method: POST
+      url: /api/v4/tests/${testId}/start
+    - url: /api/v4/reports
+    - url: /api/v4/reports/${reportId}
+

--- a/tests/resources/swagger/bzm-converted-variables.yaml
+++ b/tests/resources/swagger/bzm-converted-variables.yaml
@@ -7,23 +7,23 @@ scenarios:
   BZM-API:
     default-address: https://a.blazemeter.com
     requests:
-    - url: /${basePath}/tests
+    - url: ${basePath}/tests
     - body: ${body}
       method: POST
-      url: /${basePath}/tests
-    - url: /${basePath}/tests/${testId}
+      url: ${basePath}/tests
+    - url: ${basePath}/tests/${testId}
     - body: ${body}
       method: PUT
-      url: /${basePath}/tests/${testId}
+      url: ${basePath}/tests/${testId}
     - method: DELETE
-      url: /${basePath}/tests/${testId}
+      url: ${basePath}/tests/${testId}
     - body: ${body}
       method: PATCH
-      url: /${basePath}/tests/${testId}
+      url: ${basePath}/tests/${testId}
     - method: POST
-      url: /${basePath}/tests/${testId}/start
-    - url: /${basePath}/reports
-    - url: /${basePath}/reports/${reportId}
+      url: ${basePath}/tests/${testId}/start
+    - url: ${basePath}/reports
+    - url: ${basePath}/reports/${reportId}
 settings:
   env:
     basePath: /api/v4

--- a/tests/resources/swagger/petstore-converted.yaml
+++ b/tests/resources/swagger/petstore-converted.yaml
@@ -9,54 +9,55 @@ scenarios:
     requests:
     - label: updatePet
       method: PUT
-      url: /v2/pet
+      url: /${basePath}/pet
     - label: addPet
       method: POST
-      url: /v2/pet
+      url: /${basePath}/pet
     - label: findPetsByStatus
-      url: /v2/pet/findByStatus?status=%5B1%2C+2%2C+3%5D
+      url: /${basePath}/pet/findByStatus?status=%5B1%2C+2%2C+3%5D
     - label: findPetsByTags
-      url: /v2/pet/findByTags?tags=%5B1%2C+2%2C+3%5D
+      url: /${basePath}/pet/findByTags?tags=%5B1%2C+2%2C+3%5D
     - label: getPetById
-      url: /v2/pet/1
+      url: /${basePath}/pet/1
     - label: updatePetWithForm
       method: POST
-      url: /v2/pet/1
+      url: /${basePath}/pet/1
     - label: deletePet
       method: DELETE
-      url: /v2/pet/1
+      url: /${basePath}/pet/1
     - label: uploadFile
       method: POST
-      url: /v2/pet/1/uploadImage
+      url: /${basePath}/pet/1/uploadImage
     - label: getInventory
-      url: /v2/store/inventory
+      url: /${basePath}/store/inventory
     - label: placeOrder
       method: POST
-      url: /v2/store/order
+      url: /${basePath}/store/order
     - label: getOrderById
-      url: /v2/store/order/1
+      url: /${basePath}/store/order/1
     - label: deleteOrder
       method: DELETE
-      url: /v2/store/order/1
+      url: /${basePath}/store/order/1
     - label: createUser
       method: POST
-      url: /v2/user
+      url: /${basePath}/user
     - label: createUsersWithArrayInput
       method: POST
-      url: /v2/user/createWithArray
+      url: /${basePath}/user/createWithArray
     - label: createUsersWithListInput
       method: POST
-      url: /v2/user/createWithList
+      url: /${basePath}/user/createWithList
     - label: loginUser
-      url: /v2/user/login?username=some_string
+      url: /${basePath}/user/login?username=some_string
     - label: logoutUser
-      url: /v2/user/logout
+      url: /${basePath}/user/logout
     - label: getUserByName
-      url: /v2/user/some_string
+      url: /${basePath}/user/some_string
     - label: updateUser
       method: PUT
-      url: /v2/user/some_string
+      url: /${basePath}/user/some_string
     - label: deleteUser
       method: DELETE
-      url: /v2/user/some_string
-
+      url: /${basePath}/user/some_string
+    variables:
+      basePath: /v2

--- a/tests/resources/swagger/petstore-converted.yaml
+++ b/tests/resources/swagger/petstore-converted.yaml
@@ -5,61 +5,62 @@ execution:
   scenario: Swagger-Petstore
 scenarios:
   Swagger-Petstore:
-    default-address: http://petstore.swagger.io
+    default-address: ${default-address}
     requests:
     - label: updatePet
       method: PUT
-      url: ${basePath}/pet
+      url: ${default-path}/pet
     - label: addPet
       method: POST
-      url: ${basePath}/pet
+      url: ${default-path}/pet
     - label: findPetsByStatus
-      url: ${basePath}/pet/findByStatus?status=%5B1%2C+2%2C+3%5D
+      url: ${default-path}/pet/findByStatus?status=%5B1%2C+2%2C+3%5D
     - label: findPetsByTags
-      url: ${basePath}/pet/findByTags?tags=%5B1%2C+2%2C+3%5D
+      url: ${default-path}/pet/findByTags?tags=%5B1%2C+2%2C+3%5D
     - label: getPetById
-      url: ${basePath}/pet/1
+      url: ${default-path}/pet/1
     - label: updatePetWithForm
       method: POST
-      url: ${basePath}/pet/1
+      url: ${default-path}/pet/1
     - label: deletePet
       method: DELETE
-      url: ${basePath}/pet/1
+      url: ${default-path}/pet/1
     - label: uploadFile
       method: POST
-      url: ${basePath}/pet/1/uploadImage
+      url: ${default-path}/pet/1/uploadImage
     - label: getInventory
-      url: ${basePath}/store/inventory
+      url: ${default-path}/store/inventory
     - label: placeOrder
       method: POST
-      url: ${basePath}/store/order
+      url: ${default-path}/store/order
     - label: getOrderById
-      url: ${basePath}/store/order/1
+      url: ${default-path}/store/order/1
     - label: deleteOrder
       method: DELETE
-      url: ${basePath}/store/order/1
+      url: ${default-path}/store/order/1
     - label: createUser
       method: POST
-      url: ${basePath}/user
+      url: ${default-path}/user
     - label: createUsersWithArrayInput
       method: POST
-      url: ${basePath}/user/createWithArray
+      url: ${default-path}/user/createWithArray
     - label: createUsersWithListInput
       method: POST
-      url: ${basePath}/user/createWithList
+      url: ${default-path}/user/createWithList
     - label: loginUser
-      url: ${basePath}/user/login?username=some_string
+      url: ${default-path}/user/login?username=some_string
     - label: logoutUser
-      url: ${basePath}/user/logout
+      url: ${default-path}/user/logout
     - label: getUserByName
-      url: ${basePath}/user/some_string
+      url: ${default-path}/user/some_string
     - label: updateUser
       method: PUT
-      url: ${basePath}/user/some_string
+      url: ${default-path}/user/some_string
     - label: deleteUser
       method: DELETE
-      url: ${basePath}/user/some_string
+      url: ${default-path}/user/some_string
 settings:
   env:
-    basePath: /v2
+    default-address: http://petstore.swagger.io
+    default-path: /v2
 

--- a/tests/resources/swagger/petstore-converted.yaml
+++ b/tests/resources/swagger/petstore-converted.yaml
@@ -9,56 +9,56 @@ scenarios:
     requests:
     - label: updatePet
       method: PUT
-      url: /${basePath}/pet
+      url: ${basePath}/pet
     - label: addPet
       method: POST
-      url: /${basePath}/pet
+      url: ${basePath}/pet
     - label: findPetsByStatus
-      url: /${basePath}/pet/findByStatus?status=%5B1%2C+2%2C+3%5D
+      url: ${basePath}/pet/findByStatus?status=%5B1%2C+2%2C+3%5D
     - label: findPetsByTags
-      url: /${basePath}/pet/findByTags?tags=%5B1%2C+2%2C+3%5D
+      url: ${basePath}/pet/findByTags?tags=%5B1%2C+2%2C+3%5D
     - label: getPetById
-      url: /${basePath}/pet/1
+      url: ${basePath}/pet/1
     - label: updatePetWithForm
       method: POST
-      url: /${basePath}/pet/1
+      url: ${basePath}/pet/1
     - label: deletePet
       method: DELETE
-      url: /${basePath}/pet/1
+      url: ${basePath}/pet/1
     - label: uploadFile
       method: POST
-      url: /${basePath}/pet/1/uploadImage
+      url: ${basePath}/pet/1/uploadImage
     - label: getInventory
-      url: /${basePath}/store/inventory
+      url: ${basePath}/store/inventory
     - label: placeOrder
       method: POST
-      url: /${basePath}/store/order
+      url: ${basePath}/store/order
     - label: getOrderById
-      url: /${basePath}/store/order/1
+      url: ${basePath}/store/order/1
     - label: deleteOrder
       method: DELETE
-      url: /${basePath}/store/order/1
+      url: ${basePath}/store/order/1
     - label: createUser
       method: POST
-      url: /${basePath}/user
+      url: ${basePath}/user
     - label: createUsersWithArrayInput
       method: POST
-      url: /${basePath}/user/createWithArray
+      url: ${basePath}/user/createWithArray
     - label: createUsersWithListInput
       method: POST
-      url: /${basePath}/user/createWithList
+      url: ${basePath}/user/createWithList
     - label: loginUser
-      url: /${basePath}/user/login?username=some_string
+      url: ${basePath}/user/login?username=some_string
     - label: logoutUser
-      url: /${basePath}/user/logout
+      url: ${basePath}/user/logout
     - label: getUserByName
-      url: /${basePath}/user/some_string
+      url: ${basePath}/user/some_string
     - label: updateUser
       method: PUT
-      url: /${basePath}/user/some_string
+      url: ${basePath}/user/some_string
     - label: deleteUser
       method: DELETE
-      url: /${basePath}/user/some_string
+      url: ${basePath}/user/some_string
 settings:
   env:
     basePath: /v2

--- a/tests/resources/swagger/petstore-converted.yaml
+++ b/tests/resources/swagger/petstore-converted.yaml
@@ -59,5 +59,7 @@ scenarios:
     - label: deleteUser
       method: DELETE
       url: /${basePath}/user/some_string
-    variables:
-      basePath: /v2
+settings:
+  env:
+    basePath: /v2
+

--- a/tests/test_swagger2yaml.py
+++ b/tests/test_swagger2yaml.py
@@ -49,7 +49,7 @@ class TestSwagger2YAML(BZTestCase):
         expected = yaml.load(open(RESOURCES_DIR + "/swagger/bzm-api-converted.yaml").read())
         self.assertEqual(actual, expected)
 
-    def test_convert_security_apikey(self):
+    def test_convert_security_apikey_header(self):
         self.maxDiff = None
         source = RESOURCES_DIR + "/swagger/auth-key.json"
         result = self._get_tmp()
@@ -67,6 +67,16 @@ class TestSwagger2YAML(BZTestCase):
         process(options, [source])
         actual = yaml.load(open(result).read())
         expected = yaml.load(open(RESOURCES_DIR + "/swagger/auth-basic-converted.yaml").read())
+        self.assertEqual(actual, expected)
+
+    def test_convert_security_apikey_query(self):
+        self.maxDiff = None
+        source = RESOURCES_DIR + "/swagger/auth-key-as-param.json"
+        result = self._get_tmp()
+        options = FakeOptions(file_name=result)
+        process(options, [source])
+        actual = yaml.load(open(result).read())
+        expected = yaml.load(open(RESOURCES_DIR + "/swagger/auth-key-as-param-converted.yaml").read())
         self.assertEqual(actual, expected)
 
 

--- a/tests/test_swagger2yaml.py
+++ b/tests/test_swagger2yaml.py
@@ -143,10 +143,10 @@ class TestSwaggerConverter(BZTestCase):
         scenario = config["scenarios"].get("Swagger-Petstore")
         self.assertEqual(6, len(scenario["requests"]))
         requests = scenario["requests"]
-        self.assertEqual(requests[0]["url"], "/v1/pets")
-        self.assertEqual(requests[1]["url"], "/v1/pets")
-        self.assertEqual(requests[2]["url"], "/v1/pets/some_string")
-        self.assertEqual(requests[3]["url"], "/v1/owners?limit=1")
+        self.assertEqual(requests[0]["url"], "/${basePath}/pets")
+        self.assertEqual(requests[1]["url"], "/${basePath}/pets")
+        self.assertEqual(requests[2]["url"], "/${basePath}/pets/some_string")
+        self.assertEqual(requests[3]["url"], "/${basePath}/owners?limit=1")
 
     def test_headers(self):
         obj = SwaggerConverter(logging.getLogger(''))
@@ -186,7 +186,7 @@ class TestSwaggerConverter(BZTestCase):
             scenario_requests = scenario["requests"]
             self.assertGreater(len(scenario_requests), 0)
             for scenario_request in scenario_requests:
-                self.assertRegexpMatches(scenario_request["url"], "\/api\/v4\/.*")
+                self.assertTrue(scenario_request["url"].startswith("/${basePath}/"))
 
         self.assertEqual(len(config["scenarios"]["/reports"]["requests"]), 1)
         self.assertEqual(len(config["scenarios"]["/reports/1"]["requests"]), 1)

--- a/tests/test_swagger2yaml.py
+++ b/tests/test_swagger2yaml.py
@@ -104,6 +104,16 @@ class TestSwagger2YAML(BZTestCase):
         expected = yaml.load(open(RESOURCES_DIR + "/swagger/bzm-converted-none.yaml").read())
         self.assertEqual(actual, expected)
 
+    def test_convert_security_apikey_multiscenarios(self):
+        source = RESOURCES_DIR + "/swagger/auth-key.json"
+        result = self._get_tmp()
+        options = FakeOptions(file_name=result, scenarios_from_paths=True)
+        process(options, [source])
+        actual = yaml.load(open(result).read())
+        expected = yaml.load(open(RESOURCES_DIR + "/swagger/auth-key-multiscenarios-converted.yaml").read())
+        self.assertEqual(actual, expected)
+
+
 
 class TestSwaggerConverter(BZTestCase):
     def test_minimal_json(self):
@@ -181,8 +191,9 @@ class TestSwaggerConverter(BZTestCase):
 
         self.assertEqual(len(config["execution"]), 5)
 
+        self.assertEqual(config["settings"]["env"]["defaultAddress"], "https://a.blazemeter.com")
         for scenario_name, scenario in iteritems(config["scenarios"]):
-            self.assertEqual(scenario["default-address"], "https://a.blazemeter.com")
+            self.assertEqual(scenario["default-address"], "${defaultAddress}")
             scenario_requests = scenario["requests"]
             self.assertGreater(len(scenario_requests), 0)
             for scenario_request in scenario_requests:

--- a/tests/test_swagger2yaml.py
+++ b/tests/test_swagger2yaml.py
@@ -49,6 +49,26 @@ class TestSwagger2YAML(BZTestCase):
         expected = yaml.load(open(RESOURCES_DIR + "/swagger/bzm-api-converted.yaml").read())
         self.assertEqual(actual, expected)
 
+    def test_convert_security_apikey(self):
+        self.maxDiff = None
+        source = RESOURCES_DIR + "/swagger/auth-key.json"
+        result = self._get_tmp()
+        options = FakeOptions(file_name=result)
+        process(options, [source])
+        actual = yaml.load(open(result).read())
+        expected = yaml.load(open(RESOURCES_DIR + "/swagger/auth-key-converted.yaml").read())
+        self.assertEqual(actual, expected)
+
+    def test_convert_security_basic(self):
+        self.maxDiff = None
+        source = RESOURCES_DIR + "/swagger/auth-basic.json"
+        result = self._get_tmp()
+        options = FakeOptions(file_name=result)
+        process(options, [source])
+        actual = yaml.load(open(result).read())
+        expected = yaml.load(open(RESOURCES_DIR + "/swagger/auth-basic-converted.yaml").read())
+        self.assertEqual(actual, expected)
+
 
 class TestSwaggerConverter(BZTestCase):
     def test_minimal_json(self):
@@ -138,4 +158,3 @@ class TestSwaggerConverter(BZTestCase):
         self.assertEqual(len(config["scenarios"]["/tests"]["requests"]), 2)
         self.assertEqual(len(config["scenarios"]["/tests/1"]["requests"]), 4)
         self.assertEqual(len(config["scenarios"]["/tests/1/start"]["requests"]), 1)
-

--- a/tests/test_swagger2yaml.py
+++ b/tests/test_swagger2yaml.py
@@ -161,10 +161,10 @@ class TestSwaggerConverter(BZTestCase):
         scenario = config["scenarios"].get("Swagger-Petstore")
         self.assertEqual(6, len(scenario["requests"]))
         requests = scenario["requests"]
-        self.assertEqual(requests[0]["url"], "/${basePath}/pets")
-        self.assertEqual(requests[1]["url"], "/${basePath}/pets")
-        self.assertEqual(requests[2]["url"], "/${basePath}/pets/some_string")
-        self.assertEqual(requests[3]["url"], "/${basePath}/owners?limit=1")
+        self.assertEqual(requests[0]["url"], "${basePath}/pets")
+        self.assertEqual(requests[1]["url"], "${basePath}/pets")
+        self.assertEqual(requests[2]["url"], "${basePath}/pets/some_string")
+        self.assertEqual(requests[3]["url"], "${basePath}/owners?limit=1")
 
     def test_headers(self):
         obj = SwaggerConverter(logging.getLogger(''))
@@ -205,7 +205,7 @@ class TestSwaggerConverter(BZTestCase):
             scenario_requests = scenario["requests"]
             self.assertGreater(len(scenario_requests), 0)
             for scenario_request in scenario_requests:
-                self.assertTrue(scenario_request["url"].startswith("/${basePath}/"))
+                self.assertTrue(scenario_request["url"].startswith("${basePath}/"))
 
         self.assertEqual(len(config["scenarios"]["/reports"]["requests"]), 1)
         self.assertEqual(len(config["scenarios"]["/reports/1"]["requests"]), 1)

--- a/tests/test_swagger2yaml.py
+++ b/tests/test_swagger2yaml.py
@@ -222,9 +222,9 @@ class TestSwaggerConverter(BZTestCase):
 
         self.assertEqual(len(config["execution"]), 5)
 
-        self.assertEqual(config["settings"]["env"]["defaultAddress"], "https://a.blazemeter.com")
+        self.assertEqual(config["settings"]["env"]["default-address"], "https://a.blazemeter.com")
         for scenario_name, scenario in iteritems(config["scenarios"]):
-            self.assertEqual(scenario["default-address"], "${defaultAddress}")
+            self.assertEqual(scenario["default-address"], "${default-address}")
             scenario_requests = scenario["requests"]
             self.assertGreater(len(scenario_requests), 0)
             for scenario_request in scenario_requests:

--- a/tests/test_swagger2yaml.py
+++ b/tests/test_swagger2yaml.py
@@ -68,6 +68,15 @@ class TestSwagger2YAML(BZTestCase):
         expected = yaml.load(open(RESOURCES_DIR + "/swagger/auth-basic-converted.yaml").read())
         self.assertEqual(actual, expected)
 
+    def test_convert_security_basic_local(self):
+        source = RESOURCES_DIR + "/swagger/auth-basic-local.json"
+        result = self._get_tmp()
+        options = FakeOptions(file_name=result)
+        process(options, [source])
+        actual = yaml.load(open(result).read())
+        expected = yaml.load(open(RESOURCES_DIR + "/swagger/auth-basic-local-converted.yaml").read())
+        self.assertEqual(actual, expected)
+
     def test_convert_security_apikey_query(self):
         source = RESOURCES_DIR + "/swagger/auth-key-as-param.json"
         result = self._get_tmp()
@@ -112,7 +121,6 @@ class TestSwagger2YAML(BZTestCase):
         actual = yaml.load(open(result).read())
         expected = yaml.load(open(RESOURCES_DIR + "/swagger/auth-key-multiscenarios-converted.yaml").read())
         self.assertEqual(actual, expected)
-
 
 
 class TestSwaggerConverter(BZTestCase):

--- a/tests/test_swagger2yaml.py
+++ b/tests/test_swagger2yaml.py
@@ -1,4 +1,5 @@
 import logging
+import shutil
 
 import yaml
 
@@ -34,92 +35,112 @@ class TestSwagger2YAML(BZTestCase):
 
     def test_convert(self):
         source = RESOURCES_DIR + "/swagger/petstore.json"
+        expected = RESOURCES_DIR + "/swagger/petstore-converted.yaml"
         result = self._get_tmp()
         options = FakeOptions(file_name=result)
         process(options, [source])
+        # shutil.copy(result, expected)
         actual = yaml.load(open(result).read())
-        expected = yaml.load(open(RESOURCES_DIR + "/swagger/petstore-converted.yaml").read())
+        expected = yaml.load(open(expected).read())
         self.assertEqual(actual, expected)
 
     def test_convert_scenarios_from_paths(self):
         source = RESOURCES_DIR + "/swagger/bzm-api.json"
+        expected = RESOURCES_DIR + "/swagger/bzm-api-converted.yaml"
         result = self._get_tmp()
         options = FakeOptions(file_name=result, scenarios_from_paths=True)
         process(options, [source])
+        # shutil.copy(result, expected)
         actual = yaml.load(open(result).read())
-        expected = yaml.load(open(RESOURCES_DIR + "/swagger/bzm-api-converted.yaml").read())
+        expected = yaml.load(open(expected).read())
         self.assertEqual(actual, expected)
 
     def test_convert_security_apikey_header(self):
         source = RESOURCES_DIR + "/swagger/auth-key.json"
+        expected = RESOURCES_DIR + "/swagger/auth-key-converted.yaml"
         result = self._get_tmp()
         options = FakeOptions(file_name=result)
         process(options, [source])
+        # shutil.copy(result, expected)
         actual = yaml.load(open(result).read())
-        expected = yaml.load(open(RESOURCES_DIR + "/swagger/auth-key-converted.yaml").read())
+        expected = yaml.load(open(expected).read())
         self.assertEqual(actual, expected)
 
     def test_convert_security_basic(self):
         source = RESOURCES_DIR + "/swagger/auth-basic.json"
+        expected = RESOURCES_DIR + "/swagger/auth-basic-converted.yaml"
         result = self._get_tmp()
         options = FakeOptions(file_name=result)
         process(options, [source])
+        # shutil.copy(result, expected)
         actual = yaml.load(open(result).read())
-        expected = yaml.load(open(RESOURCES_DIR + "/swagger/auth-basic-converted.yaml").read())
+        expected = yaml.load(open(expected).read())
         self.assertEqual(actual, expected)
 
     def test_convert_security_basic_local(self):
         source = RESOURCES_DIR + "/swagger/auth-basic-local.json"
+        expected = RESOURCES_DIR + "/swagger/auth-basic-local-converted.yaml"
         result = self._get_tmp()
         options = FakeOptions(file_name=result)
         process(options, [source])
+        # shutil.copy(result, expected)
         actual = yaml.load(open(result).read())
-        expected = yaml.load(open(RESOURCES_DIR + "/swagger/auth-basic-local-converted.yaml").read())
+        expected = yaml.load(open(expected).read())
         self.assertEqual(actual, expected)
 
     def test_convert_security_apikey_query(self):
         source = RESOURCES_DIR + "/swagger/auth-key-as-param.json"
+        expected = RESOURCES_DIR + "/swagger/auth-key-as-param-converted.yaml"
         result = self._get_tmp()
         options = FakeOptions(file_name=result)
         process(options, [source])
+        # shutil.copy(result, expected)
         actual = yaml.load(open(result).read())
-        expected = yaml.load(open(RESOURCES_DIR + "/swagger/auth-key-as-param-converted.yaml").read())
+        expected = yaml.load(open(expected).read())
         self.assertEqual(actual, expected)
 
     def test_convert_interpolation_values(self):
         source = RESOURCES_DIR + "/swagger/bzm-api.json"
+        expected = RESOURCES_DIR + "/swagger/bzm-converted-values.yaml"
         result = self._get_tmp()
         options = FakeOptions(file_name=result)
         process(options, [source])
+        # shutil.copy(result, expected)
         actual = yaml.load(open(result).read())
-        expected = yaml.load(open(RESOURCES_DIR + "/swagger/bzm-converted-values.yaml").read())
+        expected = yaml.load(open(expected).read())
         self.assertEqual(actual, expected)
 
     def test_convert_interpolation_variables(self):
         source = RESOURCES_DIR + "/swagger/bzm-api.json"
+        expected = RESOURCES_DIR + "/swagger/bzm-converted-variables.yaml"
         result = self._get_tmp()
         options = FakeOptions(file_name=result, parameter_interpolation=Swagger.INTERPOLATE_WITH_JMETER_VARS)
         process(options, [source])
+        # shutil.copy(result, expected)
         actual = yaml.load(open(result).read())
-        expected = yaml.load(open(RESOURCES_DIR + "/swagger/bzm-converted-variables.yaml").read())
+        expected = yaml.load(open(expected).read())
         self.assertEqual(actual, expected)
 
     def test_convert_interpolation_none(self):
         source = RESOURCES_DIR + "/swagger/bzm-api.json"
+        expected = RESOURCES_DIR + "/swagger/bzm-converted-none.yaml"
         result = self._get_tmp()
         options = FakeOptions(file_name=result, parameter_interpolation=Swagger.INTERPOLATE_DISABLE)
         process(options, [source])
+        # shutil.copy(result, expected)
         actual = yaml.load(open(result).read())
-        expected = yaml.load(open(RESOURCES_DIR + "/swagger/bzm-converted-none.yaml").read())
+        expected = yaml.load(open(expected).read())
         self.assertEqual(actual, expected)
 
     def test_convert_security_apikey_multiscenarios(self):
         source = RESOURCES_DIR + "/swagger/auth-key.json"
+        expected = RESOURCES_DIR + "/swagger/auth-key-multiscenarios-converted.yaml"
         result = self._get_tmp()
         options = FakeOptions(file_name=result, scenarios_from_paths=True)
         process(options, [source])
+        # shutil.copy(result, expected)
         actual = yaml.load(open(result).read())
-        expected = yaml.load(open(RESOURCES_DIR + "/swagger/auth-key-multiscenarios-converted.yaml").read())
+        expected = yaml.load(open(expected).read())
         self.assertEqual(actual, expected)
 
 
@@ -132,7 +153,8 @@ class TestSwaggerConverter(BZTestCase):
         self.assertIsNotNone(config.get("scenarios"))
 
         scenario = config["scenarios"].get("Swagger-Petstore")
-        self.assertEqual("http://petstore.swagger.io", scenario["default-address"])
+        self.assertEqual("${default-address}", scenario["default-address"])
+        self.assertEqual("http://petstore.swagger.io", config["settings"]["env"]["default-address"])
         self.assertEqual(20, len(scenario["requests"]))
 
     def test_minimal_yaml(self):
@@ -143,7 +165,8 @@ class TestSwaggerConverter(BZTestCase):
         self.assertIsNotNone(config.get("scenarios"))
 
         scenario = config["scenarios"].get("Swagger-Petstore")
-        self.assertEqual("http://petstore.swagger.io", scenario["default-address"])
+        self.assertEqual("${default-address}", scenario["default-address"])
+        self.assertEqual("http://petstore.swagger.io", config["settings"]["env"]["default-address"])
         self.assertEqual(6, len(scenario["requests"]))
 
     def test_interpolated_paths(self):
@@ -161,10 +184,10 @@ class TestSwaggerConverter(BZTestCase):
         scenario = config["scenarios"].get("Swagger-Petstore")
         self.assertEqual(6, len(scenario["requests"]))
         requests = scenario["requests"]
-        self.assertEqual(requests[0]["url"], "${basePath}/pets")
-        self.assertEqual(requests[1]["url"], "${basePath}/pets")
-        self.assertEqual(requests[2]["url"], "${basePath}/pets/some_string")
-        self.assertEqual(requests[3]["url"], "${basePath}/owners?limit=1")
+        self.assertEqual(requests[0]["url"], "${default-path}/pets")
+        self.assertEqual(requests[1]["url"], "${default-path}/pets")
+        self.assertEqual(requests[2]["url"], "${default-path}/pets/some_string")
+        self.assertEqual(requests[3]["url"], "${default-path}/owners?limit=1")
 
     def test_headers(self):
         obj = SwaggerConverter(logging.getLogger(''))
@@ -205,7 +228,7 @@ class TestSwaggerConverter(BZTestCase):
             scenario_requests = scenario["requests"]
             self.assertGreater(len(scenario_requests), 0)
             for scenario_request in scenario_requests:
-                self.assertTrue(scenario_request["url"].startswith("${basePath}/"))
+                self.assertTrue(scenario_request["url"].startswith("${default-path}/"))
 
         self.assertEqual(len(config["scenarios"]["/reports"]["requests"]), 1)
         self.assertEqual(len(config["scenarios"]["/reports/1"]["requests"]), 1)


### PR DESCRIPTION
## Enhancements for Swagger2YAML converter

### Added `securityDefinitions` support

Swagger2YAML now understands `securityDefinitions` and `security`. Both global (defined at the top level of Swagger file) and local security should work. For basic authentication the converter generates scenario/request header. For API key authentication converter generates either a header or a request query parameter.

Note that `oauth2` authentication is not yet supported by converter, the support will be added later.

### Added the ability to configure handling of templated parameters

This PR introduces new CLI option for converter: `--parameter-interpolation=VALUE`. Converter accepts 3 values:

- `values` — to replace templated parameters with concrete values"),
- `variables` — to replace templated parameters with Taurus/JMeter variables (`${varname}`)
- `none` — leave templated parameters as-is.

The default value for this option is `values`.

### Move base path and default address to global variables

This PR introduces a behavior where converter creates a global variable for default address and base path, so it can be changed by changing one field. This is more relevant when used with `--scenarios-from-paths`, where multiple scenarios with `default-address` and `default-path` are generated.

This change relies on a global variables, which are a new feature of Taurus.


### Example of generated code:

Basic auth + default address + default path.

```yaml
---
execution:
- concurrency: 1
  hold-for: 1m
  scenario: /tests
scenarios:
  /tests:
    default-address: ${default-address}
    headers:
      Authorization: Basic ${__base64Encode(${auth})}
    requests:
    - url: ${default-path}/tests

settings:
  env:
    auth: USER:PASSWORD
    default-path: /api/v4
    default-address: https://a.blazemeter.com
```

API key auth:
```yaml
---
execution:
- concurrency: 1
  hold-for: 1m
  scenario: /tests
scenarios:
  /tests:
    default-address: ${default-address}
    headers:
      X-API-Key: ${myApiKey}
    requests:
    - url: ${default-path}/tests
settings:
  env:
    default-path: /api/v4
    default-address: https://a.blazemeter.com
    myApiKey: TOKEN
```

Parameter interpolation with variables (`--parameter-interpolation=variables`):
```yaml
---
execution:
- concurrency: 1
  hold-for: 1m
  scenario: BZM-API
scenarios:
  BZM-API:
    default-address: https://a.blazemeter.com
    requests:
    - url: /api/v4/tests/${testId}
```

### Development checklist
1. [x] Support authentication (aka `securityDefinitions`)
2. [x] Support disabling automatic params interpolation
3. [x] Move base path (prepended to URLs) to `path` variable
4. [x] Update docs