### PR TITLE
Fix JMeter delay

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -355,7 +355,7 @@ class JMeterExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInstall
         """
         distr_multiplier = len(self.execution.get('distributed', [None]))  # 1 for regular, N of servers for distributed
 
-        max_attempts = self.settings.get("shutdown-wait", 5 * distr_multiplier)
+        max_attempts = self.settings.get("shutdown-wait", 5) * distr_multiplier
         if self._process_stopped(1):
             return
 

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -353,7 +353,9 @@ class JMeterExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInstall
         """
         If JMeter is still running - let's stop it.
         """
-        max_attempts = self.settings.get("shutdown-wait", 5)
+        distr_multiplier = len(self.execution.get('distributed', [None]))  # 1 for regular, N of servers for distributed
+
+        max_attempts = self.settings.get("shutdown-wait", 5 * distr_multiplier)
         if self._process_stopped(1):
             return
 

--- a/site/dat/docs/changes/fix-jmeter-shutdown-delay.change
+++ b/site/dat/docs/changes/fix-jmeter-shutdown-delay.change
@@ -1,0 +1,1 @@
+multiplied shutdown-delay for distributed test in jmeter


### PR DESCRIPTION
Multiplied shutdown-delay for distributed test in JMeter
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [x] Documentation update
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
