### PR TITLE
Attach to quitting event of locust to ignore constraints for cleanup

### DIFF
--- a/site/dat/docs/changes/locust-handle-quitting-event-to-ignore-constraints.change
+++ b/site/dat/docs/changes/locust-handle-quitting-event-to-ignore-constraints.change
@@ -1,0 +1,1 @@
+handle quitting event from locust to ignore restrictions on teardown


### PR DESCRIPTION
As discussed in [the forum](https://groups.google.com/forum/#!topic/codename-taurus/_1Vxy4ReSOU), I need to execute a teardown within locust that calls the client. Currently, the teardown fails because Taurus prevents any calls to be made after the timeout (or the number of execution) has been reached.

This change allows the [quitting](https://docs.locust.io/en/stable/api.html#locust.events.quitting) event of Locust to be used for cleanup - on Taurus, it sets the stop_time, and from now on, will not prevent executions.

It's not ideal, because the quitting event attaches itself before the one from the TaskSet - and the `quitting` event triggers all the handlers in reverse. But from the locustfile, I can force my cleanup to be registered before the `quitting` handler of Taurus, and therefore bypass the restriction.

Let me know if you see a better way to do it.