### PR TITLE
Fix editContent

### DIFF
--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -693,11 +693,24 @@ import selenium_taurus_extras
                     "self.driver.get(_tpl.apply(%r))" % selector.strip(), indent=indent
                 ))
         elif atype == "editcontent":
-            element = "self.driver.find_element(By.%s, _tpl.apply(%r))" % (bys[tag], selector)
-            tpl = "if {element}.get_attribute('contenteditable'): {element}.clear(); " \
-                  "{element}.send_keys(_tpl.apply('{keys}'))"
-            vals = {"element": element, "keys": param}
-            action_elements.append(self.gen_statement(tpl.format(**vals), indent=indent))
+            element = "self.driver.find_element(By.%s, %r)" % (bys[tag], selector)
+            editable_error = "The element (By.%s, %r) " \
+                             "is not contenteditable element" % (bys[tag], selector)
+            editable_script_inner = "arguments[0].innerHTML = %s;"
+            editable_script = "%r %% %s" % \
+                              (editable_script_inner, "_tpl.str_repr(_tpl.apply(%r)), %s)"
+                               % (param.strip(), element))
+            action_elements.extend([
+                self.gen_statement(
+                    "if %s.get_attribute('contenteditable'):" % element, indent=indent),
+                self.gen_statement(
+                    "self.driver.execute_script(%s" % editable_script,
+                    indent=indent + self.INDENT_STEP),
+                self.gen_statement(
+                    "else:", indent=indent),
+                self.gen_statement(
+                    "raise NoSuchElementException(%r)" % editable_error, indent=indent + self.INDENT_STEP)
+            ])
         elif atype == 'echo' and tag == 'string':
             if len(selector) > 0 and not param:
                 action_elements.append(

--- a/bzt/resources/selenium_taurus_extras.py
+++ b/bzt/resources/selenium_taurus_extras.py
@@ -42,6 +42,10 @@ class Template:
         self.tmpl.variables = self.variables
         return text_type(self.tmpl)
 
+    @staticmethod
+    def str_repr(text):
+        return repr(text)[1:] if repr(text)[0] == "u" else repr(text)
+
 
 class FrameManager:
 

--- a/tests/resources/selenium/generated_from_requests.py
+++ b/tests/resources/selenium/generated_from_requests.py
@@ -69,7 +69,10 @@ class TestRequests(unittest.TestCase):
             self.frm_mng.switch(self.driver.find_element(By.NAME, _tpl.apply('my_frame')))
             self.frm_mng.switch(1)
             self.frm_mng.switch('relative=parent')
-            if self.driver.find_element(By.ID, _tpl.apply('editor')).get_attribute('contenteditable'): self.driver.find_element(By.ID, _tpl.apply('editor')).clear(); self.driver.find_element(By.ID, _tpl.apply('editor')).send_keys(_tpl.apply('lo-la-lu'))
+            if self.driver.find_element(By.ID, 'editor').get_attribute('contenteditable'):
+                self.driver.execute_script('arguments[0].innerHTML = %s;' % _tpl.str_repr(_tpl.apply('lo-la-lu')), self.driver.find_element(By.ID, 'editor'))
+            else:
+                raise NoSuchElementException("The element (By.ID, 'editor') is not contenteditable element")
             sleep(3)
             self.driver.delete_all_cookies()
             self.driver.find_element(By.LINK_TEXT, _tpl.apply('destination of the week! The Beach!')).click()


### PR DESCRIPTION
Hi @undera @dmand @greyfenrir 

I discovered that the implementation of editContent made by @greyfenrir differed in the results of our tests against the version we had in our fork.

The basis of the contenteditable elements is that it transforms that element into a live html editor.
The approach that is currently implemented in taurus sends keystrokes, and not html, which prevents to format the contents.
When html is sent to him, he typed it and therefore he writes html tags losing the format, we realized later the problem due to an error in the assert of our tests, that he made an assert against the text, which then fit, but his content in html differed.

I took the current implementation and I incorporated the innerHTML handling from our fork.
I incorporated something new, the generation of exception when the element is not in editable.

I also found in the tests of our fork a detail in the handling of the representation of the strings when they are sent outside of python (python 2 incorporates 'u' from unicode in front, outside of python like javascript that gives problems because not is standard).
I implemented a simple method that allows formatting using the template system for these particular case, and was tested with texts with utf-8 / unicode and works perfectly, allowing in python 2 and 3 write in that type of content any type of text (with the assurance that the escape of the quotes is correct).

A sample yml with the all sample cases
```yaml
scenarios:
  sample:
    browser: Firefox  # available browsers are: ["Firefox", "Chrome", "Ie", "Opera"]
    headless: false
    timeout: 60s
    think-time: 0s
    requests:
    - label: Test
      actions:
      - go(http://the-internet.herokuapp.com/iframe)
      - switchFrame(index=0)
      - clickByCSS(body)
      # utf-8 and double quotes
      - editContentByID(tinymce): <p>test "9999" éí இனிதாவது எ<br></p>
      # Single quotes
      - editContentByCSS(#tinymce): "<p>test '99'<br></p>"
      # Element not editable
      - editContentByXPath(/html/head): "<p>test 0<br></p>"
      - assertTextByXPath(//body[@id='tinymce']): "test 0"
      - switchFrame(relative=parent)
      - clickByCSS(body)
```