### PR TITLE
Add `store-cache` flag support to Gatling

### DIFF
--- a/bzt/modules/gatling.py
+++ b/bzt/modules/gatling.py
@@ -56,6 +56,9 @@ class GatlingScriptBuilder(object):
 
         http_str = 'http.baseURL("%(addr)s")\n' % {'addr': self.fixed_addr(default_address)}
 
+        if not self.scenario.get('store-cache', True):
+            http_str += self.indent('.disableCaching\n', level=2)
+
         scenario_headers = self.scenario.get_headers()
         for key in scenario_headers:
             http_str += self.indent('.header("%(key)s", "%(val)s")\n' % {'key': key, 'val': scenario_headers[key]},

--- a/site/dat/docs/Gatling.md
+++ b/site/dat/docs/Gatling.md
@@ -90,7 +90,7 @@ If your scenario don't contains `script` parameter and contains at least one ele
 scala script for test. This script will be placed in `[artifact-dir](ConfigSyntax/#Top-Level-Settings)`:
 you can modify it and use with Gatling later.
 
-Following features are supported: request generation, `default-address`, `follow-redirect`, `headers`, `think-time`
+Following features are supported: request generation, `default-address`, `follow-redirect`, `headers`, `store-cache`, `think-time`
 on scenario and request levels, `body` of request and params that described in
 `[Load Configuration](#Load-Configuration)`.
 Some asserts can be added to request. Assert describes templates and area for search (`contains` and `subject`
@@ -113,6 +113,7 @@ scenarios:
     - path: buyouts.csv  # path to CSV file
       delimiter: ','  # optional, set to comma by default
       loop: true  # loop over data source file, true by default
+    store-cache: true  # cache HTTP responses, true by default
     default-address: blazedemo.com
     headers:
       HEADER_1: VALUE_1

--- a/site/dat/docs/changes/add-store-http-cache-flag-to-gatling.change
+++ b/site/dat/docs/changes/add-store-http-cache-flag-to-gatling.change
@@ -1,0 +1,1 @@
+Support `store-cache` flag in Gatling

--- a/tests/modules/test_Gatling.py
+++ b/tests/modules/test_Gatling.py
@@ -285,6 +285,20 @@ class TestGatlingExecutor(BZTestCase):
         })
         self.assertRaises(TaurusConfigError, self.obj.prepare)
 
+    def test_requests_6(self):
+        self.obj.execution.merge({
+            "iterations": 5,
+            "scenario": {
+                "store-cache": False,
+                "default-address": "example.com",
+                "requests": ['/'],
+            }
+        })
+        self.obj.prepare()
+        scala_file = self.obj.engine.artifacts_dir + '/' + self.obj.get_scenario().get('simulation') + '.scala'
+        self.assertFilesEqual(RESOURCES_DIR + "gatling/generated6.scala", scala_file,
+                              self.obj.get_scenario().get('simulation'), "SIMNAME")
+
     def test_fail_on_zero_results(self):
         self.obj.execution.merge({"scenario": {"script": RESOURCES_DIR + "gatling/bs/BasicSimulation.scala"}})
         self.obj.prepare()

--- a/tests/resources/gatling/generated6.scala
+++ b/tests/resources/gatling/generated6.scala
@@ -1,0 +1,47 @@
+// generated automatically by Taurus
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+import scala.concurrent.duration._
+
+class SIMNAME extends Simulation {
+  val concurrency = Integer.getInteger("concurrency", 1).toInt
+  val rampUpTime = Integer.getInteger("ramp-up", 0).toInt
+  val holdForTime = Integer.getInteger("hold-for", 0).toInt
+  val throughput = Integer.getInteger("throughput")
+  val iterationLimit = Integer.getInteger("iterations")
+
+  val durationLimit = rampUpTime + holdForTime
+
+
+  var httpConf = http.baseURL("http://example.com")
+    .disableCaching
+
+  var testScenario = scenario("Taurus Scenario")
+
+  var execution = exec(
+    http("/").get("/")
+  )
+
+  if (iterationLimit == null)
+    testScenario = testScenario.forever{execution}
+  else
+    testScenario = testScenario.repeat(iterationLimit.toInt){execution}
+
+  val virtualUsers =
+    if (rampUpTime > 0)
+      rampUsers(concurrency) over (rampUpTime seconds)
+    else
+      atOnceUsers(concurrency)
+
+  var testSetup = setUp(testScenario.inject(virtualUsers).protocols(httpConf))
+
+  if (throughput != null)
+    testSetup = testSetup.throttle(
+      reachRps(throughput) in (rampUpTime),
+      holdFor(Int.MaxValue)
+    )
+
+  if (durationLimit > 0)
+    testSetup.maxDuration(durationLimit)
+}


### PR DESCRIPTION
This is to ensure that user has a possibility to disable Gatling's pretty aggressive HTTP caching.