### PR TITLE
fix shellexec task hanging

### DIFF
--- a/bzt/modules/shellexec.py
+++ b/bzt/modules/shellexec.py
@@ -167,7 +167,7 @@ class Task(object):
             self.check(sync=True)
 
     def check(self, sync=False):
-        if self.ret_code is not None:   # finished task
+        if not self.process or self.ret_code is not None:   # finished task
             return
 
         self.ret_code = self.process.poll()
@@ -178,7 +178,6 @@ class Task(object):
 
         stdout, stderr = self.process.communicate()
         self.ret_code = self.process.poll()
-        self.process = None
 
         if stdout and (self.out == subprocess.PIPE):
             self.log.debug("Output for %s:\n%s", self, stdout)
@@ -204,7 +203,8 @@ class Task(object):
         if self.process and self.ret_code is None:
             self.log.info("Background task was not completed, shutting it down: %s", self)
             shutdown_process(self.process, self.log)
-            self.process = None
+
+        self.process = None
 
     def __repr__(self):
         return self.command

--- a/bzt/modules/shellexec.py
+++ b/bzt/modules/shellexec.py
@@ -190,7 +190,7 @@ class Task(object):
         if not self.ignore_failure and self.ret_code != 0:
             if self.out != subprocess.PIPE:
                 self.log.warning("Output for %s:\n%s", self, stdout)
-            raise CalledProcessError(self.ret_code, self.command)
+            raise CalledProcessError(self.ret_code, self)
         return True
 
     def shutdown(self):

--- a/site/dat/docs/changes/fix-shellexec.change
+++ b/site/dat/docs/changes/fix-shellexec.change
@@ -1,0 +1,4 @@
+fix hanging of shellexec due to wait()
+
+In case of filling buffer (PIPE) OS blocks writing process (task). If shellexec just wait for finish of task (wait())
+it stops taurus at all. communicate() handle that more carefully as it read buffers before internal wait() call.

--- a/tests/modules/test_shellexec.py
+++ b/tests/modules/test_shellexec.py
@@ -1,5 +1,6 @@
 import os
 import time
+import tempfile
 from subprocess import CalledProcessError
 
 from bzt.engine import Service
@@ -27,6 +28,27 @@ class TestBlockingTasks(TaskTestCase):
             task = "dir .. && cd .."
         else:
             task = "ls .. && cd .."
+        self.obj.parameters.merge({"prepare": [task]})
+        self.obj.prepare()
+        self.obj.startup()
+        self.obj.shutdown()
+
+    def test_long_buf(self):
+        """ subprocess (tast) became blocked and blocks parent (shellexec)
+        if exchange buffer (PIPE) is full because of wait() """
+        fd, file_name = tempfile.mkstemp()
+        os.close(fd)
+        if is_windows():
+            task = "type "
+            buf_len = 2 ** 10 * 4    # 4K
+        else:
+            task = "tail "
+            buf_len = 2 ** 10 * 64  # 64K
+        task += file_name
+        buf = '*' * (buf_len + 1)
+        with open(file_name, "w+") as _file:
+            _file.write(buf)
+
         self.obj.parameters.merge({"prepare": [task]})
         self.obj.prepare()
         self.obj.startup()

--- a/tests/modules/test_shellexec.py
+++ b/tests/modules/test_shellexec.py
@@ -49,7 +49,6 @@ class TestBlockingTasks(TaskTestCase):
         with open(file_name, "w+") as _file:
             _file.write(buf)
 
-        self.sniff_log(self.obj.log)
         self.obj.parameters.merge({"prepare": [task]})
         self.obj.prepare()
         self.obj.startup()

--- a/tests/modules/test_shellexec.py
+++ b/tests/modules/test_shellexec.py
@@ -49,10 +49,12 @@ class TestBlockingTasks(TaskTestCase):
         with open(file_name, "w+") as _file:
             _file.write(buf)
 
+        self.sniff_log(self.obj.log)
         self.obj.parameters.merge({"prepare": [task]})
         self.obj.prepare()
         self.obj.startup()
         self.obj.shutdown()
+        self.assertIn(buf, self.log_recorder.debug_buff.getvalue())
 
     def test_nonbackground_prepare(self):
         task = {"command": "echo hello", "background": True}


### PR DESCRIPTION
In case of filling buffer (PIPE) OS blocks writing process (task).
If shellexec just wait for finish of task (wait()), it stops taurus at all.
communicate() handle that more carefully as it read buffers out before internal wait() call.