### PR TITLE
Create basis for centralized proxy support

### DIFF
--- a/bzt/engine.py
+++ b/bzt/engine.py
@@ -117,7 +117,7 @@ class Engine(object):
         self.config['included-configs'] = all_includes
 
         self.config.merge({"version": bzt.VERSION})
-        self._set_up_proxy()
+        self.get_http_client()
 
         if self.config.get(SETTINGS).get("check-updates", True):
             install_id = self.config.get("install-id", self._generate_id())
@@ -591,23 +591,6 @@ class Engine(object):
             self.aggregator = self.instantiate_module(cls)
         self.prepared.append(self.aggregator)
         self.aggregator.prepare()
-
-    def _set_up_proxy(self):
-        proxy_settings = self.config.get("settings").get("proxy")
-        # if proxy_settings and proxy_settings.get("address"):
-        #     proxy_url = parse.urlsplit(proxy_settings.get("address"))
-        #     self.log.debug("Using proxy settings: %s", proxy_url)
-        #     username = proxy_settings.get("username")
-        #     pwd = proxy_settings.get("password")
-        #     scheme = proxy_url.scheme if proxy_url.scheme else 'http'
-        #     if username and pwd:
-        #         proxy_uri = "%s://%s:%s@%s" % (scheme, username, pwd, proxy_url.netloc)
-        #     else:
-        #         proxy_uri = "%s://%s" % (scheme, proxy_url.netloc)
-        #     self.log.info("Proxy uri: %r", proxy_uri)
-        #     proxy_handler = ProxyHandler({"https": proxy_uri, "http": proxy_uri})
-        #     opener = build_opener(proxy_handler)
-        #     install_opener(opener)
 
     def get_http_client(self):
         if self._http_client is None:

--- a/bzt/jmx/http.py
+++ b/bzt/jmx/http.py
@@ -49,7 +49,7 @@ class HTTPProtocolHandler(ProtocolHandler):
         timeout = scenario.get("timeout", None)
         timeout = self.safe_time(timeout)
         elements = [JMX._get_http_defaults(default_address, timeout, retrieve_resources,
-                                            concurrent_pool_size, content_encoding, resources_regex),
+                                           concurrent_pool_size, content_encoding, resources_regex),
                     etree.Element("hashTree")]
         return elements
 

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -868,7 +868,8 @@ class JMeterExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInstall
         download_link = self.settings.get("download-link", None)
         plugins = self.settings.get("plugins", [])
         proxy = self.engine.config.get('settings').get('proxy')
-        self.tool = JMeter(jmeter_path, self.log, jmeter_version, download_link, plugins, proxy)
+        self.tool = JMeter(jmeter_path, self.log, jmeter_version, download_link, plugins, proxy,
+                           self.engine.get_http_client())
 
         if self._need_to_install(self.tool):
             self.tool.install()
