### PR TITLE
Selenium extras and vars

### DIFF
--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -349,8 +349,8 @@ import selenium_taurus_extras
             "_tpl = selenium_taurus_extras.Template(_vars)"
         ]
 
-        for key, value in iteritems(variables):
-            stmts.append("_vars['%s'] = %r" % (key, value))
+        for key in sorted(variables.keys()):
+            stmts.append("_vars['%s'] = %r" % (key, variables[key]))
         stmts.append("")
         return self.gen_statement("\n".join(stmts), indent=0)
 
@@ -606,7 +606,8 @@ import selenium_taurus_extras
                 elif atype == 'assertvalue':
                     action = "get_attribute('value')"
                 action_elements.append(
-                    self.gen_statement("self.assertEqual(%s, %r)" % (tpl % (bys[tag], selector, action), param),
+                    self.gen_statement("self.assertEqual(%s, _tpl.apply(%r))" %
+                                       (tpl % (bys[tag], selector, action), param),
                                        indent=indent))
             if not action_elements:
                 action_elements.append(self.gen_statement(tpl % (bys[tag], selector, action), indent=indent))

--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -345,8 +345,8 @@ import selenium_taurus_extras
     def gen_global_vars(self):
         variables = self.scenario.get("variables")
         stmts = [
-            "vars = {}",
-            "tpl = selenium_taurus_extras.Template(vars)"
+            "_vars = {}",
+            "_tpl = selenium_taurus_extras.Template(_vars)"
         ]
 
         for key, value in iteritems(variables):

--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -350,7 +350,7 @@ import selenium_taurus_extras
         ]
 
         for key, value in iteritems(variables):
-            stmts.append("vars['%s']=%r" % (key, value))
+            stmts.append("_vars['%s']=%r" % (key, value))
         stmts.append("")
         return self.gen_statement("\n".join(stmts), indent=0)
 

--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -350,7 +350,7 @@ import selenium_taurus_extras
         ]
 
         for key, value in iteritems(variables):
-            stmts.append("_vars['%s']=%r" % (key, value))
+            stmts.append("_vars['%s'] = %r" % (key, value))
         stmts.append("")
         return self.gen_statement("\n".join(stmts), indent=0)
 

--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -331,6 +331,7 @@ import selenium_taurus_extras
         imports = self.add_imports()
 
         self.root.append(imports)
+        self.root.append(self.gen_global_vars())
         self.root.append(test_class)
 
     def add_imports(self):
@@ -340,6 +341,18 @@ import selenium_taurus_extras
         else:
             imports.text = self.IMPORTS_SELENIUM
         return imports
+
+    def gen_global_vars(self):
+        variables = self.scenario.get("variables")
+        stmts = [
+            "vars = {}",
+            "tpl = selenium_taurus_extras.Template(vars)"
+        ]
+
+        for key, value in iteritems(variables):
+            stmts.append("vars['%s']=%r" % (key, value))
+        stmts.append("")
+        return self.gen_statement("\n".join(stmts), indent=0)
 
     def _add_url_request(self, default_address, req, test_method):
         parsed_url = parse.urlparse(req.url)

--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -21,6 +21,7 @@ import shlex
 import string
 import sys
 import time
+import shutil
 from abc import abstractmethod
 from collections import OrderedDict
 from subprocess import CalledProcessError
@@ -86,6 +87,10 @@ class ApiritifNoseExecutor(SubprocessedExecutor):
             builder = ApiritifScriptGenerator(scenario, self.label, self.log)
             builder.verbose = self.__is_verbose()
         else:
+            selenium_extras = os.path.join(get_full_path(__file__, step_up=2), "resources", "selenium_taurus_extras.py")
+            selenium_extras_artifacts = os.path.join(self.engine.artifacts_dir, os.path.basename(selenium_extras))
+            if not os.path.isfile(selenium_extras_artifacts):
+                shutil.copyfile(selenium_extras, selenium_extras_artifacts)
             wdlog = self.engine.create_artifact('webdriver', '.log')
             ignore_unknown_actions = self.settings.get("ignore-unknown-actions", False)
             builder = SeleniumScriptBuilder(self.get_scenario(), self.log, wdlog, ignore_unknown_actions)
@@ -228,6 +233,7 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 
 import apiritif
+import selenium_taurus_extras
 """
     IMPORTS_APPIUM = """import unittest
 import re
@@ -243,6 +249,7 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 
 import apiritif
