### PR TITLE
Fix/empty jmx concurrency

### DIFF
--- a/bzt/jmx/tools.py
+++ b/bzt/jmx/tools.py
@@ -123,7 +123,9 @@ class LoadSettingsProcessor(object):
             concurrency_list = []
             for group in groups:
                 concurrency = group.get_concurrency(raw=raw)
-                concurrency_list.append(concurrency or 0)
+                if concurrency is None:
+                    concurrency = 1
+                concurrency_list.append(concurrency)
 
             if not raw:  # divide numeric concurrency
                 self._divide_concurrency(concurrency_list)

--- a/bzt/jmx/tools.py
+++ b/bzt/jmx/tools.py
@@ -122,7 +122,8 @@ class LoadSettingsProcessor(object):
 
             concurrency_list = []
             for group in groups:
-                concurrency_list.append(group.get_concurrency(raw=raw))
+                concurrency = group.get_concurrency(raw=raw)
+                concurrency_list.append(concurrency or 0)
 
             if not raw:  # divide numeric concurrency
                 self._divide_concurrency(concurrency_list)

--- a/site/dat/docs/changes/fix-empty-jmx-concurrency.change
+++ b/site/dat/docs/changes/fix-empty-jmx-concurrency.change
@@ -1,0 +1,1 @@
+handle empty (None) concurrency with care

--- a/tests/modules/jmeter/test_JMX.py
+++ b/tests/modules/jmeter/test_JMX.py
@@ -25,6 +25,11 @@ class TestLoadSettingsProcessor(BZTestCase):
                 groupset.append(group)
         return groupset
 
+    def test_empty_concuurency(self):
+        self.configure(load={"concurrency": 22}, jmx_file=RESOURCES_DIR + 'jmeter/jmx/empty_concurrency.jmx')
+        self.obj.modify(self.jmx)
+        self.assertFalse(self.get_groupset())     # disabled
+
     def test_keep_original(self):
         self.configure(jmx_file=RESOURCES_DIR + 'jmeter/jmx/threadgroups.jmx')
         self.assertEqual(LoadSettingsProcessor.TG, self.obj.tg)  # because no duration

--- a/tests/modules/jmeter/test_JMX.py
+++ b/tests/modules/jmeter/test_JMX.py
@@ -28,7 +28,7 @@ class TestLoadSettingsProcessor(BZTestCase):
     def test_empty_concuurency(self):
         self.configure(load={"concurrency": 22}, jmx_file=RESOURCES_DIR + 'jmeter/jmx/empty_concurrency.jmx')
         self.obj.modify(self.jmx)
-        self.assertFalse(self.get_groupset())     # disabled
+        self.assertEqual("22", self.get_groupset()[0].get_concurrency(raw=True))
 
     def test_keep_original(self):
         self.configure(jmx_file=RESOURCES_DIR + 'jmeter/jmx/threadgroups.jmx')

--- a/tests/resources/jmeter/jmx/empty_concurrency.jmx
+++ b/tests/resources/jmeter/jmx/empty_concurrency.jmx
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.1.1 r1855137">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="BZT Generated Test Plan" enabled="true">
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <stringProp name="TestPlan.comments"></stringProp>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+    </TestPlan>
+    <hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="AccountSummaryStandardView" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">3</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads"></stringProp>
+        <stringProp name="ThreadGroup.ramp_time">0</stringProp>
+        <stringProp name="ThreadGroup.start_time"></stringProp>
+        <stringProp name="ThreadGroup.end_time"></stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration">0</stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="http://blazedemo.com" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain">blazedemo.com</stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.protocol">http</stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path"></stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout">0</stringProp>
+          <stringProp name="HTTPSampler.response_timeout">0</stringProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <DurationAssertion guiclass="DurationAssertionGui" testclass="DurationAssertion" testname="Timeout Check" enabled="true">
+            <stringProp name="DurationAssertion.duration">0</stringProp>
+          </DurationAssertion>
+          <hashTree/>
+        </hashTree>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
