### PR TITLE
Support keystore config for JMeter executor in yaml

### DIFF
--- a/bzt/engine.py
+++ b/bzt/engine.py
@@ -1294,6 +1294,7 @@ class Scenario(UserDict, object):
     FIELD_HEADERS = "headers"
     FIELD_BODY = "body"
     FIELD_DATA_SOURCES = 'data-sources'
+    FIELD_KEYSTORE_CONFIG = 'keystore-config'
 
     def __init__(self, engine, scenario=None):
         super(Scenario, self).__init__()
@@ -1353,6 +1354,9 @@ class Scenario(UserDict, object):
                 raise TaurusConfigError("Data source must have valid file path: '%s'" % source)
 
             yield source
+
+    def get_keystore_config(self):
+        return self.get(self.FIELD_KEYSTORE_CONFIG)
 
     def get_requests(self, parser=RequestParser, require_url=True):
         """

--- a/bzt/engine.py
+++ b/bzt/engine.py
@@ -1294,7 +1294,6 @@ class Scenario(UserDict, object):
     FIELD_HEADERS = "headers"
     FIELD_BODY = "body"
     FIELD_DATA_SOURCES = 'data-sources'
-    FIELD_KEYSTORE_CONFIG = 'keystore-config'
 
     def __init__(self, engine, scenario=None):
         super(Scenario, self).__init__()
@@ -1354,9 +1353,6 @@ class Scenario(UserDict, object):
                 raise TaurusConfigError("Data source must have valid file path: '%s'" % source)
 
             yield source
-
-    def get_keystore_config(self):
-        return self.get(self.FIELD_KEYSTORE_CONFIG)
 
     def get_requests(self, parser=RequestParser, require_url=True):
         """

--- a/bzt/jmx/base.py
+++ b/bzt/jmx/base.py
@@ -406,6 +406,19 @@ class JMX(object):
         return elements
 
     @staticmethod
+    def get_keystore_config_elements(variable_name, start_index, end_index, preload):
+        elements = []
+        if variable_name:
+            elements = etree.Element("KeystoreConfig", guiclass="TestBeanGUI", testclass="KeystoreConfig",
+                                     testname="Taurus-Keystore-Configuration")
+            elements.append(JMX._string_prop("clientCertAliasVarName", variable_name))
+            elements.append(JMX._string_prop("startIndex", start_index))
+            elements.append(JMX._string_prop("endIndex", end_index))
+            elements.append(JMX._string_prop("preload", preload))
+
+        return elements
+
+    @staticmethod
     def __add_body_from_string(args, body, proxy):
         proxy.append(JMX._bool_prop("HTTPSampler.postBodyRaw", True))
         coll_prop = JMX._collection_prop("Arguments.arguments")

--- a/bzt/jmx/tools.py
+++ b/bzt/jmx/tools.py
@@ -424,6 +424,7 @@ class JMeterScenarioBuilder(JMX):
         for _, protocol in iteritems(self.protocol_handlers):
             elements.extend(protocol.get_toplevel_elements(scenario))
         elements.extend(self.__gen_authorization(scenario))
+        elements.extend(self.__gen_keystore_config(scenario))
         elements.extend(self.__gen_data_sources(scenario))
         elements.extend(self.__gen_requests(scenario))
         return elements
@@ -674,3 +675,19 @@ class JMeterScenarioBuilder(JMX):
             elements.append(config)
             elements.append(etree.Element("hashTree"))
         return elements
+
+    @staticmethod
+    def __gen_keystore_config(scenario):
+        elements = []
+        keystore_config = scenario.get_keystore_config()
+        if keystore_config:
+            variable_name = keystore_config["variable-name"]
+            start_index = keystore_config["start-index"]
+            end_index = keystore_config["end-index"]
+            preload = keystore_config["preload"]
+
+            config = JMX.get_keystore_config_elements(variable_name, start_index, end_index, preload)
+            elements.append(config)
+            elements.append(etree.Element("hashTree"))
+        return elements
+

