### PR TITLE
Allow custom SSL certificates to be specified in settings

### DIFF
--- a/bzt/bza.py
+++ b/bzt/bza.py
@@ -33,6 +33,7 @@ class BZAObject(dict):
         self.timeout = 30
         self.logger_limit = 256
         self.token = None
+        self.ssl_cert = None
         self.log = logging.getLogger(self.__class__.__name__)
         self.http_session = requests.Session()
         self.http_request = self.http_session.request
@@ -86,7 +87,8 @@ class BZAObject(dict):
 
         self.log.debug("Request: %s %s %s", log_method, url, data[:self.logger_limit] if data else None)
 
-        response = self.http_request(method=log_method, url=url, data=data, headers=headers, timeout=self.timeout)
+        response = self.http_request(method=log_method, url=url, data=data, headers=headers, timeout=self.timeout,
+                                     cert=self.ssl_cert)
 
         resp = response.content
         if not isinstance(resp, str):

--- a/bzt/bza.py
+++ b/bzt/bza.py
@@ -33,7 +33,8 @@ class BZAObject(dict):
         self.timeout = 30
         self.logger_limit = 256
         self.token = None
-        self.ssl_cert = None
+        self.cert = None
+        self.verify = None
         self.log = logging.getLogger(self.__class__.__name__)
         self.http_session = requests.Session()
         self.http_request = self.http_session.request
@@ -88,7 +89,7 @@ class BZAObject(dict):
         self.log.debug("Request: %s %s %s", log_method, url, data[:self.logger_limit] if data else None)
 
         response = self.http_request(method=log_method, url=url, data=data, headers=headers, timeout=self.timeout,
-                                     cert=self.ssl_cert)
+                                     cert=self.cert, verify=self.verify)
 
         resp = response.content
         if not isinstance(resp, str):

--- a/bzt/bza.py
+++ b/bzt/bza.py
@@ -34,7 +34,7 @@ class BZAObject(dict):
         self.logger_limit = 256
         self.token = None
         self.cert = None
-        self.verify = None
+        self.verify = True
         self.log = logging.getLogger(self.__class__.__name__)
         self.http_session = requests.Session()
         self.http_request = self.http_session.request

--- a/bzt/engine.py
+++ b/bzt/engine.py
@@ -123,8 +123,9 @@ class Engine(object):
 
             def wrapper():
                 settings = self.config.get(SETTINGS)
-                ssl_cert = settings.get('ssl-cert', None)
-                return self._check_updates(install_id, ssl_cert=ssl_cert)
+                verify = settings.get('ssl-cert', True)
+                cert = settings.get('ssl-client-cert', None)
+                return self._check_updates(install_id, verify=verify, cert=cert)
 
             thread = threading.Thread(target=wrapper)  # intentionally non-daemon thread
             thread.start()
@@ -609,12 +610,12 @@ class Engine(object):
             opener = build_opener(proxy_handler)
             install_opener(opener)
 
-    def _check_updates(self, install_id, ssl_cert=None):
+    def _check_updates(self, install_id, verify=None, cert=None):
         try:
             params = (bzt.VERSION, install_id)
             url = "http://gettaurus.org/updates/?version=%s&installID=%s" % params
             self.log.debug("Requesting updates info: %s", url)
-            response = requests.get(url, timeout=10, cert=ssl_cert)
+            response = requests.get(url, timeout=10, cert=cert, verify=verify)
 
             resp = response.content
             if not isinstance(resp, str):

--- a/bzt/engine.py
+++ b/bzt/engine.py
@@ -35,13 +35,14 @@ from collections import namedtuple, defaultdict
 from distutils.version import LooseVersion
 from json import encoder
 
+import requests
 import yaml
 from yaml.representer import SafeRepresenter
 
 import bzt
 from bzt import ManualShutdown, get_configs_dir, TaurusConfigError, TaurusInternalException, InvalidTaurusConfiguration
 from bzt.requests_model import RequestsParser
-from bzt.six import build_opener, install_opener, urlopen, numeric_types
+from bzt.six import build_opener, install_opener, numeric_types
 from bzt.six import string_types, text_type, PY2, UserDict, parse, ProxyHandler, reraise
 from bzt.utils import PIPE, shell_exec, get_full_path, ExceptionalDownloader, get_uniq_name
 from bzt.utils import load_class, to_json, BetterDict, ensure_is_dict, dehumanize_time, is_windows, is_linux
@@ -121,7 +122,9 @@ class Engine(object):
             install_id = self.config.get("install-id", self._generate_id())
 
             def wrapper():
-                return self._check_updates(install_id)
+                settings = self.config.get(SETTINGS)
+                ssl_cert = settings.get('ssl-cert', None)
+                return self._check_updates(install_id, ssl_cert=ssl_cert)
 
             thread = threading.Thread(target=wrapper)  # intentionally non-daemon thread
             thread.start()
@@ -606,14 +609,14 @@ class Engine(object):
             opener = build_opener(proxy_handler)
             install_opener(opener)
 
-    def _check_updates(self, install_id):
+    def _check_updates(self, install_id, ssl_cert=None):
         try:
             params = (bzt.VERSION, install_id)
