### PR TITLE
Fix downloading jmeter dist

### DIFF
--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -1121,9 +1121,9 @@ class HTTPClient(object):
     def download_file(self, url, filename, reporthook=None, data=None, timeout=None):
         headers = None
         try:
-            with self.session.get(url, stream=True, data=data, timeout=timeout) as conn:
-                self._save_file_from_connection(conn, filename, reporthook=reporthook)
-                headers = conn.headers
+            conn = self.session.get(url, stream=True, data=data, timeout=timeout)
+            self._save_file_from_connection(conn, filename, reporthook=reporthook)
+            headers = conn.headers
         except requests.exceptions.RequestException as exc:
             resp = exc.response
             self.log.debug("File download resulted in exception: %s", traceback.format_exc())


### PR DESCRIPTION
The current code doesn't work with my (python2) installation. I think this is because the requests library doesn't support self closing (`__exit__`) using `with`, nor does it need to be managed in this way.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
