### PR TITLE
Support strings for Target Concurrency in ConcurrencyThreadGroup

### DIFF
--- a/bzt/jmx/threadgroups.py
+++ b/bzt/jmx/threadgroups.py
@@ -158,6 +158,10 @@ class ConcurrencyThreadGroup(AbstractDynamicThreadGroup):
         concurrency_prop = self.element.find(self.CONCURRENCY_SEL)
         concurrency_prop.text = str(concurrency)
 
+    def get_concurrency(self):
+        return super(AbstractDynamicThreadGroup, self).get_concurrency(True)
+
+
 
 class ArrivalsThreadGroup(AbstractDynamicThreadGroup):
     XPATH = r'jmeterTestPlan>hashTree>hashTree>com\.blazemeter\.jmeter\.threads\.arrivals\.ArrivalsThreadGroup'


### PR DESCRIPTION
For ConcurrencyThreadGroup, when using ${__tstFeedback(timer,...)} for the target concurrency, a warning is generated and the default value of 1 is used:

> WARNING: Parsing concurrency '${__tstFeedback(...}' in group 'ConcurrencyThreadGroup' failed, choose 1

This change skips int conversion to allow string values.