+import selenium_taurus_extras
     """
 
     TAGS = ("byName", "byID", "byCSS", "byXPath", "byLinkText")

--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -331,7 +331,7 @@ import selenium_taurus_extras
         imports = self.add_imports()
 
         self.root.append(imports)
-        self.root.append(self.gen_global_vars())
+        self.root.extend(self.gen_global_vars())
         self.root.append(test_class)
 
     def add_imports(self):
@@ -352,7 +352,7 @@ import selenium_taurus_extras
         for key in sorted(variables.keys()):
             stmts.append("_vars['%s'] = %r" % (key, variables[key]))
         stmts.append("")
-        return self.gen_statement("\n".join(stmts), indent=0)
+        return [self.gen_statement(stmt, indent=0) for stmt in stmts]
 
     def _add_url_request(self, default_address, req, test_method):
         parsed_url = parse.urlparse(req.url)

--- a/bzt/resources/selenium_taurus_extras.py
+++ b/bzt/resources/selenium_taurus_extras.py
@@ -38,7 +38,7 @@ class Template:
         else:
             self.variables = {}
         self.tmpl = Apply("")
-    
+
     def apply(self, template):
         self.tmpl.template = template
         self.tmpl.variables = self.variables

--- a/bzt/resources/selenium_taurus_extras.py
+++ b/bzt/resources/selenium_taurus_extras.py
@@ -1,0 +1,45 @@
+"""
+Copyright 2018 BlazeMeter Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from string import Template
+from selenium.common.exceptions import NoSuchWindowException
+
+class Apply(Template):
+    
+    def __init__(self, template):
+        super(Apply, self).__init__(template)
+        self.variables = {}
+    
+    def __repr__(self):
+        return repr(self.safe_substitute(self.variables))
+
+    def __str__(self):
+        return self.safe_substitute(self.variables)
+    
+class Template():
+
+    def __init__(self, variables=None):
+        if dict:
+            self.variables = variables
+        else:
+            self.variables = {}
+        self.tmpl = Apply("")
+    
+    def apply(self, template):
+        self.tmpl.template = template
+        self.tmpl.variables = self.variables
+        return str(self.tmpl)
+

--- a/bzt/resources/selenium_taurus_extras.py
+++ b/bzt/resources/selenium_taurus_extras.py
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from string import Template
-from selenium.common.exceptions import NoSuchWindowException
+from string import Template as StrTemplate
 
-class Apply(Template):
-    
+
+class Apply(StrTemplate):
+
     def __init__(self, template):
         super(Apply, self).__init__(template)
         self.variables = {}
@@ -28,8 +28,9 @@ class Apply(Template):
 
     def __str__(self):
         return self.safe_substitute(self.variables)
-    
-class Template():
+
+
+class Template:
 
     def __init__(self, variables=None):
         if dict:

--- a/bzt/resources/selenium_taurus_extras.py
+++ b/bzt/resources/selenium_taurus_extras.py
@@ -32,11 +32,8 @@ class Apply(StrTemplate):
 
 class Template:
 
-    def __init__(self, variables=None):
-        if dict:
-            self.variables = variables
-        else:
-            self.variables = {}
+    def __init__(self, variables):
+        self.variables = variables
         self.tmpl = Apply("")
 
     def apply(self, template):

--- a/bzt/resources/selenium_taurus_extras.py
+++ b/bzt/resources/selenium_taurus_extras.py
@@ -22,7 +22,7 @@ class Apply(StrTemplate):
     def __init__(self, template):
         super(Apply, self).__init__(template)
         self.variables = {}
-    
+
     def __repr__(self):
         return repr(self.safe_substitute(self.variables))
 

--- a/bzt/resources/selenium_taurus_extras.py
+++ b/bzt/resources/selenium_taurus_extras.py
@@ -43,4 +43,3 @@ class Template:
         self.tmpl.template = template
         self.tmpl.variables = self.variables
         return str(self.tmpl)
-

