### PR TITLE
Prevent crash diagnostics data from being posted to BZA report `note`

### DIFF
--- a/bzt/__init__.py
+++ b/bzt/__init__.py
@@ -58,13 +58,6 @@ class ToolError(TaurusException):
         :type message: str
         :type diagnostics: list[str]
         """
-        try:
-            if diagnostics:
-                message += "\n" + "\n".join(line for line in diagnostics)
-        except BaseException as exc:
-            logger = logging.getLogger()
-            logger.debug(traceback.format_exc())
-            logger.warn("Coulnd't extract diagnostics info from the tool: %s", str(exc))
         super(ToolError, self).__init__(message)
         self.diagnostics = diagnostics
 

--- a/bzt/engine.py
+++ b/bzt/engine.py
@@ -199,7 +199,7 @@ class Engine(object):
         calls `shutdown` in any case
         """
         self.log.info("Starting...")
-        exc_info = None
+        exc_info = exc_value = None
         try:
             self._startup()
             self.logging_level_down()
@@ -219,9 +219,11 @@ class Engine(object):
                     self.stopping_reason = exc
                 if not exc_info:
                     exc_info = sys.exc_info()
+                if not exc_value:
+                    exc_value = exc
 
         if exc_info:
-            reraise(exc_info)
+            reraise(exc_info, exc_value)
 
     def _check_modules_list(self):
         stop = False
@@ -262,7 +264,7 @@ class Engine(object):
         """
         self.log.info("Shutting down...")
         self.log.debug("Current stop reason: %s", self.stopping_reason)
-        exc_info = None
+        exc_info = exc_value = None
         modules = [self.provisioning, self.aggregator] + self.reporters + self.services  # order matters
         for module in modules:
             try:
@@ -272,10 +274,12 @@ class Engine(object):
                 self.log.debug("%s:\n%s", exc, traceback.format_exc())
                 if not exc_info:
                     exc_info = sys.exc_info()
+                if not exc_value:
+                    exc_value = exc
 
         self.config.dump()
         if exc_info:
-            reraise(exc_info)
+            reraise(exc_info, exc_value)
 
     def post_process(self):
         """
@@ -283,7 +287,7 @@ class Engine(object):
         """
         self.log.info("Post-processing...")
         # :type exception: BaseException
-        exc_info = None
+        exc_info = exc_value = None
         modules = [self.provisioning, self.aggregator] + self.reporters + self.services  # order matters
         # services are last because of shellexec which is "final-final" action
         for module in modules:
@@ -299,10 +303,12 @@ class Engine(object):
                         self.stopping_reason = exc
                     if not exc_info:
                         exc_info = sys.exc_info()
+                    if not exc_value:
+                        exc_value = exc
         self.config.dump()
 
         if exc_info:
-            reraise(exc_info)
+            reraise(exc_info, exc_value)
 
     def create_artifact(self, prefix, suffix):
         """

