### PR TITLE
NUnitRunner now writes test context properties to NUnitExecutor.idjso…

### DIFF
--- a/dotnet/NUnitRunner/NUnitRunner/Program.cs
+++ b/dotnet/NUnitRunner/NUnitRunner/Program.cs
@@ -106,6 +106,17 @@ namespace NUnitRunner
                         item.TestSuite = node.Attributes["classname"].Value;
                         item.ErrorMessage = "";
                         item.ErrorTrace = "";
+
+                        //Get Properties
+                        Dictionary<object, object> dictionary = new Dictionary<object, object>();
+
+                        foreach (XmlNode childNode in node.FirstChild)
+                        {
+                            dictionary.Add(childNode.Attributes["name"].Value, childNode.Attributes["value"]);
+                        }
+
+                        item.Extras = dictionary;
+
                         if (node.Attributes["result"].Value == "Passed")
                         {
                             item.Status = "PASSED";

--- a/dotnet/NUnitRunner/NUnitRunner/Program.cs
+++ b/dotnet/NUnitRunner/NUnitRunner/Program.cs
@@ -114,7 +114,7 @@ namespace NUnitRunner
                         {
                             foreach (XmlNode childNode in node.FirstChild)
                             {
-                                dictionary.Add(childNode.Attributes["name"].Value, childNode.Attributes["value"]);
+                                dictionary.Add(childNode.Attributes["name"].Value, childNode.Attributes["value"].Value);
                             }
                         }
 

--- a/dotnet/NUnitRunner/NUnitRunner/Program.cs
+++ b/dotnet/NUnitRunner/NUnitRunner/Program.cs
@@ -110,9 +110,12 @@ namespace NUnitRunner
                         //Get Properties
                         Dictionary<object, object> dictionary = new Dictionary<object, object>();
 
-                        foreach (XmlNode childNode in node.FirstChild)
+                        if (node.HasChildNodes)
                         {
-                            dictionary.Add(childNode.Attributes["name"].Value, childNode.Attributes["value"]);
+                            foreach (XmlNode childNode in node.FirstChild)
+                            {
+                                dictionary.Add(childNode.Attributes["name"].Value, childNode.Attributes["value"]);
+                            }
                         }
 
                         item.Extras = dictionary;

--- a/dotnet/NUnitRunner/NUnitRunner/Program.cs
+++ b/dotnet/NUnitRunner/NUnitRunner/Program.cs
@@ -108,14 +108,21 @@ namespace NUnitRunner
                         item.ErrorTrace = "";
 
                         //Get Properties
+                        XmlNodeList propertiesNodeList = node.SelectNodes("properties");
+
                         Dictionary<object, object> dictionary = new Dictionary<object, object>();
 
-                        if (node.HasChildNodes)
+                        if (propertiesNodeList.Count == 1)
                         {
-                            foreach (XmlNode childNode in node.FirstChild)
+                        
+                            Dictionary<string, string> transactionDictionary = new Dictionary<string, string>();
+
+                            foreach (XmlNode childNode in propertiesNodeList[0])
                             {
-                                dictionary.Add(childNode.Attributes["name"].Value, childNode.Attributes["value"].Value);
+                                transactionDictionary.Add(childNode.Attributes["name"].Value, childNode.Attributes["value"].Value);
                             }
+
+                            dictionary.Add("test_context", transactionDictionary);
                         }
 
                         item.Extras = dictionary;

--- a/site/dat/docs/changes/nunit-runner-write-test-context-properties.change
+++ b/site/dat/docs/changes/nunit-runner-write-test-context-properties.change
@@ -1,1 +1,2 @@
 - Expanded NUnitRunner to write test context properties to NUnitExecutor.Idjson for parsing later on.  Any objects in the test context will be listed in under extras.
+- Changed test context output to be within test_context within extras in Id.json report.

--- a/site/dat/docs/changes/nunit-runner-write-test-context-properties.change
+++ b/site/dat/docs/changes/nunit-runner-write-test-context-properties.change
@@ -1,0 +1,1 @@
+- Expanded NUnitRunner to write test context properties to NUnitExecutor.Idjson for parsing later on.  Any objects in the test context will be listed in under extras.

--- a/site/dat/docs/changes/nunit-runner-write-test-context-properties.change
+++ b/site/dat/docs/changes/nunit-runner-write-test-context-properties.change
@@ -1,2 +1,2 @@
-- Expanded NUnitRunner to write test context properties to NUnitExecutor.Idjson for parsing later on.  Any objects in the test context will be listed in under extras.
-- Changed test context output to be within test_context within extras in Id.json report.
+- Expanded NUnitRunner to write test context properties to NUnitExecutor.ldjson for parsing later on.  Any objects in the test context will be listed in under `extras`.
+- Changed test context output to be within `test_context` within `extras` in ldjson report.


### PR DESCRIPTION
…n extras node.  Enables adding transaction timers to reports by adding to the test context during the test case iteration.  This can later be parsed and monitored.