### PR TITLE
Nose Request, Go command

### DIFF
--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -620,7 +620,7 @@ import selenium_taurus_extras
             action_elements.append(self.gen_statement('self.driver.execute_script(_tpl.apply("%s"))' %
                                                       selector, indent=indent))
         elif atype == 'go':
-            if len(selector) > 0 and not param or len(param) == 0:
+            if selector and not param:
                 action_elements.append(self.gen_statement(
                     "self.driver.get(_tpl.apply(%r))" % selector.strip(), indent=indent
                 ))

--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -619,6 +619,11 @@ import selenium_taurus_extras
         elif atype == "run" and tag == "script":
             action_elements.append(self.gen_statement('self.driver.execute_script(_tpl.apply("%s"))' %
                                                       selector, indent=indent))
+        elif atype == 'go':
+            if len(selector) > 0 and not param or len(param) == 0:
+                action_elements.append(self.gen_statement(
+                    "self.driver.get(_tpl.apply(%r))" % selector.strip(), indent=indent
+                ))
         elif atype == "editcontent":
             element = "self.driver.find_element(By.%s, _tpl.apply(%r))" % (bys[tag], selector)
             tpl = "if {element}.get_attribute('contenteditable'): {element}.clear(); " \
@@ -657,9 +662,9 @@ import selenium_taurus_extras
 
         actions = "|".join(['click', 'doubleClick', 'mouseDown', 'mouseUp', 'mouseMove', 'select', 'wait', 'keys',
                             'pause', 'clear', 'assert', 'assertText', 'assertValue', 'submit', 'close', 'run',
-                            'editcontent', 'selectFrame'])
+                            'editcontent', 'selectFrame', 'go'])
         tag = "|".join(self.TAGS) + "|For|Cookies|Title|Window|Script|ByIdx"
-        expr = re.compile("^(%s)(%s)\((.*)\)$" % (actions, tag), re.IGNORECASE)
+        expr = re.compile("^(%s)(%s)?(\((.*)\))?$" % (actions, tag), re.IGNORECASE)
         res = expr.match(name)
         if not res:
             msg = "Unsupported action: %s" % name
@@ -670,15 +675,17 @@ import selenium_taurus_extras
                 raise TaurusConfigError(msg)
 
         atype = res.group(1).lower()
-        tag = res.group(2).lower()
-        selector = res.group(3)
+        tag = res.group(2).lower() if res.group(2) else ""
+        selector = res.group(4)
 
         # hello, reviewer!
-        if selector.startswith('"') and selector.endswith('"'):
-            selector = selector[1:-1]
-        elif selector.startswith("'") and selector.endswith("'"):
-            selector = selector[1:-1]
-
+        if selector:
+            if selector.startswith('"') and selector.endswith('"'):
+                selector = selector[1:-1]
+            elif selector.startswith("'") and selector.endswith("'"):
+                selector = selector[1:-1]
+        else:
+            selector = ""
         return atype, tag, param, selector
 
 

--- a/site/dat/docs/Nose.md
+++ b/site/dat/docs/Nose.md
@@ -40,6 +40,7 @@ Supported features:
   - pauseFor (pause for n seconds) 
   - request method GET (only)
   - selenium commands:
+    - go(url) Redirect to another website
     - window controls (selectWindow, closeWindow)
     - selectFrameBy*<sup>1</sup> Switch to frame
     - keysBy* Send keys to element
@@ -49,7 +50,7 @@ Supported features:
     - waitBy* 
     - clickBy* 
     - doubleClickBy* 
-    - mouseDownBy* 
+    - mouseDownBy*
     - mouseUpBy* 
     - assertTextBy* Assert text on element
     - assertValueBy* Assert value attribute

--- a/site/dat/docs/changes/add-nose-request-go-command.change
+++ b/site/dat/docs/changes/add-nose-request-go-command.change
@@ -1,0 +1,1 @@
+Go command added to Nose Request (Selenium)

--- a/tests/modules/selenium/test_python.py
+++ b/tests/modules/selenium/test_python.py
@@ -330,8 +330,8 @@ class TestSeleniumScriptBuilder(SeleniumTestCase):
                             {"editContentById(editor)": "lo-la-lu"},
                             "pauseFor(3s)",
                             "clearCookies()",
-                            "clickByLinkText(destination of the week! The Beach!)"
-
+                            "clickByLinkText(destination of the week! The Beach!)",
+                            "go(http:\\blazemeter.com)"
                         ],
                     },
                         {"label": "empty"}

--- a/tests/resources/selenium/generated_from_requests.py
+++ b/tests/resources/selenium/generated_from_requests.py
@@ -67,6 +67,7 @@ class TestRequests(unittest.TestCase):
             sleep(3)
             self.driver.delete_all_cookies()
             self.driver.find_element(By.LINK_TEXT, _tpl.apply('destination of the week! The Beach!')).click()
+            self.driver.get(_tpl.apply('http:\\blazemeter.com'))
 
 
         body = self.driver.page_source


### PR DESCRIPTION
Hi @undera @dmand and @greyfenrir

A new PR with a new command. Go (go or redirect to a website).

In functional tests it is necessary for test cases browsing and in different websites to collect information, load it into variables to be able to make assertions or similar things, all inside the same scenario/request.

I took the liberty of proposing to incorporate a change in the regular expression (the second part of the action is optional).
Actually the second part used like |For|Cookies|Title|Window|Script|ByIdx they suffer from the condition so that the second part of the action was created like a tag, and if the option of the second part becomes optional, it would be possible for these special cases to return complete commands, which would not allow someone to make an inappropriate combination.

In the case of "go", splitting it into "g" and "o" was not very nice.
