### PR TITLE
Use http client everywhere (where needed)

### DIFF
--- a/bzt/modules/gatling.py
+++ b/bzt/modules/gatling.py
@@ -481,7 +481,8 @@ class GatlingExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInstal
         gatling_path = get_full_path(self.settings.get("path", def_path))
         self.settings["path"] = gatling_path
         download_link = self.settings.get("download-link", GatlingExecutor.DOWNLOAD_LINK)
-        required_tools.append(Gatling(gatling_path, self.log, download_link, gatling_version))
+        gatling = Gatling(gatling_path, self.log, download_link, gatling_version, self.engine.get_http_client())
+        required_tools.append(gatling)
 
         for tool in required_tools:
             if not tool.check_if_installed():
@@ -714,8 +715,8 @@ class Gatling(RequiredTool):
     Gatling tool
     """
 
-    def __init__(self, tool_path, parent_logger, download_link, version):
-        super(Gatling, self).__init__("Gatling", tool_path, download_link.format(version=version))
+    def __init__(self, tool_path, parent_logger, download_link, version, http_client):
+        super(Gatling, self).__init__("Gatling", tool_path, download_link.format(version=version), http_client)
         self.log = parent_logger.getChild(self.__class__.__name__)
         self.version = version
 

--- a/bzt/modules/grinder.py
+++ b/bzt/modules/grinder.py
@@ -233,10 +233,11 @@ class GrinderExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInstal
         grinder_path = get_full_path(grinder_path)
         self.settings["path"] = grinder_path
         download_link = self.settings.get("download-link", "")
+        grinder = Grinder(grinder_path, self.log, GrinderExecutor.VERSION, download_link, self.engine.get_http_client())
         required_tools = [TclLibrary(self.log),
                           JavaVM(self.log),
                           TaurusJavaHelper(),
-                          Grinder(grinder_path, self.log, GrinderExecutor.VERSION, download_link=download_link)]
+                          grinder]
 
         for tool in required_tools:
             if not tool.check_if_installed():
@@ -424,8 +425,8 @@ class DataLogReader(ResultsReader):
 
 
 class Grinder(RequiredTool):        # todo: take it from maven and convert to JarTool(?)
-    def __init__(self, tool_path, parent_logger, version, download_link):
-        super(Grinder, self).__init__("Grinder", tool_path, download_link=download_link)
+    def __init__(self, tool_path, parent_logger, version, download_link, http_client):
+        super(Grinder, self).__init__("Grinder", tool_path, download_link, http_client)
         self.log = parent_logger.getChild(self.__class__.__name__)
         self.version = version
         self.mirror_manager = GrinderMirrorsManager(self.log, self.version)

--- a/bzt/modules/grinder.py
+++ b/bzt/modules/grinder.py
@@ -233,10 +233,11 @@ class GrinderExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInstal
         grinder_path = get_full_path(grinder_path)
         self.settings["path"] = grinder_path
         download_link = self.settings.get("download-link", "")
-        grinder = Grinder(grinder_path, self.log, GrinderExecutor.VERSION, download_link, self.engine.get_http_client())
+        http_client = self.engine.get_http_client()
+        grinder = Grinder(grinder_path, self.log, GrinderExecutor.VERSION, download_link, http_client)
         required_tools = [TclLibrary(self.log),
                           JavaVM(self.log),
-                          TaurusJavaHelper(),
+                          TaurusJavaHelper(http_client),
                           grinder]
 
         for tool in required_tools:

--- a/bzt/modules/java/executors.py
+++ b/bzt/modules/java/executors.py
@@ -45,10 +45,11 @@ class JavaTestRunner(SubprocessedExecutor, HavingInstallableTools):
         self._full_install = True
 
     def install_required_tools(self):
-        self._add_jar_tool(SeleniumServer(self.settings.get("selenium-server")))
-        self._add_jar_tool(Hamcrest(self.settings.get("hamcrest-core")))
-        self._add_jar_tool(Json(self.settings.get("json-jar")))
-        self._add_jar_tool(TaurusJavaHelper())
+        http = self.engine.get_http_client()
+        self._add_jar_tool(SeleniumServer(http, self.settings.get("selenium-server")))
+        self._add_jar_tool(Hamcrest(http, self.settings.get("hamcrest-core")))
+        self._add_jar_tool(Json(http, self.settings.get("json-jar")))
+        self._add_jar_tool(TaurusJavaHelper(http))
 
         if self._full_install or self._java_scripts:
             self._tools.append(JavaC())
@@ -200,17 +201,18 @@ class JUnitTester(JavaTestRunner):
 
             path = os.path.join(path, "{tool_file}")
 
-        self._add_jar_tool(JUnitJupiterApi(path))
-        self._add_jar_tool(JUnitJupiterEngine(path))
-        self._add_jar_tool(JUnitPlatformCommons(path))
-        self._add_jar_tool(JUnitPlatformEngine(path))
-        self._add_jar_tool(JUnitPlatformLauncher(path))
-        self._add_jar_tool(JUnitPlatformRunner(path))
-        self._add_jar_tool(JUnitPlatformSuiteApi(path))
-        self._add_jar_tool(JUnitVintageEngine(path))
-        self._add_jar_tool(ApiGuardian(path))
-        self._add_jar_tool(OpenTest4j(path))
-        self._add_jar_tool(JUnit(path))
+        http = self.engine.get_http_client()
+        self._add_jar_tool(JUnitJupiterApi(http, path))
+        self._add_jar_tool(JUnitJupiterEngine(http, path))
+        self._add_jar_tool(JUnitPlatformCommons(http, path))
+        self._add_jar_tool(JUnitPlatformEngine(http, path))
+        self._add_jar_tool(JUnitPlatformLauncher(http, path))
+        self._add_jar_tool(JUnitPlatformRunner(http, path))
+        self._add_jar_tool(JUnitPlatformSuiteApi(http, path))
+        self._add_jar_tool(JUnitVintageEngine(http, path))
+        self._add_jar_tool(ApiGuardian(http, path))
+        self._add_jar_tool(OpenTest4j(http, path))
+        self._add_jar_tool(JUnit(http, path))
 
         super(JUnitTester, self).install_required_tools()
 

--- a/bzt/modules/java/tools.py
+++ b/bzt/modules/java/tools.py
@@ -27,7 +27,7 @@ class JarTool(RequiredTool):
     REMOTE_PATH = ""
     LOCAL_PATH = "~/.bzt/selenium-taurus/{tool_file}"
 
-    def __init__(self, tool_name, local_path, tool_file):
+    def __init__(self, tool_name, local_path, tool_file, http_client):
         tool_file = tool_file.format(version=self.VERSION)
         remote_path = self.REMOTE_PATH.format(version=self.VERSION)
 
@@ -36,7 +36,8 @@ class JarTool(RequiredTool):
 
         local_path = local_path.format(tool_file=tool_file)
         download_link = self.URL.format(remote_addr=self.REMOTE_ADDR, remote_path=remote_path)
-        super(JarTool, self).__init__(tool_name=tool_name, tool_path=local_path, download_link=download_link)
+        super(JarTool, self).__init__(tool_name=tool_name, tool_path=local_path, download_link=download_link,
+                                      http_client=http_client)
 
 
 class JavaC(RequiredTool):
@@ -73,9 +74,9 @@ class SeleniumServer(JarTool):
     REMOTE_ADDR = "http://selenium-release.storage.googleapis.com/"
     REMOTE_PATH = "{version}/selenium-server-standalone-{version}.0.jar"
 
-    def __init__(self, local_path=""):
+    def __init__(self, http_client, local_path=""):
         tool_file = "selenium-server-{version}.jar"
-        super(SeleniumServer, self).__init__("Selenium server", local_path, tool_file)
+        super(SeleniumServer, self).__init__("Selenium server", local_path, tool_file, http_client)
 
     def check_if_installed(self):
         self.log.debug("%s path: %s", self.tool_name, self.tool_path)
@@ -93,9 +94,9 @@ class SeleniumServer(JarTool):
 class Json(JarTool):
     REMOTE_PATH = "org/json/json/20160810/json-20160810.jar"
 
-    def __init__(self, tool_path=""):
+    def __init__(self, http_client, tool_path=""):
         tool_file = "json.jar"
-        super(Json, self).__init__("Json", tool_path, tool_file)
+        super(Json, self).__init__("Json", tool_path, tool_file, http_client)
 
 
 class TestNG(JarTool):
@@ -111,114 +112,114 @@ class Hamcrest(JarTool):
     VERSION = "1.3"
     REMOTE_PATH = "org/hamcrest/hamcrest-core/{version}/hamcrest-core-{version}.jar"
 
-    def __init__(self, tool_path=""):
+    def __init__(self, http_client, tool_path=""):
         tool_file = "hamcrest-core-{version}.jar"
-        super(Hamcrest, self).__init__("HamcrestJar", tool_path, tool_file)
+        super(Hamcrest, self).__init__("HamcrestJar", tool_path, tool_file, http_client)
 
 
 class JUnitJupiterApi(JarTool):
     VERSION = "5.2.0"
     REMOTE_PATH = "org/junit/jupiter/junit-jupiter-api/{version}/junit-jupiter-api-{version}.jar"
 
-    def __init__(self, tool_path=""):
+    def __init__(self, http_client, tool_path=""):
         tool_file = "junit-jupiter-api-{version}.jar"
-        super(JUnitJupiterApi, self).__init__("JUnitJupiterApi", tool_path, tool_file)
+        super(JUnitJupiterApi, self).__init__("JUnitJupiterApi", tool_path, tool_file, http_client)
 
 
 class JUnitJupiterEngine(JarTool):
     VERSION = "5.2.0"
     REMOTE_PATH = "org/junit/jupiter/junit-jupiter-engine/{version}/junit-jupiter-engine-{version}.jar"
 
-    def __init__(self, tool_path=""):
+    def __init__(self, http_client, tool_path=""):
         tool_file = "junit-jupiter-engine-{version}.jar"
-        super(JUnitJupiterEngine, self).__init__("JUnitJupiterEngine", tool_path, tool_file)
+        super(JUnitJupiterEngine, self).__init__("JUnitJupiterEngine", tool_path, tool_file, http_client)
 
 
 class JUnitVintageEngine(JarTool):
     VERSION = "5.2.0"
     REMOTE_PATH = "org/junit/vintage/junit-vintage-engine/{version}/junit-vintage-engine-{version}.jar"
 
-    def __init__(self, tool_path=""):
+    def __init__(self, http_client, tool_path=""):
         tool_file = "junit-vintage-engine-{version}.jar"
-        super(JUnitVintageEngine, self).__init__("JUnitVintageEngine", tool_path, tool_file)
+        super(JUnitVintageEngine, self).__init__("JUnitVintageEngine", tool_path, tool_file, http_client)
 
 
 class JUnitPlatformCommons(JarTool):
     VERSION = "1.2.0"
     REMOTE_PATH = "org/junit/platform/junit-platform-commons/{version}/junit-platform-commons-{version}.jar"
 
-    def __init__(self, tool_path=""):
+    def __init__(self, http_client, tool_path=""):
         tool_file = "junit-platform-commons-{version}.jar"
-        super(JUnitPlatformCommons, self).__init__("JUnitPlatformCommons", tool_path, tool_file)
+        super(JUnitPlatformCommons, self).__init__("JUnitPlatformCommons", tool_path, tool_file, http_client)
 
 
 class JUnitPlatformEngine(JarTool):
     VERSION = "1.2.0"
     REMOTE_PATH = "org/junit/platform/junit-platform-engine/{version}/junit-platform-engine-{version}.jar"
 
-    def __init__(self, tool_path=""):
+    def __init__(self, http_client, tool_path=""):
         tool_file = "junit-platform-engine-{version}.jar"
-        super(JUnitPlatformEngine, self).__init__("JUnitPlatformEngine", tool_path, tool_file)
+        super(JUnitPlatformEngine, self).__init__("JUnitPlatformEngine", tool_path, tool_file, http_client)
 
 
 class JUnitPlatformLauncher(JarTool):
     VERSION = "1.2.0"
     REMOTE_PATH = "org/junit/platform/junit-platform-launcher/{version}/junit-platform-launcher-{version}.jar"
 
-    def __init__(self, tool_path=""):
+    def __init__(self, http_client, tool_path=""):
         tool_file = "junit-platform-launcher-{version}.jar"
-        super(JUnitPlatformLauncher, self).__init__("JUnitPlatformLauncher", tool_path, tool_file)
+        super(JUnitPlatformLauncher, self).__init__("JUnitPlatformLauncher", tool_path, tool_file, http_client)
 
 
 class JUnitPlatformRunner(JarTool):
     VERSION = "1.2.0"
     REMOTE_PATH = "org/junit/platform/junit-platform-runner/{version}/junit-platform-runner-{version}.jar"
 
-    def __init__(self, tool_path=""):
+    def __init__(self, http_client, tool_path=""):
         tool_file = "junit-platform-runner-{version}.jar"
-        super(JUnitPlatformRunner, self).__init__("JUnitPlatformRunner", tool_path, tool_file)
+        super(JUnitPlatformRunner, self).__init__("JUnitPlatformRunner", tool_path, tool_file, http_client)
 
 
 class JUnitPlatformSuiteApi(JarTool):
     VERSION = "1.2.0"
     REMOTE_PATH = "org/junit/platform/junit-platform-suite-api/{version}/junit-platform-suite-api-{version}.jar"
 
-    def __init__(self, tool_path=""):
+    def __init__(self, http_client, tool_path=""):
         tool_file = "junit-platform-suite-api-{version}.jar"
-        super(JUnitPlatformSuiteApi, self).__init__("JUnitPlatformSuiteApi", tool_path, tool_file)
+        super(JUnitPlatformSuiteApi, self).__init__("JUnitPlatformSuiteApi", tool_path, tool_file, http_client)
 
 
 class ApiGuardian(JarTool):
     VERSION = "1.0.0"
     REMOTE_PATH = "org/apiguardian/apiguardian-api/{version}/apiguardian-api-{version}.jar"
 
-    def __init__(self, tool_path=""):
+    def __init__(self, http_client, tool_path=""):
         tool_file = "apiguardian-api-{version}.jar"
-        super(ApiGuardian, self).__init__("ApiGuardian", tool_path, tool_file)
+        super(ApiGuardian, self).__init__("ApiGuardian", tool_path, tool_file, http_client)
 
 
 class OpenTest4j(JarTool):
     VERSION = "1.1.0"
     REMOTE_PATH = "org/opentest4j/opentest4j/{version}/opentest4j-{version}.jar"
 
-    def __init__(self, tool_path=""):
+    def __init__(self, http_client, tool_path=""):
         tool_file = "opentest4j-{version}.jar"
-        super(OpenTest4j, self).__init__("OpenTest4j", tool_path, tool_file)
+        super(OpenTest4j, self).__init__("OpenTest4j", tool_path, tool_file, http_client)
 
 
 class JUnit(JarTool):
     VERSION = "4.12"
     REMOTE_PATH = "junit/junit/{version}/junit-{version}.jar"
 
-    def __init__(self, tool_path=""):
+    def __init__(self, http_client, tool_path=""):
         tool_file = "junit-{version}.jar"
-        super(JUnit, self).__init__("JUnit", tool_path, tool_file)
+        super(JUnit, self).__init__("JUnit", tool_path, tool_file, http_client)
 
 
 class TaurusJavaHelper(JarTool):
     VERSION = "1.4"
     REMOTE_PATH = "com/blazemeter/taurus-java-helpers/{version}/taurus-java-helpers-{version}.jar"
 
-    def __init__(self, tool_path=""):
+    def __init__(self, http_client, tool_path=""):
         tool_file = "taurus-java-helpers-{version}.jar"
-        super(TaurusJavaHelper, self).__init__("TaurusJavaHelper", tool_path, tool_file)
+        super(TaurusJavaHelper, self).__init__("TaurusJavaHelper", tool_path, tool_file, http_client)

--- a/bzt/modules/selenium.py
+++ b/bzt/modules/selenium.py
@@ -156,8 +156,9 @@ class SeleniumExecutor(AbstractSeleniumExecutor, WidgetProvider, FileLister, Hav
         geckodriver_path = self._get_geckodriver_path()
         geckodriver_link = self._get_geckodriver_link()
 
-        self.webdrivers = [ChromeDriver(chromedriver_path, self.log, chromedriver_link),
-                           GeckoDriver(geckodriver_path, self.log, geckodriver_link)]
+        http_client = self.engine.get_http_client()
+        self.webdrivers = [ChromeDriver(chromedriver_path, self.log, chromedriver_link, http_client),
+                           GeckoDriver(geckodriver_path, self.log, geckodriver_link, http_client)]
 
         for tool in self.webdrivers:
             if not tool.check_if_installed():
@@ -331,8 +332,8 @@ class SeleniumWidget(Pile, PrioritizedWidget):
 
 
 class ChromeDriver(RequiredTool):
-    def __init__(self, tool_path, parent_logger, download_link):
-        super(ChromeDriver, self).__init__("ChromeDriver", tool_path, download_link)
+    def __init__(self, tool_path, parent_logger, download_link, http_client):
+        super(ChromeDriver, self).__init__("ChromeDriver", tool_path, download_link, http_client)
         self.log = parent_logger.getChild(self.__class__.__name__)
 
     def check_if_installed(self):
@@ -362,8 +363,8 @@ class ChromeDriver(RequiredTool):
 
 
 class GeckoDriver(RequiredTool):
-    def __init__(self, tool_path, parent_logger, download_link):
-        super(GeckoDriver, self).__init__("GeckoDriver", tool_path, download_link)
+    def __init__(self, tool_path, parent_logger, download_link, http_client):
+        super(GeckoDriver, self).__init__("GeckoDriver", tool_path, download_link, http_client)
         self.log = parent_logger.getChild(self.__class__.__name__)
 
     def check_if_installed(self):


### PR DESCRIPTION
WIP: need to check Taurus-dependent projects for whether we can safely make `http_client` mandatory argument for each required tool.