### PR TITLE
Nose Request, Type command

### DIFF
--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -607,8 +607,7 @@ import selenium_taurus_extras
                     self.gen_statement("self.assertEqual(%s, _tpl.apply(%r))" %
                                        (tpl % (bys[tag], selector, action), param),
                                        indent=indent))
-        elif atype in ('click', 'type', 'keys',
-                       'asserttext', 'assertvalue', 'submit'):
+        elif atype in ('click', 'type', 'keys', 'submit'):
             tpl = "self.driver.find_element(By.%s, _tpl.apply(%r)).%s"
             action = None
             if atype == 'click':

--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -582,30 +582,23 @@ import selenium_taurus_extras
             cmd = "self.driver.switch_to.frame(%s)" % frame
             action_elements.append(self.gen_statement(cmd, indent=indent))
 
-        elif atype in ('click', 'doubleclick', 'mousedown', 'mouseup', 'mousemove', 'keys',
-                       'asserttext', 'assertvalue', 'select', 'submit'):
-            tpl = "self.driver.find_element(By.%s, _tpl.apply(%r)).%s"
-            action = None
-            if atype == 'click':
-                action = "click()"
-            elif atype == 'submit':
-                action = "submit()"
-            elif atype == 'keys':
-                action = "send_keys(_tpl.apply(%r))" % param
-                if isinstance(param, str) and param.startswith("KEY_"):
-                    action = "send_keys(Keys.%s)" % param.split("KEY_")[1]
-            elif atype in action_chains:
+        elif atype in action_chains:
                 tpl = "self.driver.find_element(By.%s, _tpl.apply(%r))"
                 action = action_chains[atype]
                 action_elements.append(self.gen_statement(
                     "ActionChains(self.driver).%s(%s).perform()" % (action, (tpl % (bys[tag], selector))),
                     indent=indent))
-            elif atype == 'select':
-                tpl = "self.driver.find_element(By.%s, _tpl.apply(%r))"
-                action = "select_by_visible_text(_tpl.apply(%r))" % param
-                action_elements.append(self.gen_statement("Select(%s).%s" % (tpl % (bys[tag], selector), action),
-                                                          indent=indent))
-            elif atype.startswith('assert'):
+        elif atype == 'select':
+            tpl = "self.driver.find_element(By.%s, _tpl.apply(%r))"
+            action = "select_by_visible_text(_tpl.apply(%r))" % param
+            action_elements.append(self.gen_statement("Select(%s).%s" % (tpl % (bys[tag], selector), action),
+                                                      indent=indent))
+        elif atype.startswith('assert'):
+            if tag == 'title':
+                action_elements.append(
+                    self.gen_statement("self.assertEqual(self.driver.title, _tpl.apply(%r))" % selector, indent=indent))
+            else:
+                tpl = "self.driver.find_element(By.%s, _tpl.apply(%r)).%s"
                 if atype == 'asserttext':
                     action = "get_attribute('innerText')"
                 elif atype == 'assertvalue':
@@ -614,8 +607,24 @@ import selenium_taurus_extras
                     self.gen_statement("self.assertEqual(%s, _tpl.apply(%r))" %
                                        (tpl % (bys[tag], selector, action), param),
                                        indent=indent))
-            if not action_elements:
-                action_elements.append(self.gen_statement(tpl % (bys[tag], selector, action), indent=indent))
+        elif atype in ('click', 'type', 'keys',
+                       'asserttext', 'assertvalue', 'submit'):
+            tpl = "self.driver.find_element(By.%s, _tpl.apply(%r)).%s"
+            action = None
+            if atype == 'click':
+                action = "click()"
+            elif atype == 'submit':
+                action = "submit()"
+            elif atype in ['keys', 'type']:
+                if atype == 'type':
+                    action_elements.append(self.gen_statement(
+                        tpl % (bys[tag], selector, "clear()"), indent=indent))
+                action = "send_keys(_tpl.apply(%r))" % str(param)
+                if isinstance(param, str) and param.startswith("KEY_"):
+                    action = "send_keys(Keys.%s)" % param.split("KEY_")[1]
+
+            action_elements.append(self.gen_statement(tpl % (bys[tag], selector, action), indent=indent))
+
         elif atype == "run" and tag == "script":
             action_elements.append(self.gen_statement('self.driver.execute_script(_tpl.apply("%s"))' %
                                                       selector, indent=indent))
@@ -637,11 +646,8 @@ import selenium_taurus_extras
             action_elements.append(self.gen_statement(tpl % (dehumanize_time(selector),), indent=indent))
         elif atype == 'clear' and tag == 'cookies':
             action_elements.append(self.gen_statement("self.driver.delete_all_cookies()", indent=indent))
