### PR TITLE
Add script Jars and additional classpath to Gatling classpath for Gatling 3.x

### DIFF
--- a/bzt/modules/gatling.py
+++ b/bzt/modules/gatling.py
@@ -856,6 +856,9 @@ class Gatling(RequiredTool):
                         if line.startswith('set COMPILER_CLASSPATH='):
                             mod_success = True
                             line = line.rstrip() + ';%COMPILATION_CLASSPATH%\n'  # add from env
+                        elif line.startswith('set GATLING_CLASSPATH='):
+                            mod_success = True
+                            line = line.rstrip() + ';%JAVA_CLASSPATH%\n'  # add from env
                     else:
                         if line.startswith('COMPILER_CLASSPATH='):
                             mod_success = True

--- a/bzt/modules/gatling.py
+++ b/bzt/modules/gatling.py
@@ -860,6 +860,9 @@ class Gatling(RequiredTool):
                         if line.startswith('COMPILER_CLASSPATH='):
                             mod_success = True
                             line = line.rstrip()[:-1] + '${COMPILATION_CLASSPATH}"\n'  # add from env
+                        elif line.startswith('GATLING_CLASSPATH='):
+                            mod_success = True
+                            line = line.rstrip()[:-1] + '${JAVA_CLASSPATH}"\n'  # add from env
                         elif line.startswith('"$JAVA"'):
                             line = 'eval ' + line
                     modified_lines.append(line)

--- a/site/dat/docs/changes/gatling3-classpath-fix.change
+++ b/site/dat/docs/changes/gatling3-classpath-fix.change
@@ -1,0 +1,1 @@
+Fixed Gatling classpath in generated Gatling launcher (for complex Jar scripts and additional classpath)

--- a/tests/modules/test_Gatling.py
+++ b/tests/modules/test_Gatling.py
@@ -155,6 +155,8 @@ class TestGatlingExecutor(ExecutorTestCase):
                 self.assertTrue(line.startswith('eval'))
             if line.startswith('set COMPILER_CLASSPATH='):  # win
                 self.assertTrue(line.endswith(';%COMPILATION_CLASSPATH%\n'))
+            if line.startswith('set GATLING_CLASSPATH='):  # win
+                self.assertTrue(line.endswith(';%JAVA_CLASSPATH%\n'))
             if line.startswith('COMPILER_CLASSPATH'):  # linux
                 self.assertTrue(line.endswith('${COMPILATION_CLASSPATH}"\n'))
             if line.startswith('GATLING_CLASSPATH'):  # linux

--- a/tests/modules/test_Gatling.py
+++ b/tests/modules/test_Gatling.py
@@ -155,8 +155,10 @@ class TestGatlingExecutor(ExecutorTestCase):
                 self.assertTrue(line.startswith('eval'))
             if line.startswith('set COMPILER_CLASSPATH='):  # win
                 self.assertTrue(line.endswith(';%COMPILATION_CLASSPATH%\n'))
-            if line.startswith('COMPILER_CLASSPATH='):  # linux
-                self.assertTrue('${COMPILATION_CLASSPATH}"\n')
+            if line.startswith('COMPILER_CLASSPATH'):  # linux
+                self.assertTrue(line.endswith('${COMPILATION_CLASSPATH}"\n'))
+            if line.startswith('GATLING_CLASSPATH'):  # linux
+                self.assertTrue(line.endswith('${JAVA_CLASSPATH}"\n'))
 
     def test_install_Gatling(self):
         path = os.path.abspath(BUILD_DIR + "gatling-taurus/bin/gatling" + EXE_SUFFIX)

--- a/tests/resources/gatling/gatling3.bat
+++ b/tests/resources/gatling/gatling3.bat
@@ -1,6 +1,7 @@
 @echo off
 
 set COMPILER_CLASSPATH=""
+set GATLING_CLASSPATH=""
 
 if DEFINED GATLING_HOME (
   set GATLING_PATH=%GATLING_HOME%/gatling

--- a/tests/resources/gatling/gatling3.sh
+++ b/tests/resources/gatling/gatling3.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 COMPILER_CLASSPATH=
+GATLING_CLASSPATH=
 
 if [ -n "$GATLING_HOME" ]; then
   GATLING_DIR=${GATLING_HOME}/gatling


### PR DESCRIPTION
Since 3.0.0, Gatling does not use `JAVA_CLASSPATH` variable to define it's `GATLING_CLASSPATH` for execution: [gatling.sh](https://github.com/gatling/gatling/blob/master/gatling-bundle/src/universal/bin/gatling.sh) https://github.com/gatling/gatling/issues/3081
```
# Setup classpaths
COMPILER_CLASSPATH="$GATLING_HOME/lib/*:$GATLING_CONF:"
GATLING_CLASSPATH="$GATLING_HOME/lib/*:$GATLING_HOME/user-files:$GATLING_CONF:"
```

This PR adds `JAVA_CLASSPATH` back to converted `gatling-launcher.sh`
```
# Setup classpaths
COMPILER_CLASSPATH="$GATLING_HOME/lib/*:$GATLING_CONF:${COMPILATION_CLASSPATH}"
GATLING_CLASSPATH="$GATLING_HOME/lib/*:$GATLING_HOME/user-files:$GATLING_CONF:${JAVA_CLASSPATH}"
```
--- 

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside