### PR TITLE
Support Python 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ astunparse>=1.6.0
 colorama; sys_platform == 'win32'
 colorlog
 cssselect
-fuzzyset
+-e git+https://github.com/dmand/fuzzyset.git@regenerate-cython-for-python-3.7#egg=fuzzyset  # TODO: replace with `fuzzyset` once it supports py37
 hdrpy>=0.3.3
 ipaddress; python_version < '3.0'
 lxml>=3.8.0,!=4.2.0


### PR DESCRIPTION
By switching dependency to a fork of fuzzyset.

It is questionable whether we should merge this right now. But in case someone asks — this is the solution to the question "does Taurus support Python 3.7?".