--- a/bzt/jmx/tools.py
+++ b/bzt/jmx/tools.py
@@ -241,6 +241,7 @@ class JMeterScenarioBuilder(JMX):
             cls_obj = load_class(cls_name)
             instance = cls_obj(self.system_props)
             self.protocol_handlers[protocol] = instance
+        self.FIELD_KEYSTORE_CONFIG = 'keystore-config'
 
     @staticmethod
     def _get_timer(req):
@@ -676,10 +677,9 @@ class JMeterScenarioBuilder(JMX):
             elements.append(etree.Element("hashTree"))
         return elements
 
-    @staticmethod
-    def __gen_keystore_config(scenario):
+    def __gen_keystore_config(self, scenario):
         elements = []
-        keystore_config = scenario.get_keystore_config()
+        keystore_config = scenario.get(self.FIELD_KEYSTORE_CONFIG)
         if keystore_config:
             variable_name = keystore_config["variable-name"]
             start_index = keystore_config["start-index"]

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -19,6 +19,7 @@
 - fix 'None' iterations written into JMeter CTG
 - remember rolling concurrency to avoid fuzziness in multi-executor case
 - use HTTPS to check for version upgrade needs
+- support keystore configuration for jmeter executor in yaml
 
 
 ## 1.13.3<sup>24 feb 2019</sup>

--- a/site/dat/docs/changes/feat-jmeter-keystore-support-in-yaml.change
+++ b/site/dat/docs/changes/feat-jmeter-keystore-support-in-yaml.change
@@ -1,0 +1,1 @@
+- Add new feature where JMeter keystore configuration will be suppported by yaml syntax. This allows https requests authentication based on client certificates.

--- a/tests/modules/jmeter/test_JMeterExecutor.py
+++ b/tests/modules/jmeter/test_JMeterExecutor.py
@@ -2795,3 +2795,33 @@ class TestJMeterExecutor(ExecutorTestCase):
         jmeter_home = self.obj.env.get("JMETER_HOME")
         self.assertEqual(jmeter_home, get_full_path(self.obj.settings.get("path"), step_up=2))
         self.assertEqual(jmeter_home, get_full_path(RESOURCES_DIR))
+
+    def test_keystore_config(self):
+        self.configure({
+            "execution": {
+                "scenario": {
+                    "requests": [{
+                        "url": "http://example.com/"
+                    }],
+                    "keystore-config": {
+                        "variable-name": "certalias",
+                        "start-index": 0,
+                        "end-index": 99,
+                        "preload": 'true'
+                    }
+                }
+            }
+        })
+        self.obj.prepare()
+        xml_tree = etree.fromstring(open(self.obj.original_jmx, "rb").read())
+        keystore_config = xml_tree.find(".//KeystoreConfig/")
+        self.assertIsNotNone(keystore_config)
+        keystore_config_clientcert_alias_varname = xml_tree.find(
+            ".//KeystoreConfig/stringProp[@name='clientCertAliasVarName']")
+        self.assertEqual(keystore_config_clientcert_alias_varname.text, 'certalias')
+        keystore_config_start_index = xml_tree.find(".//KeystoreConfig/stringProp[@name='startIndex']")
+        self.assertEqual(keystore_config_start_index.text, '0')
+        keystore_config_end_index = xml_tree.find(".//KeystoreConfig/stringProp[@name='endIndex']")
+        self.assertEqual(keystore_config_end_index.text, '99')
+        keystore_config_preload = xml_tree.find(".//KeystoreConfig/stringProp[@name='preload']")
+        self.assertEqual(keystore_config_preload.text, 'true')


### PR DESCRIPTION
We use client certificate based authentication in our application. Though JMeter supports such authentication, taurus does not in its yaml syntax.

This feature was requested by at least one user in recent past in the project's support forum (Link [here](https://groups.google.com/forum/#!searchin/codename-taurus/client$20certificate%7Csort:date/codename-taurus/oM0NmZVfghw/ciMlM5L8BQAJ) ). And it seems important enough for the community. 