### PR TITLE
Do not crash `swagger2yaml` when an optional `description` field is missing

### DIFF
--- a/bzt/swagger2yaml.py
+++ b/bzt/swagger2yaml.py
@@ -90,7 +90,7 @@ class Swagger(object):
             self.definitions[name] = Swagger.Definition(name=name, schema=schema)
 
         for name, response in iteritems(self.swagger.get("responses", {})):
-            self.responses[name] = Swagger.Response(name=name, description=response["description"],
+            self.responses[name] = Swagger.Response(name=name, description=response.get("description"),
                                                     schema=response.get("schema"), headers=response.get("headers"))
 
         for name, param in iteritems(self.swagger.get("parameters", {})):
@@ -131,7 +131,7 @@ class Swagger(object):
 
         responses = OrderedDict()
         for name, resp in iteritems(operation.get("responses", {})):
-            response = Swagger.Response(name=name, description=resp["description"], schema=resp.get("schema"),
+            response = Swagger.Response(name=name, description=resp.get("description"), schema=resp.get("schema"),
                                         headers=resp.get("headers"))
             responses[name] = response
 

--- a/site/dat/docs/changes/fix-swagger2yaml-crash-when-optional-field-is-missing.change
+++ b/site/dat/docs/changes/fix-swagger2yaml-crash-when-optional-field-is-missing.change
@@ -1,0 +1,1 @@
+Fix `swagger2yaml` crash when an optional field is missing

--- a/tests/resources/swagger/bzm-api.json
+++ b/tests/resources/swagger/bzm-api.json
@@ -62,7 +62,6 @@
             }
           },
           "404": {
-            "description": "Not found",
             "schema": {
               "$ref": "#/definitions/ApiResponseError"
             }


### PR DESCRIPTION
WAP-11357