### PR TITLE
fix body-file handling

### DIFF
--- a/bzt/jmx/http.py
+++ b/bzt/jmx/http.py
@@ -66,7 +66,10 @@ class HTTPProtocolHandler(ProtocolHandler):
 
         files = request.upload_files
         body_file = request.config.get("body-file")
-        if not body and not files and body_file and request.method in ("PUT", "POST"):
+        has_file_for_body = not (body or files) and body_file
+
+        # method can be put, post, or even variable
+        if has_file_for_body and request.method != "GET":
             files = [{"path": body_file}]
 
         http = JMX._get_http_request(request.url, request.label, request.method, timeout, body,

--- a/tests/modules/jmeter/test_JMeterExecutor.py
+++ b/tests/modules/jmeter/test_JMeterExecutor.py
@@ -216,12 +216,12 @@ class TestJMeterExecutor(BZTestCase):
                     "requests": [
                         {
                             'url': 'http://zero.com',
-                            "method": "get",    # ignore because of method is GET
-                            'body-file': body_file0
+                            "method": "get",
+                            'body-file': body_file0     # ignore because method is GET
                         }, {
                             'url': 'http://first.com',
-                            "method": "${put_method}",  # handle as body-file
-                            'body-file': body_file1
+                            "method": "${put_method}",
+                            'body-file': body_file1     # handle as body-file
                         }, {
                             'url': 'http://second.com',
                             'method': 'post',


### PR DESCRIPTION
We look at body-file only if it's POST or PUT. It's generally correct, but
jmeter variable in method field causes ingnoring of body-file
Soution: change condition to skip body-file only if method is GET