--- a/bzt/modules/blazemeter.py
+++ b/bzt/modules/blazemeter.py
@@ -127,6 +127,7 @@ CLOUD_CONFIG_FILTER_RULES = {
 
 CLOUD_CONFIG_FILTER_RULES['modules']['!cloud'] = CLOUD_CONFIG_FILTER_RULES['modules']['!blazemeter']
 NETWORK_PROBLEMS = (IOError, URLError, SSLError, ReadTimeout, TaurusNetworkError)
+NOTE_SIZE_LIMIT = 2048
 
 
 def send_with_retry(method):
@@ -467,7 +468,7 @@ class BlazeMeterUploader(Reporter, AggregatorListener, MonitoringListener, Singl
             note = self._session['note'] + '\n' + note
         note = note.strip()
         if note:
-            self._session.set({'note': note})
+            self._session.set({'note': note[:NOTE_SIZE_LIMIT]})
 
     def append_note_to_master(self, note):
         self._master.fetch()
@@ -475,7 +476,7 @@ class BlazeMeterUploader(Reporter, AggregatorListener, MonitoringListener, Singl
             note = self._master['note'] + '\n' + note
         note = note.strip()
         if note:
-            self._master.set({'note': note})
+            self._master.set({'note': note[:NOTE_SIZE_LIMIT]})
 
     def check(self):
         """

--- a/bzt/modules/provisioning.py
+++ b/bzt/modules/provisioning.py
@@ -136,7 +136,7 @@ class Local(Provisioning):
         """
         Call shutdown on executors
         """
-        exc_info = None
+        exc_info = exc_value = None
         for executor in self.executors:
             if executor in self.engine.started:
                 self.log.debug("Shutdown %s", executor)
@@ -147,14 +147,16 @@ class Local(Provisioning):
                     self.log.debug(msg, executor.__class__.__name__, exc, traceback.format_exc())
                     if not exc_info:
                         exc_info = sys.exc_info()
+                    if not exc_value:
+                        exc_value = exc
         if exc_info:
-            reraise(exc_info)
+            reraise(exc_info, exc_value)
 
     def post_process(self):
         """
         Post-process executors
         """
-        exc_info = None
+        exc_info = exc_value = None
         for executor in self.executors:
             if executor in self.engine.prepared:
                 self.log.debug("Post-process %s", executor)
@@ -173,5 +175,7 @@ class Local(Provisioning):
                     self.log.debug(msg, executor.__class__.__name__, exc, traceback.format_exc())
                     if not exc_info:
                         exc_info = sys.exc_info()
+                    if not exc_value:
+                        exc_value = exc
         if exc_info:
-            reraise(exc_info)
+            reraise(exc_info, exc_value)

--- a/bzt/six/py2.py
+++ b/bzt/six/py2.py
@@ -82,8 +82,11 @@ def get_stacktrace(exc):
     return traceback.format_exc(exc).rstrip()
 
 
-def reraise(exc_info):
-    raise exc_info[0], exc_info[1], exc_info[2]
+def reraise(exc_info, exc=None):
+    exc_type, exc_value, exc_tb = exc_info
+    if exc is not None:
+        exc_value = exc
+    raise exc_type, exc_value, exc_tb
 
 
 def stream_decode(string):

--- a/bzt/six/py3.py
+++ b/bzt/six/py3.py
@@ -77,9 +77,10 @@ def get_stacktrace(exc):
     return ''.join(traceback.format_tb(exc.__traceback__)).rstrip()
 
 
-def reraise(exc_info):
+def reraise(exc_info, exc=None):
     _type, message, stacktrace = exc_info
-    exc = _type(message)
+    if exc is None:
+        exc = _type(message)
     exc.__traceback__ = stacktrace
     raise exc
 

--- a/site/dat/docs/changes/fix-multiline-note-to-bza.change
+++ b/site/dat/docs/changes/fix-multiline-note-to-bza.change
@@ -1,0 +1,1 @@
+Do not send multiline note to BZA

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -9,7 +9,7 @@ from collections import Counter
 
 import requests
 
-from bzt.engine import Engine, Configuration, FileLister, HavingInstallableTools, Singletone, Service
+from bzt.engine import Engine, Configuration, FileLister, HavingInstallableTools, Singletone, Service, SelfDiagnosable
 from bzt.engine import Provisioning, ScenarioExecutor, Reporter
 from bzt.modules import TransactionListener
 from bzt.modules.aggregator import ResultsReader, AggregatorListener
@@ -61,7 +61,7 @@ class EngineEmul(Engine):
         return super(EngineEmul, self).prepare()
 
 
-class ModuleMock(ScenarioExecutor, Provisioning, Reporter, FileLister, HavingInstallableTools):
+class ModuleMock(ScenarioExecutor, Provisioning, Reporter, FileLister, HavingInstallableTools, SelfDiagnosable):
     """ mock """
 
     def __init__(self):
@@ -170,6 +170,9 @@ class ModuleMock(ScenarioExecutor, Provisioning, Reporter, FileLister, HavingIns
 
     def install_required_tools(self):
         self.log.debug("All is good")
+
+    def get_error_diagnostics(self):
+        return ['DIAGNOSTICS']
 
 
 class MockReader(ResultsReader, AggregatorListener):

--- a/tests/modules/test_LocalProvisioning.py
+++ b/tests/modules/test_LocalProvisioning.py
@@ -2,6 +2,7 @@ import time
 
 import datetime
 
+from bzt import ToolError
 from bzt.engine import ScenarioExecutor
 from bzt.modules.provisioning import Local
 from tests import BZTestCase
@@ -107,3 +108,23 @@ class LocalProvisioningTest(BZTestCase):
             executor.is_has_results = True
 
         local.post_process()
+
+    def test_exception(self):
+        local = Local()
+        local.engine = EngineEmul()
+        local.engine.config[ScenarioExecutor.EXEC] = [{}]
+        local.engine.config.get("settings")["default-executor"] = "mock"
+        local.prepare()
+        local.startup()
+
+        local.check()
+
+        local.shutdown()
+        try:
+            local.post_process()
+        except ToolError as exc:
+            self.assertNotIn('DIAGNOSTICS', str(exc))
+            self.assertIsNotNone(exc.diagnostics)
+            self.assertEqual(exc.diagnostics, ['DIAGNOSTICS'])
+        except BaseException as exc:
+            self.fail("Was supposed to fail with ToolError, but crashed with %s" % exc)


### PR DESCRIPTION
...by adapting `reraise` to not throw away diagnostics.

The issue is that Taurus glues all diagnostics data (JMeter logs, stderr/stdout) into `ToolError.message`, which gets sent into the test report at BZA as a note. And because of that, the note gets really big, which is not acceptable.

The obvious idea would be to attach diagnostics into the ToolError in other way, as a `diagnostics` attribute. This, unfortunately, wouldn't fly, as the mechanism we use to have centralized exception handling (`reraise()`) throws away all exception attributes except `message`.

Another way to fix this would be to ensure that `note` that is sent to BZA is no longer than one line. This isn't really feasible, as it required patching both `blazemeter` reporter in Taurus and parts of taurus in the cloud.

So the solution is to adapt the `reraise()` function to preserve diagnostics attached to the exception, instead of throwing them away.
