### PR TITLE
fix string props encoding for py2 on win

### DIFF
--- a/bzt/modules/gatling.py
+++ b/bzt/modules/gatling.py
@@ -402,9 +402,9 @@ class GatlingExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInstal
             prop = props[key]
             val_tpl = "%s"
 
-            # extend properties support (contained separators/quotes/etc.) on lin/mac
-            if not is_windows() and isinstance(prop, string_types):
-                val_tpl = "%r"
+            if isinstance(prop, string_types):
+                if not is_windows():    # extend properties support (contained separators/quotes/etc.) on lin/mac
+                    val_tpl = "%r"
                 if PY2:
                     prop = prop.encode("utf-8", 'ignore')  # to convert from unicode into str
 

--- a/site/dat/docs/changes/fix-gatling-props-encoding.change
+++ b/site/dat/docs/changes/fix-gatling-props-encoding.change
@@ -1,0 +1,1 @@
+string props must be encoded for py2 (even on win) 


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
