### PR TITLE
WAP-14910 - BZM always sends email for external tests

### DIFF
--- a/bzt/modules/blazemeter.py
+++ b/bzt/modules/blazemeter.py
@@ -1174,7 +1174,7 @@ class CloudTaurusTest(BaseCloudTest):
         self._test.upload_files(taurus_config, rfiles)
         self._test.update_props({'configuration': {'executionType': self.cloud_mode}})
         self._test.update_props({
-            'configuration': {'plugins': {'reportEmail': {"enabled": self.send_report_email}}}
+            "shouldSendReportEmail": self.send_report_email
         })
 
     def launch_test(self):

--- a/tests/modules/test_cloudProvisioning.py
+++ b/tests/modules/test_cloudProvisioning.py
@@ -1705,8 +1705,7 @@ class TestCloudProvisioning(BZTestCase):
         self.assertEqual(reqs[13]['url'], 'https://a.blazemeter.com/api/v4/tests/1')
         self.assertEqual(reqs[13]['method'], 'PATCH')
         data = json.loads(reqs[13]['data'])
-        plugins = data['configuration']['plugins']
-        self.assertEqual(plugins["reportEmail"], {"enabled": False})
+        self.assertEqual(data["shouldSendReportEmail"], False)
 
     def test_send_report_email(self):
         self.configure(engine_cfg={EXEC: {"executor": "mock"}}, get={
@@ -1729,8 +1728,7 @@ class TestCloudProvisioning(BZTestCase):
         self.assertEqual(reqs[13]['url'], 'https://a.blazemeter.com/api/v4/tests/1')
         self.assertEqual(reqs[13]['method'], 'PATCH')
         data = json.loads(reqs[13]['data'])
-        plugins = data['configuration']['plugins']
-        self.assertEqual(plugins["reportEmail"], {"enabled": True})
+        self.assertEqual(data['shouldSendReportEmail'], True)
 
     def test_multi_account_choice(self):
         with open(RESOURCES_DIR + "json/blazemeter-api-accounts.json") as fhd:


### PR DESCRIPTION
BZA has changed the parameter used to determine rather we should send an email or not at the end of the test, but Taurus was not updated with the right field, this commit has the right field.