### PR TITLE
utf-8 compatibility

### DIFF
--- a/bzt/engine.py
+++ b/bzt/engine.py
@@ -29,6 +29,7 @@ import threading
 import time
 import traceback
 import uuid
+import codecs
 from abc import abstractmethod
 from collections import namedtuple, defaultdict
 from distutils.version import LooseVersion
@@ -697,7 +698,7 @@ class Configuration(BetterDict):
         for config_file in config_files:
             try:
                 configs = []
-                with open(config_file) as fds:
+                with codecs.open(config_file, 'r', encoding='utf-8') as fds:
                     if self.tab_replacement_spaces:
                         contents = self._replace_tabs(fds.readlines(), config_file)
                     else:

--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -353,6 +353,7 @@ import selenium_taurus_extras
 
         imports = self.add_imports()
 
+        self.root.append(self.gen_statement("# coding=utf-8", indent=0))
         self.root.append(imports)
         self.root.extend(self.gen_global_vars())
         self.root.append(test_class)

--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -1329,7 +1329,7 @@ class PythonGenerator(object):
         return self.gen_statement("# %s" % comment, indent=indent)
 
     def save(self, filename):
-        with open(filename, 'wt') as fds:
+        with codecs.open(filename, 'w', encoding='utf-8') as fds:
             for child in self.root.iter():
                 if child.text is not None:
                     indent = int(child.get('indent', "0"))

--- a/tests/resources/selenium/generated_from_requests.py
+++ b/tests/resources/selenium/generated_from_requests.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import unittest
 import re
 from time import sleep

--- a/tests/resources/selenium/generated_from_requests_appium_browser.py
+++ b/tests/resources/selenium/generated_from_requests_appium_browser.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import unittest
 import re
 from time import sleep

--- a/tests/resources/selenium/generated_from_requests_remote.py
+++ b/tests/resources/selenium/generated_from_requests_remote.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import unittest
 import re
 from time import sleep


### PR DESCRIPTION
Hi @undera @dmand and @greyfenrir

We discovered that Taurus does not support its yml to be utf-8, being currently the most common and used to allow a base for internationalization.

I share a simple arrangement that makes Taurus support yml file with content in utf-8 allowing that there is now text such as in Japanese, Portuguese or Chinese among others.

The selenium python code generator was not generating with support outside the text, I also gave it an extension for its support.
The change of the parsing of yml is at a general level and the other change at the punctual level of Nose.
I think the change would not affect the rest of the components. You have to see what the automated tests say about it.

Sample yml used by us for test the utf-8 support
```
execution:
- executor: selenium
  scenario: UTF8-Selenium
  iterations: 1

scenarios:
  UTF8-Selenium:
    browser: Chrome 
    headless: false
    timeout: 60s
    think-time: 0s
    requests:
    - label: Test
      actions:
      - go(https://www.sljfaq.org/afaq/encodings.html)
      - assertTextByXPath(//tr[2]/td[2]): "か"

```