--- a/site/dat/docs/Nose.md
+++ b/site/dat/docs/Nose.md
@@ -113,6 +113,26 @@ modules:
 
 ```
 
+## Variables
+
+It is possible to define variables to be used in the script, declaring them at the scenario level.
+
+To use it, simply in any reference to a text in the script you must declare the insertion of the variable by using ```${name}```
+
+Sample:
+```yaml
+scenario:
+  sample:
+    variables:
+        sample: The is a sample site you can test with BlazeMeter!
+    requests:
+    - url: http://blazedemo.com/
+      actions:
+      - assertTextByCSS(body > div.jumbotron > div > p:nth-child(2)): ${sample}
+
+```
+
+
 ## Remote WebDriver
 
 It is possible to use the browser remotely using Remote WebDriver. It must be indicated as the browser name `Remote` and indicate in the `remote` property the URL in which the webdriver service is located to control the browser.

--- a/site/dat/docs/changes/add-selenium-extras.change
+++ b/site/dat/docs/changes/add-selenium-extras.change
@@ -1,0 +1,1 @@
+Built-in new support module for generated selenium script called selenium_taurus_extras

--- a/site/dat/docs/changes/add-selenium-variables.change
+++ b/site/dat/docs/changes/add-selenium-variables.change
@@ -1,0 +1,1 @@
+Variable support added to Selenium (Nose)

--- a/tests/modules/selenium/test_python.py
+++ b/tests/modules/selenium/test_python.py
@@ -289,6 +289,9 @@ class TestSeleniumScriptBuilder(SeleniumTestCase):
             "scenarios": {
                 "loc_sc": {
                     "default-address": "http://blazedemo.com",
+                    "variables": {
+                        "red_pill": "take_it"
+                    },
                     "timeout": "3.5s",
                     "requests": [{
                         "url": "/",

--- a/tests/modules/selenium/test_python.py
+++ b/tests/modules/selenium/test_python.py
@@ -290,7 +290,8 @@ class TestSeleniumScriptBuilder(SeleniumTestCase):
                 "loc_sc": {
                     "default-address": "http://blazedemo.com",
                     "variables": {
-                        "red_pill": "take_it"
+                        "red_pill": "take_it",
+                        "name": "Name"
                     },
                     "timeout": "3.5s",
                     "requests": [{
@@ -309,7 +310,7 @@ class TestSeleniumScriptBuilder(SeleniumTestCase):
                             {"selectByName(toPort)": "London"},
                             {"keysByCSS(body input.btn.btn-primary)": "KEY_ENTER"},
                             {"assertValueByID(address)": "123 Beautiful st."},
-                            {"assertTextByXPath(/html/body/div[2]/form/div[1]/label)": "Name"},
+                            {"assertTextByXPath(/html/body/div[2]/form/div[1]/label)": "${name}"},
                             {"waitByName('toPort')": "visible"},
                             {"keysByName(\"toPort\")": "B"},
                             "clickByXPath(//div[3]/form/select[1]//option[3])",

--- a/tests/resources/selenium/generated_from_requests.py
+++ b/tests/resources/selenium/generated_from_requests.py
@@ -16,6 +16,7 @@ import selenium_taurus_extras
 
 _vars = {}
 _tpl = selenium_taurus_extras.Template(_vars)
+_vars['name'] = 'Name'
 _vars['red_pill'] = 'take_it'
 
 class TestRequests(unittest.TestCase):
@@ -43,8 +44,8 @@ class TestRequests(unittest.TestCase):
             ActionChains(self.driver).release(self.driver.find_element(By.XPATH, '/html/body/div[3]/form/select[1]/option[6]')).perform()
             Select(self.driver.find_element(By.NAME, 'toPort')).select_by_visible_text('London')
             self.driver.find_element(By.CSS_SELECTOR, 'body input.btn.btn-primary').send_keys(Keys.ENTER)
-            self.assertEqual(self.driver.find_element(By.ID, 'address').get_attribute('value'), '123 Beautiful st.')
-            self.assertEqual(self.driver.find_element(By.XPATH, '/html/body/div[2]/form/div[1]/label').get_attribute('innerText'), 'Name')
+            self.assertEqual(self.driver.find_element(By.ID, 'address').get_attribute('value'), _tpl.apply('123 Beautiful st.'))
+            self.assertEqual(self.driver.find_element(By.XPATH, '/html/body/div[2]/form/div[1]/label').get_attribute('innerText'), _tpl.apply('${name}'))
             WebDriverWait(self.driver, 3.5).until(econd.visibility_of_element_located((By.NAME, 'toPort')), "Element 'toPort' failed to appear within 3.5s")
             self.driver.find_element(By.NAME, 'toPort').send_keys('B')
             self.driver.find_element(By.XPATH, '//div[3]/form/select[1]//option[3]').click()

--- a/tests/resources/selenium/generated_from_requests.py
+++ b/tests/resources/selenium/generated_from_requests.py
@@ -12,6 +12,7 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 
 import apiritif
+import selenium_taurus_extras
 
 class TestRequests(unittest.TestCase):
     def setUp(self):

--- a/tests/resources/selenium/generated_from_requests.py
+++ b/tests/resources/selenium/generated_from_requests.py
@@ -16,6 +16,7 @@ import selenium_taurus_extras
 
 _vars = {}
 _tpl = selenium_taurus_extras.Template(_vars)
+_vars['red_pill'] = 'take_it'
 
 class TestRequests(unittest.TestCase):
     def setUp(self):

--- a/tests/resources/selenium/generated_from_requests.py
+++ b/tests/resources/selenium/generated_from_requests.py
@@ -14,8 +14,8 @@ from selenium.webdriver.common.keys import Keys
 import apiritif
 import selenium_taurus_extras
 
-vars = {}
-tpl = selenium_taurus_extras.Template(vars)
+_vars = {}
+_tpl = selenium_taurus_extras.Template(_vars)
 
 class TestRequests(unittest.TestCase):
     def setUp(self):

--- a/tests/resources/selenium/generated_from_requests.py
+++ b/tests/resources/selenium/generated_from_requests.py
@@ -14,6 +14,9 @@ from selenium.webdriver.common.keys import Keys
 import apiritif
 import selenium_taurus_extras
 
+vars = {}
+tpl = selenium_taurus_extras.Template(vars)
+
 class TestRequests(unittest.TestCase):
     def setUp(self):
         options = webdriver.FirefoxOptions()

--- a/tests/resources/selenium/generated_from_requests_appium_browser.py
+++ b/tests/resources/selenium/generated_from_requests_appium_browser.py
@@ -12,6 +12,7 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 
 import apiritif
+import selenium_taurus_extras
 
 class TestRequests(unittest.TestCase):
     def setUp(self):

--- a/tests/resources/selenium/generated_from_requests_appium_browser.py
+++ b/tests/resources/selenium/generated_from_requests_appium_browser.py
@@ -14,8 +14,8 @@ from selenium.webdriver.common.keys import Keys
 import apiritif
 import selenium_taurus_extras
 
-vars = {}
-tpl = selenium_taurus_extras.Template(vars)
+_vars = {}
+_tpl = selenium_taurus_extras.Template(_vars)
 
 class TestRequests(unittest.TestCase):
     def setUp(self):

--- a/tests/resources/selenium/generated_from_requests_appium_browser.py
+++ b/tests/resources/selenium/generated_from_requests_appium_browser.py
@@ -14,6 +14,9 @@ from selenium.webdriver.common.keys import Keys
 import apiritif
 import selenium_taurus_extras
 
+vars = {}
+tpl = selenium_taurus_extras.Template(vars)
+
 class TestRequests(unittest.TestCase):
     def setUp(self):
         self.driver = webdriver.Remote(command_executor='http://localhost:4723/wd/hub', desired_capabilities={"browserName": "Chrome", "deviceName": "", "platformName": "Android"})

--- a/tests/resources/selenium/generated_from_requests_remote.py
+++ b/tests/resources/selenium/generated_from_requests_remote.py
@@ -14,6 +14,9 @@ from selenium.webdriver.common.keys import Keys
 import apiritif
 import selenium_taurus_extras
 
+vars = {}
+tpl = selenium_taurus_extras.Template(vars)
+
 class TestRequests(unittest.TestCase):
     def setUp(self):
         self.driver = webdriver.Remote(command_executor='http://user:key@remote_web_driver_host:port/wd/hub', desired_capabilities={"app": "", "browserName": "firefox", "deviceName": "", "javascriptEnabled": "True", "platformName": "linux", "platformVersion": "", "seleniumVersion": "", "version": "54.0"})

--- a/tests/resources/selenium/generated_from_requests_remote.py
+++ b/tests/resources/selenium/generated_from_requests_remote.py
@@ -12,6 +12,7 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 
 import apiritif
+import selenium_taurus_extras
 
 class TestRequests(unittest.TestCase):
     def setUp(self):

--- a/tests/resources/selenium/generated_from_requests_remote.py
+++ b/tests/resources/selenium/generated_from_requests_remote.py
@@ -14,8 +14,8 @@ from selenium.webdriver.common.keys import Keys
 import apiritif
 import selenium_taurus_extras
 
-vars = {}
-tpl = selenium_taurus_extras.Template(vars)
+_vars = {}
+_tpl = selenium_taurus_extras.Template(_vars)
 
 class TestRequests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Hi @greyfenrir, @dmand, @undera !

I share a PR with variables support for the Nose executor (focused on selenium generation).

I tried to leave it simple for the initial review. 
I just incorporated an example of the use of the template system for a couple of commands (assertText and assertValue).

I have incorporated a new resource file that will be used as the helper library for the test scripts.
In that file of "selenium extras" of Taurus, at the moment I only left the management of templates, but the idea is to incorporate here everything that is simple, small and generic for its use in the tests.

I put "extras" in the name because it is very common, usually refers to that set of helpers, tricks and small tools that without becoming a framework help in the use of the tool, in this case Taurus and Selenium.

An advantage is versioned in the base code and it is possible to update it and keep it aligned between Taurus versions. The generated code can be executed outside a machine like before (only required python, apiritif and selenium installed). It allows multiple scenarios to use it, all generated tests import the same .py available in the artifacts dir.

In case the idea seems good, I can continue to incorporate the template management to the rest of the commands inside this PR (and thereby also reflect the changes in the tests, I did not do it initially to keep a simple PR for review).

After solving everything around this PR (selenium extras and variables), I will continue with the release of code that depends from this to continue with more commands and improvements.

