### PR TITLE
Added support for concurrency in NunitRunner

### DIFF
--- a/bzt/modules/csharp.py
+++ b/bzt/modules/csharp.py
@@ -61,7 +61,10 @@ class NUnitExecutor(SubprocessedExecutor, HavingInstallableTools):
             cmdline += ['--iterations', str(load.iterations)]
         if load.hold:
             cmdline += ['--duration', str(int(load.hold))]
-
+        if load.concurrency:
+            cmdline += ['--concurrency', str(int(load.concurrency))]
+        if load.ramp_up:
+            cmdline =+ ['--ramp_up', str(int(load.ramp_up))]
         if not is_windows():
             self.env.add_path({"MONO_PATH": self.runner_dir})
 

--- a/dotnet/NUnitRunner/NUnitRunner/Program.cs
+++ b/dotnet/NUnitRunner/NUnitRunner/Program.cs
@@ -302,16 +302,16 @@ namespace NUnitRunner
 
             for (int i = 0; i < opts.concurrency; i++)
             {
-                var handle = new EventWaitHandle(false, EventResetMode.ManualReset);
+                var workerHandle = new EventWaitHandle(false, EventResetMode.ManualReset);
 
-                var thread = new Thread(()=>
+                var workerThread = new Thread(()=>
                                         {
                                             RunTest(startTime);
-                                            handle.Set();
+                                            workerHandle.Set();
                                         });
-                thread.Start();
+                workerThread.Start();
 
-                waitHandles[i] = handle;
+                waitHandles[i] = workerHandle;
 
                 Thread.Sleep(userStepTime * 1000);
             }
@@ -334,9 +334,7 @@ namespace NUnitRunner
             {
                 Thread.Sleep(1000);
 
-                ReportItem item;
-
-                while (blockedCollection.TryTake(out item, 100))
+                while (blockedCollection.TryTake(out ReportItem item, 100))
                 {
                     listener.WriteReport(item);
                 }

--- a/dotnet/NUnitRunner/NUnitRunner/Program.cs
+++ b/dotnet/NUnitRunner/NUnitRunner/Program.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Threading;
@@ -217,24 +216,38 @@ namespace NUnitRunner
             optionSet.Parse(args);
 
 			if (opts.shouldShowHelp)
-				ShowHelp();
+            {
+                ShowHelp();
+            }
 
-			if (opts.targetAssembly == null)
-				throw new Exception("Target test suite wasn't provided. Is your file actually NUnit test DLL?");
+            if (opts.targetAssembly == null)
+            {
+                throw new Exception("Target test suite wasn't provided. Is your file actually NUnit test DLL?");
+            }
 
             if (opts.iterations == 0)
-				if (opts.durationLimit > 0)
+            {
+                if (opts.durationLimit > 0)
+                {
                     opts.iterations = int.MaxValue;
-				else
+                }
+                else
+                {
                     opts.iterations = 1;
+                }
+            }
 
             if (opts.concurrency == 0)
+            {
                 opts.concurrency = 1;
+            }
 
             if (opts.ramp_up == 0)
+            {
                 opts.ramp_up = 1;
+            }
 
-			Console.WriteLine("Iterations: {0}", opts.iterations);
+            Console.WriteLine("Iterations: {0}", opts.iterations);
             Console.WriteLine("Hold for: {0}", opts.durationLimit);
             Console.WriteLine("Current users: {0}", opts.concurrency);
             Console.WriteLine("Ramp period: {0}", opts.ramp_up);
@@ -265,7 +278,9 @@ namespace NUnitRunner
 
             int testCount = listener.runner.CountTestCases(TestFilter.Empty);
             if (testCount < 1)
+            {
                 throw new ArgumentException("Nothing to run, no tests were loaded");
+            }
 
             if (opts.ramp_up > 1 && opts.durationLimit > 0)
             {

--- a/dotnet/NUnitRunner/NUnitRunner/Program.cs
+++ b/dotnet/NUnitRunner/NUnitRunner/Program.cs
@@ -37,6 +37,7 @@ namespace NUnitRunner
         {
             public long StartTime;
             public double Duration;
+            public string ThreadName;
             public string TestCase;
             public string TestSuite;
             public string Status;
@@ -77,6 +78,7 @@ namespace NUnitRunner
 				var sample = new Dictionary<object, object>
                 {
                     { "start_time", item.StartTime },
+                    { "ThreadName", item.ThreadName },
                     { "duration", item.Duration },
                     { "test_case", item.TestCase },
 					{ "test_suite", item.TestSuite },
@@ -173,6 +175,8 @@ namespace NUnitRunner
                         {
                             Console.WriteLine(report);
                         }
+
+                        item.ThreadName = Thread.CurrentThread.Name;
 
                         blockedCollection.Add(item);
                     }
@@ -282,10 +286,10 @@ namespace NUnitRunner
                 throw new ArgumentException("Nothing to run, no tests were loaded");
             }
 
-            if (opts.ramp_up > 1 && opts.durationLimit > 0)
-            {
-                opts.durationLimit = opts.durationLimit + opts.ramp_up;
-            }
+            //if (opts.ramp_up > 1 && opts.durationLimit > 0)
+            //{
+            //    opts.durationLimit = opts.durationLimit + opts.ramp_up;
+            //}
 
             WaitHandle[] waitHandles = new WaitHandle[opts.concurrency];
 
@@ -296,6 +300,8 @@ namespace NUnitRunner
                                             {
                                                 WriteResults();
                                             });
+
+            writerThread.Name = "WriterThread";
             writerThread.Start();
 
             DateTime startTime = DateTime.Now;
@@ -309,6 +315,8 @@ namespace NUnitRunner
                                             RunTest(startTime);
                                             workerHandle.Set();
                                         });
