### PR TITLE
Enable SIEGERC ENV

### DIFF
--- a/bzt/modules/siege.py
+++ b/bzt/modules/siege.py
@@ -45,17 +45,21 @@ class SiegeExecutor(ScenarioExecutor, WidgetProvider, HavingInstallableTools, Fi
         self.scenario = self.get_scenario()
         self.tool_path = self.install_required_tools()
 
-        config_params = ('verbose = true',
-                         'csv = true',
-                         'timestamp = false',
-                         'fullurl = true',
-                         'display-id = true',
-                         'show-logfile = false',
-                         'logging = false')
+        if self.env.get("SIEGERC"):
+          with open( self.env.get("SIEGERC"), 'r') as rc_file:
+            config_params = rc_file.readlines()
+        else:
+          config_params = ('verbose = true',
+                           'csv = true',
+                           'timestamp = false',
+                           'fullurl = true',
+                           'display-id = true',
+                           'show-logfile = false',
+                           'logging = false')
 
         self.__rc_name = self.engine.create_artifact("siegerc", "")
-        with open(self.__rc_name, 'w') as rc_file:
-            rc_file.writelines('\n'.join(config_params))
+        with open(self.__rc_name, 'w') as rc_artifact_file:
+            rc_artifact_file.writelines('\n'.join(config_params))
 
         self.__url_name = self.get_script_path()
 

--- a/bzt/modules/siege.py
+++ b/bzt/modules/siege.py
@@ -45,8 +45,8 @@ class SiegeExecutor(ScenarioExecutor, WidgetProvider, HavingInstallableTools, Fi
         self.scenario = self.get_scenario()
         self.tool_path = self.install_required_tools()
 
-        if self.env.get("SIEGERC"):
-          with open( self.env.get("SIEGERC"), 'r') as rc_file:
+        if self.execution.get("rc-file", None):
+          with open( self.execution.get("rc-file"), 'r') as rc_file:
             config_params = rc_file.readlines()
         else:
           config_params = ('verbose = true',

--- a/bzt/modules/siege.py
+++ b/bzt/modules/siege.py
@@ -46,10 +46,10 @@ class SiegeExecutor(ScenarioExecutor, WidgetProvider, HavingInstallableTools, Fi
         self.tool_path = self.install_required_tools()
 
         if self.execution.get("rc-file", None):
-          with open( self.execution.get("rc-file"), 'r') as rc_file:
-            config_params = rc_file.readlines()
+            with open( self.execution.get("rc-file"), 'r') as rc_file:
+                config_params = rc_file.readlines()
         else:
-          config_params = ('verbose = true',
+            config_params = ('verbose = true',
                            'csv = true',
                            'timestamp = false',
                            'fullurl = true',

--- a/site/dat/docs/Siege.md
+++ b/site/dat/docs/Siege.md
@@ -10,6 +10,7 @@
  - HEADER(`headers` in config file): set HTTP headers for request,
  - REPS(`iterations`): repeat requests N times,
  - TIME(`hold-for`): set execution time limit.
+ - SIEGERC(`rc-file`): the siege config file to use (default None)
 
 Please keep in mind these rules when using Siege test executor:
  - You must specify at least one URL with `url` param in `requests` section or as url-file (`script`).

--- a/site/dat/docs/changes/siegerc.change
+++ b/site/dat/docs/changes/siegerc.change
@@ -1,0 +1,1 @@
+Added rc-file as an executor option for Siege

--- a/tests/modules/test_Siege.py
+++ b/tests/modules/test_Siege.py
@@ -90,6 +90,7 @@ class TestSiegeExecutor(BZTestCase):
         self.obj.execution.merge({
             "concurrency": 2,
             "iterations": 3,
+            "rc-file": join(RESOURCES_DIR, "siege", "siegerc")}})
             "scenario": {
                 "requests": [
                     "http://blazedemo.com",

--- a/tests/modules/test_Siege.py
+++ b/tests/modules/test_Siege.py
@@ -90,7 +90,7 @@ class TestSiegeExecutor(BZTestCase):
         self.obj.execution.merge({
             "concurrency": 2,
             "iterations": 3,
-            "rc-file": join(RESOURCES_DIR, "siege", "siegerc")}})
+            "rc-file": join(RESOURCES_DIR, "siege", "siegerc"),
             "scenario": {
                 "requests": [
                     "http://blazedemo.com",

--- a/tests/resources/siege/siegerc
+++ b/tests/resources/siege/siegerc
@@ -1,0 +1,9 @@
+verbose = true
+csv = true
+timestamp = false
+fullurl = true
+display-id = true
+show-logfile = false
+logging = false
+foo = baz
+


### PR DESCRIPTION
Manually tested with SIEGERC unset, SIEGERC=siegerc.local, SIEGERC=/etc/siege/siegerc

The /etc/siege/siegerc runs fine but fails due to logfile being unwritable.

Writing tests is a bit beyond my skillset, but if someone can point me in the right direction I'm happy to attempt it.