### PR TITLE
Support 'tags'  in Robot Executor

### DIFF
--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -1690,7 +1690,7 @@ class RobotExecutor(SubprocessedExecutor, HavingInstallableTools):
                 self.tags = tags
             else:
                 raise TaurusConfigError("`tags` is not a string or text")
-                  
+
     def install_required_tools(self):
         self._check_tools([Robot(self.settings.get("interpreter", sys.executable), self.log),
                            TaurusRobotRunner(self.runner_path, "")])

--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -1684,7 +1684,6 @@ class RobotExecutor(SubprocessedExecutor, HavingInstallableTools):
                     fds.write(yml)
             else:
                 raise TaurusConfigError("`variables` is neither file nor dict")
-        
         tags = scenario.get("tags", None)
         if tags:
             if isinstance(tags, (string_types, text_type)):

--- a/bzt/modules/python.py
+++ b/bzt/modules/python.py
@@ -1653,6 +1653,7 @@ class RobotExecutor(SubprocessedExecutor, HavingInstallableTools):
         super(RobotExecutor, self).__init__()
         self.runner_path = os.path.join(get_full_path(__file__, step_up=2), "resources", "robot_runner.py")
         self.variables_file = None
+        self.tags = None
 
     def resource_files(self):
         files = super(RobotExecutor, self).resource_files()
@@ -1683,7 +1684,14 @@ class RobotExecutor(SubprocessedExecutor, HavingInstallableTools):
                     fds.write(yml)
             else:
                 raise TaurusConfigError("`variables` is neither file nor dict")
-
+        
+        tags = scenario.get("tags", None)
+        if tags:
+            if isinstance(tags, (string_types, text_type)):
+                self.tags = tags
+            else:
+                raise TaurusConfigError("`tags` is not a string or text")
+                  
     def install_required_tools(self):
         self._check_tools([Robot(self.settings.get("interpreter", sys.executable), self.log),
                            TaurusRobotRunner(self.runner_path, "")])
@@ -1706,6 +1714,9 @@ class RobotExecutor(SubprocessedExecutor, HavingInstallableTools):
         if self.variables_file is not None:
             cmdline += ['--variablefile', self.variables_file]
 
+        if self.tags is not None:
+            cmdline += ['--include', self.tags]
+            
         cmdline += [self.script]
         self._start_subprocess(cmdline)
 


### PR DESCRIPTION
You can pass either single or multiple 'tags' to robot executor for executing tagged base test cases.
Example:
execution:
- executor: robot
  scenario:
    script: tests/resources/selenium/robot/simple/test_novar.robot
    tags: database

- executor: robot
  scenario:
    script: tests/resources/selenium/robot/simple/test_novar.robot
    tags: variables, database