-        elif atype == 'assert' and tag == 'title':
-            action_elements.append(
-                self.gen_statement("self.assertEqual(self.driver.title, _tpl.apply(%r))" % selector, indent=indent))
 
-        if not action_elements:
+        if len(action_elements) == 0:
             raise TaurusInternalException("Could not build code for action: %s" % action_config)
 
         return action_elements
@@ -655,9 +661,9 @@ import selenium_taurus_extras
         else:
             raise TaurusConfigError("Unsupported value for action: %s" % action_config)
 
-        actions = "|".join(['click', 'doubleClick', 'mouseDown', 'mouseUp', 'mouseMove', 'select', 'wait', 'keys',
-                            'pause', 'clear', 'assert', 'assertText', 'assertValue', 'submit', 'close', 'run',
-                            'editcontent', 'selectFrame'])
+        actions = "|".join(['click', 'doubleClick', 'mouseDown', 'mouseUp', 'mouseMove', 'select', 'wait',
+                            'type', 'keys', 'pause', 'clear', 'assert', 'assertText', 'assertValue',
+                            'submit', 'close', 'run', 'editcontent', 'selectFrame'])
         tag = "|".join(self.TAGS) + "|For|Cookies|Title|Window|Script|ByIdx"
         expr = re.compile("^(%s)(%s)\((.*)\)$" % (actions, tag), re.IGNORECASE)
         res = expr.match(name)

--- a/site/dat/docs/Nose.md
+++ b/site/dat/docs/Nose.md
@@ -42,7 +42,8 @@ Supported features:
   - selenium commands:
     - window controls (selectWindow, closeWindow)
     - selectFrameBy*<sup>1</sup> Switch to frame
-    - keysBy* Send keys to element
+    - keysBy* Send keystrokes to element
+    - typeBy* Assign the value to element, cleaning it previously
     - editContent Change text in editable field (checks contenteditable prop)
     - submitBy* Send data of form by any its element
     - runScript Execute JS command

--- a/site/dat/docs/changes/add-nose-request-type-command.change
+++ b/site/dat/docs/changes/add-nose-request-type-command.change
@@ -1,0 +1,1 @@
+Type command added to Nose Request (Selenium)

--- a/tests/modules/selenium/test_python.py
+++ b/tests/modules/selenium/test_python.py
@@ -313,6 +313,7 @@ class TestSeleniumScriptBuilder(SeleniumTestCase):
                             {"assertTextByXPath(/html/body/div[2]/form/div[1]/label)": "${name}"},
                             {"waitByName('toPort')": "visible"},
                             {"keysByName(\"toPort\")": "B"},
+                            {"typeByName(\"toPort\")": "B"},
                             "clickByXPath(//div[3]/form/select[1]//option[3])",
                             "clickByXPath(//div[3]/form/select[2]//option[6])",
                             "selectWindow(0)",

--- a/tests/resources/selenium/generated_from_requests.py
+++ b/tests/resources/selenium/generated_from_requests.py
@@ -49,6 +49,8 @@ class TestRequests(unittest.TestCase):
             self.assertEqual(self.driver.find_element(By.XPATH, _tpl.apply('/html/body/div[2]/form/div[1]/label')).get_attribute('innerText'), _tpl.apply('${name}'))
             WebDriverWait(self.driver, 3.5).until(econd.visibility_of_element_located((By.NAME, _tpl.apply('toPort'))), "Element 'toPort' failed to appear within 3.5s")
             self.driver.find_element(By.NAME, _tpl.apply('toPort')).send_keys(_tpl.apply('B'))
+            self.driver.find_element(By.NAME, _tpl.apply('toPort')).clear()
+            self.driver.find_element(By.NAME, _tpl.apply('toPort')).send_keys(_tpl.apply('B'))
             self.driver.find_element(By.XPATH, _tpl.apply('//div[3]/form/select[1]//option[3]')).click()
             self.driver.find_element(By.XPATH, _tpl.apply('//div[3]/form/select[2]//option[6]')).click()
             self.wnd_mng.switch(_tpl.apply('0'))


### PR DESCRIPTION
Hi @undera @dmand and @greyfenrir

A new PR with a new command. Type.

Unlike keysBy, it is more oriented to fill fields, deleting its value previously.
So far the keysBy if the text box came with preloaded data it was very difficult to execute its deletion and filling it correctly, since by default keysBy does text append.

I made a small fix and a mini-refactoring to solve a little problem with some commands.
