### PR TITLE
russian labels in AsciiTable

### DIFF
--- a/bzt/modules/reporting.py
+++ b/bzt/modules/reporting.py
@@ -194,7 +194,7 @@ class FinalStatus(Reporter, AggregatorListener, FunctionalAggregatorListener):
                     self.log.info(report_template, failed_samples_count, sample_label)
 
     def __console_safe_encode(self, text):
-        return text.encode(locale.getpreferredencoding(), errors='replace').decode('unicode_escape')
+        return text.encode(locale.getpreferredencoding(), errors='replace').decode('utf-8')
 
     def __get_sample_element(self, sample, label_name):
         failed_samples_count = sample['fail']


### PR DESCRIPTION
Error trace when using russian symbols in the jmeter components is as follows:

```
13:14:46 WARNING: Please wait for graceful shutdown...
13:14:46 INFO: Shutting down...
13:14:46 INFO: Post-processing...
13:14:46 INFO: Test duration: 1:30:16
13:14:46 INFO: Samples count: 51666, 0.01% failures
13:14:46 INFO: Average times: total 0.934, latency 0.007, connect 0.000
13:14:46 INFO: Percentiles:
+---------------+---------------+
| Percentile, % | Resp. Time, s |
+---------------+---------------+
|           0.0 |           0.0 |
|          50.0 |         0.383 |
|          90.0 |         1.971 |
|          95.0 |         3.328 |
|          99.0 |          7.48 |
|          99.9 |          14.2 |
|         100.0 |        79.424 |
+---------------+---------------+
13:14:46 ERROR: IndexError: list index out of range
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/bzt/cli.py", line 265, in perform
    self.engine.post_process()
  File "/usr/lib/python2.7/site-packages/bzt/engine.py", line 344, in post_process
    reraise(exc_info, exc_value)
  File "/usr/lib/python2.7/site-packages/bzt/engine.py", line 330, in post_process
    module.post_process()
  File "/usr/lib/python2.7/site-packages/bzt/modules/reporting.py", line 108, in post_process
    self.__report_summary_labels(self.last_sec[DataPoint.CUMULATIVE])
  File "/usr/lib/python2.7/site-packages/bzt/modules/reporting.py", line 228, in __report_summary_labels
    self.log.info("Request label stats:\n%s", table.table)
  File "/usr/lib/python2.7/site-packages/terminaltables/base_table.py", line 217, in table
    return flatten(self.gen_table(*dimensions))
  File "/usr/lib/python2.7/site-packages/terminaltables/build.py", line 151, in flatten
    return '\n'.join(''.join(r) for r in table)
  File "/usr/lib/python2.7/site-packages/terminaltables/build.py", line 151, in <genexpr>
    return '\n'.join(''.join(r) for r in table)
  File "/usr/lib/python2.7/site-packages/terminaltables/build.py", line 38, in combine
    peek = next(line)
  File "/usr/lib/python2.7/site-packages/terminaltables/build.py", line 140, in <genexpr>
    yield combine((c[row_index] for c in row), left, center, right)
IndexError: list index out of range
13:14:46 INFO: Artifacts dir: /home/jenkins/agent/workspace/ClaimCRM/LT/JmeterTest/2019-04-12_11-43-55.897909
13:14:46 WARNING: Done performing with code: 1
Build step 'Run Performance Test' changed build result to FAILURE
Finished: FAILURE
```

Example: 
```
print('Тестовый кейс'.encode('utf-8').decode('unicode_escape'))
Ð¢ÐµÑÑÐ¾Ð²ÑÐ¹ ÐºÐµÐ¹Ñ
```