+
+                workerThread.Name = $"Worker-{i}";
                 workerThread.Start();
 
                 waitHandles[i] = workerHandle;

--- a/dotnet/NUnitRunner/NUnitRunner/Program.cs
+++ b/dotnet/NUnitRunner/NUnitRunner/Program.cs
@@ -266,11 +266,6 @@ namespace NUnitRunner
             if (testCount < 1)
                 throw new ArgumentException("Nothing to run, no tests were loaded");
 
-            if (opts.iterations != int.MaxValue)
-            {
-                opts.iterations = opts.iterations / opts.concurrency;
-            }
-
             WaitHandle[] waitHandles = new WaitHandle[opts.concurrency];
 
             for (int i = 0; i < opts.concurrency; i++)

--- a/dotnet/NUnitRunner/NUnitRunner/Program.cs
+++ b/dotnet/NUnitRunner/NUnitRunner/Program.cs
@@ -332,7 +332,7 @@ namespace NUnitRunner
 
             while (testRunning)
             {
-                Thread.Sleep(1000);
+                Thread.Sleep(3000);
 
                 while (blockedCollection.TryTake(out ReportItem item, 100))
                 {

--- a/dotnet/NUnitRunner/NUnitRunner/Program.cs
+++ b/dotnet/NUnitRunner/NUnitRunner/Program.cs
@@ -280,11 +280,13 @@ namespace NUnitRunner
 
             for (int i = 0; i < opts.concurrency; i++)
             {
+                var reducedTime = userStepTime * i;
+
                 var handle = new EventWaitHandle(false, EventResetMode.ManualReset);
 
                 var thread = new Thread(()=>
                                         {
-                                            RunTest();
+                                            RunTest(reducedTime);
                                             handle.Set();
                                         });
                 thread.Start();
@@ -313,7 +315,7 @@ namespace NUnitRunner
             Environment.Exit(0);
 		}
 
-        static void RunTest()
+        static void RunTest(int reducedTime)
         {
             try
             {
@@ -324,8 +326,10 @@ namespace NUnitRunner
                 {
                     threadListener.runner.Run(threadListener, TestFilter.Empty);
                     TimeSpan offset = DateTime.Now - startTime;
-                    if (opts.durationLimit > 0 && offset.TotalSeconds > opts.durationLimit)
+                    if ((opts.durationLimit - reducedTime) > 0 && offset.TotalSeconds > (opts.durationLimit - reducedTime))
+                    {
                         break;
+                    }
                 }
 
                 threadListener.UpdateGlobalList();

--- a/dotnet/NUnitRunner/NUnitRunner/Program.cs
+++ b/dotnet/NUnitRunner/NUnitRunner/Program.cs
@@ -286,10 +286,10 @@ namespace NUnitRunner
                 throw new ArgumentException("Nothing to run, no tests were loaded");
             }
 
-            //if (opts.ramp_up > 1 && opts.durationLimit > 0)
-            //{
-            //    opts.durationLimit = opts.durationLimit + opts.ramp_up;
-            //}
+            if (opts.ramp_up > 1 && opts.durationLimit > 0)
+            {
+                opts.durationLimit = opts.durationLimit + opts.ramp_up;
+            }
 
             WaitHandle[] waitHandles = new WaitHandle[opts.concurrency];
 

--- a/site/dat/docs/changes/add-support-for-concurrency-nunit-executor.change
+++ b/site/dat/docs/changes/add-support-for-concurrency-nunit-executor.change
@@ -1,0 +1,1 @@
+- Added concurrency support to NunitRunner, allows -concurrency command line arguement to be passed.


### PR DESCRIPTION
As discussed here : https://groups.google.com/forum/#!topic/codename-taurus/uYwW5g-0yCc my changes to the NunitRunner are enclosed.

NUnitRunner now supports a -concurrency argument on its command line, this spins up a thread per user and executes the test.  If -iterations is passed then it will divide this by the number of concurrent users and spread the load across them.

I need support to update the python code to add the concurrency value from the taurus yml file to the NunitRunner command line.