-            req = "http://gettaurus.org/updates/?version=%s&installID=%s" % params
-            self.log.debug("Requesting updates info: %s", req)
-            response = urlopen(req, timeout=10)
-            resp = response.read()
+            url = "http://gettaurus.org/updates/?version=%s&installID=%s" % params
+            self.log.debug("Requesting updates info: %s", url)
+            response = requests.get(url, timeout=10, cert=ssl_cert)
 
+            resp = response.content
             if not isinstance(resp, str):
                 resp = resp.decode()
 

--- a/bzt/modules/blazemeter.py
+++ b/bzt/modules/blazemeter.py
@@ -235,7 +235,8 @@ class BlazeMeterUploader(Reporter, AggregatorListener, MonitoringListener, Singl
         self._user.address = self.settings.get("address", self._user.address).rstrip("/")
         self._user.data_address = self.settings.get("data-address", self._user.data_address).rstrip("/")
         self._user.timeout = dehumanize_time(self.settings.get("timeout", self._user.timeout))
-        self._user.ssl_cert = self.engine.config.get('settings').get('ssl-cert', None)
+        self._user.verify = self.engine.config.get('settings').get('ssl-cert', True)
+        self._user.cert = self.engine.config.get('settings').get('ssl-client-cert', None)
 
         # direct data feeding case
         sess_id = self.parameters.get("session-id")
@@ -1601,7 +1602,8 @@ class CloudProvisioning(MasterProvisioning, WidgetProvider):
         self.user.token = self.settings.get("token", self.user.token)
         self.user.timeout = dehumanize_time(self.settings.get("timeout", self.user.timeout))
         engine_settings = self.engine.config.get('settings')
-        self.user.ssl_cert = engine_settings.get('ssl-cert', None)
+        self.user.verify = engine_settings.get('ssl-cert', True)
+        self.user.cert = engine_settings.get('ssl-client-cert', None)
         if not self.user.token:
             raise TaurusConfigError("You must provide API token to use cloud provisioning")
 

--- a/bzt/modules/blazemeter.py
+++ b/bzt/modules/blazemeter.py
@@ -235,6 +235,7 @@ class BlazeMeterUploader(Reporter, AggregatorListener, MonitoringListener, Singl
         self._user.address = self.settings.get("address", self._user.address).rstrip("/")
         self._user.data_address = self.settings.get("data-address", self._user.data_address).rstrip("/")
         self._user.timeout = dehumanize_time(self.settings.get("timeout", self._user.timeout))
+        self._user.ssl_cert = self.engine.config.get('settings').get('ssl-cert', None)
 
         # direct data feeding case
         sess_id = self.parameters.get("session-id")
@@ -1599,6 +1600,8 @@ class CloudProvisioning(MasterProvisioning, WidgetProvider):
         self.user.address = self.settings.get("address", self.user.address)
         self.user.token = self.settings.get("token", self.user.token)
         self.user.timeout = dehumanize_time(self.settings.get("timeout", self.user.timeout))
+        engine_settings = self.engine.config.get('settings')
+        self.user.ssl_cert = engine_settings.get('ssl-cert', None)
         if not self.user.token:
             raise TaurusConfigError("You must provide API token to use cloud provisioning")
 

--- a/site/dat/docs/ConfigSyntax.md
+++ b/site/dat/docs/ConfigSyntax.md
@@ -114,7 +114,7 @@ settings:
   env: # set environment variables to set
     VARNAME1: VARVALUE1
     VARNAME2: VARVALUE2
-  ssl-cert: certs/staging.pem
+  ssl-cert: certs/staging.pem  # SSL certificate for validation. You can set it to `false` to disable validation.
   ssl-client-cert: certs/client.cert
 ```
 

--- a/site/dat/docs/ConfigSyntax.md
+++ b/site/dat/docs/ConfigSyntax.md
@@ -92,6 +92,8 @@ Available settings are:
  - `default-executor` - module alias for executor that will be used by default for [executions](ExecutionSettings.md)
  - `proxy` - proxy settings for BZA feeding, Taurus will use proxy settings from OS environment by default.
  - `env` - environment variables to set for Taurus, useful with [evaluating feature](#Environment-Variable-Access). Setting environment variable to `null` makes it to delete variable, if one is set. Special `TAURUS\_ARTIFACTS\_DIR` variable is set by Taurus, pointing onto artifacts dir location.
+ - `ssl-cert` - SSL certificate that Taurus will use for all its requests
+ - `ssl-client-cert` - client side SSL certificate (see [requests docs](http://docs.python-requests.org/en/master/user/advanced/#client-side-certificates) for more info)
  
 See default settings below:
 
@@ -112,6 +114,8 @@ settings:
   env: # set environment variables to set
     VARNAME1: VARVALUE1
     VARNAME2: VARVALUE2
+  ssl-cert: certs/staging.pem
+  ssl-client-cert: certs/client.cert
 ```
 
 ## Human-Readable Time Specifications

--- a/site/dat/docs/changes/allow-custom-ssl-certs.change
+++ b/site/dat/docs/changes/allow-custom-ssl-certs.change
@@ -1,0 +1,1 @@
+Allow custom SSL certificates for Taurus-based HTTP requests (BZA, check-updates)


### PR DESCRIPTION
Certificate will be used for Taurus-based HTTP requests (check-updates, `-report`, `-cloud`).