### PR TITLE
[WIP] Adapt for new webdriver 5

### DIFF
--- a/bzt/resources/wdio-taurus-plugin.js
+++ b/bzt/resources/wdio-taurus-plugin.js
@@ -1,7 +1,7 @@
 var util = require("util"),
     events = require("events"),
     fs = require("fs");
-var Launcher = require("webdriverio").Launcher;
+var Launcher = require("@wdio/cli").default;
 
 function epoch() {
     return (new Date()).getTime() / 1000.0;
@@ -154,7 +154,7 @@ function runWDIO() {
 
     var configFile = config.wdioConfig;
     var opts = {
-        reporters: [TaurusReporter],
+        // reporters: [TaurusReporter],
     };
 
     var wdio = new Launcher(configFile, opts);


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside

# Description:
Using webdriver I was getting the following error:
```
06:05:45 ERROR: Child Process Error: Test runner wdio.conf.js (WebdriverIOExecutor) has failed with retcode 1                                        
06:05:45 ERROR: WebdriverIOExecutor STDOUT:                                                                                                                                                                                                                                            
06:05:45 ERROR: WebdriverIOExecutor STDERR:                                                                                                          
/usr/lib/python2.7/site-packages/bzt/resources/wdio-taurus-plugin.js:162                                                                             
    var wdio = new Launcher(configFile, opts);                                                                                                       
               ^                                                                                                                                     
                                                                                                                                                     
TypeError: Launcher is not a constructor                                                                                                             
    at runWDIO (/usr/lib/python2.7/site-packages/bzt/resources/wdio-taurus-plugin.js:162:16)                                                         
    at Object.<anonymous> (/usr/lib/python2.7/site-packages/bzt/resources/wdio-taurus-plugin.js:194:5)                                               
    at Module._compile (internal/modules/cjs/loader.js:778:30)                                                                                       
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)                                                                         
    at Module.load (internal/modules/cjs/loader.js:653:32)                                                                                           
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)                                                                                         
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)                                                                                  
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)                                                                               
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:622:3)
```
The issue seams to be webdriver version, I made a patch and it worked, I have to make the reporter work, change the examples and write tests. I Did not gave the repo a thorough, I just made the patch and it work, Just found that It would be nice to at lest document the issue. 