@@ -1461,11 +1462,11 @@ class JMeter(RequiredTool):
     JMeter tool
     """
 
-    def __init__(self, tool_path, parent_logger, jmeter_version, jmeter_download_link, plugins, proxy):
+    def __init__(self, tool_path, parent_logger, jmeter_version, jmeter_download_link, plugins, proxy, http_client):
         super(JMeter, self).__init__("JMeter", tool_path, jmeter_download_link)
         self.log = parent_logger.getChild(self.__class__.__name__)
         self.version = jmeter_version
-        self.mirror_manager = JMeterMirrorsManager(self.log, self.version)
+        self.mirror_manager = JMeterMirrorsManager(http_client, self.log, self.version)
         self.plugins = plugins
         self.proxy_settings = proxy
         self.tool_path = self.tool_path.format(version=self.version)
@@ -1655,9 +1656,9 @@ class JarCleaner(object):
 
 
 class JMeterMirrorsManager(MirrorsManager):
-    def __init__(self, parent_logger, jmeter_version):
+    def __init__(self, http_client, parent_logger, jmeter_version):
         self.jmeter_version = str(jmeter_version)
-        super(JMeterMirrorsManager, self).__init__(JMeterExecutor.MIRRORS_SOURCE, parent_logger)
+        super(JMeterMirrorsManager, self).__init__(JMeterExecutor.MIRRORS_SOURCE, http_client, parent_logger)
 
     def _parse_mirrors(self):
         links = []

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1544,14 +1544,14 @@ class JMeter(RequiredTool):
             raise ToolError("Unable to run %s after installation!" % self.tool_name)
 
     def __download_additions(self, tools):
-        downloader = ExceptionalDownloader()
+        downloader = ExceptionalDownloader(self.http_client)
         with ProgressBarContext() as pbar:
             for tool in tools:
                 url = tool[0]
                 _file = os.path.basename(url)
                 self.log.info("Downloading %s from %s", _file, url)
                 try:
-                    downloader.get(url, tool[1], reporthook=pbar.download_callback, http_client=self.http_client)
+                    downloader.get(url, tool[1], reporthook=pbar.download_callback)
                 except KeyboardInterrupt:
                     raise
                 except BaseException as exc:

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1539,7 +1539,7 @@ class JMeter(RequiredTool):
             raise ToolError("Unable to run %s after installation!" % self.tool_name)
 
     def __download_additions(self, tools):
-        downloader = ExceptionalDownloader()
+        downloader = ExceptionalDownloader(self.http_client)
         with ProgressBarContext() as pbar:
             for tool in tools:
                 url = tool[0]
@@ -1658,7 +1658,7 @@ class JarCleaner(object):
 class JMeterMirrorsManager(MirrorsManager):
     def __init__(self, http_client, parent_logger, jmeter_version):
         self.jmeter_version = str(jmeter_version)
-        super(JMeterMirrorsManager, self).__init__(JMeterExecutor.MIRRORS_SOURCE, http_client, parent_logger)
+        super(JMeterMirrorsManager, self).__init__(JMeterExecutor.MIRRORS_SOURCE, parent_logger, http_client)
 
     def _parse_mirrors(self):
         links = []

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1544,14 +1544,14 @@ class JMeter(RequiredTool):
             raise ToolError("Unable to run %s after installation!" % self.tool_name)
 
     def __download_additions(self, tools):
-        downloader = ExceptionalDownloader(self.http_client)
+        downloader = ExceptionalDownloader()
         with ProgressBarContext() as pbar:
             for tool in tools:
                 url = tool[0]
                 _file = os.path.basename(url)
                 self.log.info("Downloading %s from %s", _file, url)
                 try:
-                    downloader.get(url, tool[1], reporthook=pbar.download_callback)
+                    downloader.get(url, tool[1], reporthook=pbar.download_callback, http_client=self.http_client)
                 except KeyboardInterrupt:
                     raise
                 except BaseException as exc:

--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -942,6 +942,11 @@ class HTTPClient(object):
         self.session.cert = proxy_settings.get('ssl-client-cert', None)
 
     def get_proxy_jvm_args(self):
+        if not self.proxy_settings:
+            return ''
+        if not self.proxy_settings.get("address"):
+            return ''
+
         props = OrderedDict()
 
         proxy_url = parse.urlsplit(self.proxy_settings.get("address"))
@@ -978,6 +983,7 @@ class HTTPClient(object):
             raise TaurusNetworkError(msg)
 
     def request(self, method, url, *args, **kwargs):
+        self.log.debug('Making HTTP request %s %s', method, url)
         try:
             return self.session.request(method, url, *args, **kwargs)
         except requests.exceptions.RequestException as exc:

--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -919,24 +919,20 @@ class HTTPClient(object):
         self.proxy_settings = None
 
     def add_proxy_settings(self, proxy_settings):
-        if not proxy_settings:
-            return
-        if not proxy_settings.get("address"):
-            return
-
-        self.proxy_settings = proxy_settings
-        proxy_addr = proxy_settings.get("address")
-        self.log.info("Using proxy %r", proxy_addr)
-        proxy_url = parse.urlsplit(proxy_addr)
-        self.log.debug("Using proxy settings: %s", proxy_url)
-        username = proxy_settings.get("username")
-        pwd = proxy_settings.get("password")
-        scheme = proxy_url.scheme if proxy_url.scheme else 'http'
-        if username and pwd:
-            proxy_uri = "%s://%s:%s@%s" % (scheme, username, pwd, proxy_url.netloc)
-        else:
-            proxy_uri = "%s://%s" % (scheme, proxy_url.netloc)
-        self.session.proxies = {"https": proxy_uri, "http": proxy_uri}
+        if proxy_settings and proxy_settings.get("address"):
+            self.proxy_settings = proxy_settings
+            proxy_addr = proxy_settings.get("address")
+            self.log.info("Using proxy %r", proxy_addr)
+            proxy_url = parse.urlsplit(proxy_addr)
+            self.log.debug("Using proxy settings: %s", proxy_url)
+            username = proxy_settings.get("username")
+            pwd = proxy_settings.get("password")
+            scheme = proxy_url.scheme if proxy_url.scheme else 'http'
+            if username and pwd:
+                proxy_uri = "%s://%s:%s@%s" % (scheme, username, pwd, proxy_url.netloc)
+            else:
+                proxy_uri = "%s://%s" % (scheme, proxy_url.netloc)
+            self.session.proxies = {"https": proxy_uri, "http": proxy_uri}
 
         self.session.verify = proxy_settings.get('ssl-cert', True)
         self.session.cert = proxy_settings.get('ssl-client-cert', None)

--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -998,24 +998,25 @@ class HTTPClient(object):
 
 
 class ExceptionalDownloader(request.FancyURLopener, object):
-    def __init__(self):
+    def __init__(self, http_client=None):
         """
 
         :type http_client: HTTPClient
         """
         super(ExceptionalDownloader, self).__init__()
+        self.http_client = http_client
 
     def http_error_default(self, url, fp, errcode, errmsg, headers):
         fp.close()
         raise TaurusNetworkError("Unsuccessful download from %s: %s - %s" % (url, errcode, errmsg))
 
-    def get(self, url, filename=None, reporthook=None, data=None, suffix="", http_client=None):
+    def get(self, url, filename=None, reporthook=None, data=None, suffix=""):
         fd = None
         try:
             if not filename:
                 fd, filename = tempfile.mkstemp(suffix)
-            if http_client is not None:
-                http_client.download_file(url, filename, reporthook, data)
+            if self.http_client is not None:
+                self.http_client.download_file(url, filename, reporthook, data)
                 result = [filename]
             else:
                 result = self.retrieve(url, filename, reporthook, data)
@@ -1057,8 +1058,7 @@ class RequiredTool(object):
                 os.makedirs(os.path.dirname(self.tool_path))
             downloader = ExceptionalDownloader()
             self.log.info("Downloading %s", self.download_link)
-            downloader.get(self.download_link, self.tool_path, reporthook=pbar.download_callback,
-                           http_client=self.http_client)
+            downloader.get(self.download_link, self.tool_path, reporthook=pbar.download_callback)
 
             if self.check_if_installed():
                 return self.tool_path
@@ -1071,15 +1071,14 @@ class RequiredTool(object):
         else:
             links = self.mirror_manager.mirrors()
 
-        downloader = ExceptionalDownloader()
+        downloader = ExceptionalDownloader(self.http_client)
         sock_timeout = socket.getdefaulttimeout()
         socket.setdefaulttimeout(5)
         for link in links:
             self.log.info("Downloading: %s", link)
             with ProgressBarContext() as pbar:
                 try:
-                    return downloader.get(link, reporthook=pbar.download_callback, suffix=suffix,
-                                          http_client=self.http_client)[0]
+                    return downloader.get(link, reporthook=pbar.download_callback, suffix=suffix)[0]
                 except KeyboardInterrupt:
                     raise
                 except BaseException as exc:

--- a/examples/proxy.yml
+++ b/examples/proxy.yml
@@ -1,0 +1,29 @@
+execution:
+- executor: jmeter
+  hold-for: 30s
+  scenario:
+    retrieve-resources: false
+    requests:
+    - http://blazedemo.com/
+
+
+# instructing JMeter to use proxy
+modules:
+  jmeter:
+    system-properties:
+      http.proxyHost: 192.168.100.2
+      http.proxyPort: 3128
+      http.proxyUser: me
+      http.proxyPass: really
+      https.proxyHost: 192.168.100.2
+      https.proxyPort: 3128
+      https.proxyUser: me
+      https.proxyPass: really
+
+# instructing Taurus to use proxy for Taurus-based requests (installing JMeter and plugins, etc)
+settings:
+  proxy:
+    address: http://192.168.100.2:3128
+    username: me
+    password: really
+

--- a/site/dat/docs/ConfigSyntax.md
+++ b/site/dat/docs/ConfigSyntax.md
@@ -105,6 +105,8 @@ settings:
     address: http://127.0.0.1:8080  # proxy server address
     username: user  # username and password used if authentication is configured on proxy server
     password: 12345
+    ssl-cert: path/to/cert  # SSL server-side certificate
+    ssl-client-cert: path/to/cert  # SSL client-side certificate
   check-updates: true  # check for newer version of Taurus on startup
   verbose: false  # whenever you run bzt with -v option, it sets debug=true, 
                   # some modules might use it for debug features,

--- a/site/dat/docs/changes/add-ssl-cert-support.change
+++ b/site/dat/docs/changes/add-ssl-cert-support.change
@@ -1,0 +1,1 @@
+Support SSL certificates for proxies with `settings.proxy.ssl-cert` option

--- a/site/dat/docs/changes/fix-jmeter-installation-under-proxy.change
+++ b/site/dat/docs/changes/fix-jmeter-installation-under-proxy.change
@@ -1,0 +1,1 @@
+Fix JMeter installation under proxy

--- a/tests/modules/jmeter/__init__.py
+++ b/tests/modules/jmeter/__init__.py
@@ -6,12 +6,13 @@ from bzt.utils import get_full_path
 
 
 class MockJMeter(JMeter):
-    def __init__(self, jmeter_version=JMeterExecutor.JMETER_VER, has_ctg=None, reaction=None):
+    def __init__(self, jmeter_version=JMeterExecutor.JMETER_VER, has_ctg=None, reaction=None, http_client=None):
         jmeter_path = "~/.bzt/jmeter-taurus/{version}/"
         jmeter_path = get_full_path(jmeter_path)
 
         super(MockJMeter, self).__init__(tool_path=jmeter_path, parent_logger=logging.getLogger(''),
-                                         jmeter_version=jmeter_version, jmeter_download_link=None, plugins=[], proxy={})
+                                         jmeter_version=jmeter_version, jmeter_download_link=None, plugins=[], proxy={},
+                                         http_client=http_client)
         self.has_ctg = has_ctg
         self.reaction = reaction if reaction else []
 

--- a/tests/modules/jmeter/__init__.py
+++ b/tests/modules/jmeter/__init__.py
@@ -11,7 +11,7 @@ class MockJMeter(JMeter):
         jmeter_path = get_full_path(jmeter_path)
 
         super(MockJMeter, self).__init__(tool_path=jmeter_path, parent_logger=logging.getLogger(''),
-                                         jmeter_version=jmeter_version, jmeter_download_link=None, plugins=[], proxy={},
+                                         jmeter_version=jmeter_version, jmeter_download_link=None, plugins=[],
                                          http_client=http_client)
         self.has_ctg = has_ctg
         self.reaction = reaction if reaction else []
@@ -19,7 +19,7 @@ class MockJMeter(JMeter):
     def ctg_plugin_installed(self):
         return self.has_ctg
 
-    def _pmgr_call(self, params):
+    def _pmgr_call(self, params, env=None):
         # replaces real pmgr call
         reaction = self.reaction.pop(0)
         if 'raise' in reaction:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,7 @@ from psutil import Popen
 from os.path import join
 
 from bzt.six import PY2
-from bzt.utils import log_std_streams, get_uniq_name, JavaVM, ToolError, is_windows
+from bzt.utils import log_std_streams, get_uniq_name, JavaVM, ToolError, is_windows, HTTPClient
 from tests import BZTestCase, RESOURCES_DIR
 from tests.mocks import MockFileReader
 
@@ -118,3 +118,36 @@ class TestFileReader(BZTestCase):
     def test_decode_crash(self):
         self.configure(join(RESOURCES_DIR, 'jmeter', 'jtl', 'unicode.jtl'))
         self.obj.get_bytes(size=180)  # shouldn't crash with UnicodeDecodeError
+
+
+class TestHTTPClient(BZTestCase):
+    def test_proxy_setup(self):
+        obj = HTTPClient()
+        obj.add_proxy_settings({"address": "http://localhost:3128",
+                                "username": "me",
+                                "password": "too"})
+
+        self.assertIn('http', obj.session.proxies)
+        self.assertIn('https', obj.session.proxies)
+
+        self.assertEqual(obj.session.proxies['http'], 'http://me:too@localhost:3128')
+        self.assertEqual(obj.session.proxies['https'], 'http://me:too@localhost:3128')
+
+    def test_proxy_ssl_cert(self):
+        obj = HTTPClient()
+        obj.add_proxy_settings({"ssl-cert": "i am server side cert",
+                                "ssl-client-cert": "i am client side cert"})
+
+        self.assertEqual(obj.session.verify, 'i am server side cert')
+        self.assertEqual(obj.session.cert, 'i am client side cert')
+
+    def test_jvm_args(self):
+        obj = HTTPClient()
+        obj.add_proxy_settings({"address": "http://localhost:3128",
+                                "username": "me",
+                                "password": "too"})
+        jvm_args = obj.get_proxy_jvm_args()
+        for protocol in ['http', 'https']:
+            for key in ['proxyHost', 'proxyPort', 'proxyUser', 'proxyPass']:
+                combo_key = protocol + '.' + key
+                self.assertIn(combo_key, jvm_args)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -167,12 +167,19 @@ class TestHTTPClient(BZTestCase):
 
         self.assertGreaterEqual(len(contents), 0)
 
-    def test_download_fail(self):
+    def test_download_404(self):
         obj = HTTPClient()
         fd, tmpfile = tempfile.mkstemp()
         os.close(fd)
 
         self.assertRaises(TaurusNetworkError, lambda: obj.download_file('http://httpbin.org/status/404', tmpfile))
+
+    def test_download_fail(self):
+        obj = HTTPClient()
+        fd, tmpfile = tempfile.mkstemp()
+        os.close(fd)
+
+        self.assertRaises(TaurusNetworkError, lambda: obj.download_file('http://non.existent.com/', tmpfile))
 
     def test_request(self):
         obj = HTTPClient()
@@ -181,5 +188,4 @@ class TestHTTPClient(BZTestCase):
 
     def test_request_fail(self):
         obj = HTTPClient()
-        resp = obj.request('GET', 'http://httpbin.org/status/404')
-        self.assertFalse(resp.ok)
+        self.assertRaises(TaurusNetworkError, lambda: obj.request('GET', 'http://non.existent.com/'))


### PR DESCRIPTION
This adds `HTTPClient` class that should be used for all HTTP requests inside Taurus. This class will be instantiated by Engine with proxy settings applied (HTTP proxy, SSL cert, etc).

This PR doesn't aim for a complete proxy support, but for starting a gradual transition.

Changes in this PR include:
- [x] Add HTTPClient
- [x] Use HTTPClient for checking updates
- [x] Use HTTPClient for checking JMeter mirrors and downloading JMeter distribution
- [x] Use proxy settings for installing JMeter plugins with plugin manager 