### PR TITLE
Fallback bzm location

### DIFF
--- a/bzt/modules/blazemeter.py
+++ b/bzt/modules/blazemeter.py
@@ -1182,6 +1182,11 @@ class CloudTaurusTest(BaseCloudTest):
             if not location_id.startswith('harbor-') and location['sandbox']:
                 return location_id
 
+        if available_locations:
+            location_id = sorted(available_locations.keys())[0]
+            self.log.warning("Using first location as default: %s", location_id)
+            return location_id
+
         self.log.warning("List of supported locations for you is: %s", sorted(available_locations.keys()))
         raise TaurusConfigError("No sandbox or default location available, please specify locations manually")
 

--- a/bzt/modules/functional.py
+++ b/bzt/modules/functional.py
@@ -219,7 +219,7 @@ class LoadSamplesReader(ResultsReader):
         ltc = 0
         rcd = self.STATUS_TO_CODE.get(item["status"], "UNKNOWN")
         error = item["error_msg"] if item["status"] in TestReportReader.FAILING_TESTS_STATUSES else None
-        trname = ""
+        trname = item.get("workerID", "")
         byte_count = None
         return tstmp, label, concur, rtm, cnn, ltc, rcd, error, trname, byte_count
 

--- a/bzt/modules/reporting.py
+++ b/bzt/modules/reporting.py
@@ -558,7 +558,6 @@ class XUnitFileWriter(object):
     def __init__(self, engine):
         """
         :type engine: bzt.engine.Engine
-        :type suite_name: str
         """
         super(XUnitFileWriter, self).__init__()
         self.engine = engine

--- a/site/dat/docs/ConsoleReporter.md
+++ b/site/dat/docs/ConsoleReporter.md
@@ -21,6 +21,9 @@ modules:
     # - console (ncurses-based dashboard, default for *nix systems)
     # - gui (window-based dashboard, default for Windows, requires Tkinter)
     # - dummy (text output into console for non-tty cases)
+    
+    dummy-cols: 140  # width for dummy screen
+    dummy-rows: 35   # height for dummy screen 
 ```
 
 You can also disable this reporter by using [command-line](CommandLine.md) `-o` switch:

--- a/site/dat/docs/changes/fallback-bzm-location.change
+++ b/site/dat/docs/changes/fallback-bzm-location.change
@@ -1,0 +1,1 @@
+for cloud test, if no sandbox location found and `default-location` is not valid, use first location by default

--- a/tests/modules/test_cloudProvisioning.py
+++ b/tests/modules/test_cloudProvisioning.py
@@ -544,6 +544,21 @@ class TestCloudProvisioning(BZTestCase):
         exec_locations = self.obj.executors[0].execution['locations']
         self.assertEquals(1, exec_locations['non-harbor-sandbox'])
 
+    def test_nosandbox_default_location(self):
+        locs = [{'id': 'loc1', 'sandbox': False, 'title': 'L1'}, {'id': 'loc2', 'sandbox': False, 'title': 'L2'}, ]
+        self.configure(
+            add_settings=False,
+            engine_cfg={ScenarioExecutor.EXEC: {"executor": "mock"}},
+            get={
+                'https://a.blazemeter.com/api/v4/workspaces/1': {"result": {"locations": locs}},
+            }
+        )
+        self.obj.user.token = "key"
+        self.obj.settings['default-location'] = "some-nonavailable"
+        self.obj.prepare()
+        exec_locations = self.obj.executors[0].execution['locations']
+        self.assertEquals(1, exec_locations['loc1'])
+
     def test_collection_defloc_sandbox(self):
         self.obj.user.token = object()
         self.configure(


### PR DESCRIPTION
for cloud test, if no sandbox location found and `default-location` is not valid, use first location by default 
