### PR TITLE
Fix/docs/jmeter mult thread groups

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -353,9 +353,7 @@ class JMeterExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInstall
         """
         If JMeter is still running - let's stop it.
         """
-        distr_multiplier = len(self.execution.get('distributed', [None]))  # 1 for regular, N of servers for distributed
-
-        max_attempts = self.settings.get("shutdown-wait", 5 * distr_multiplier)
+        max_attempts = self.settings.get("shutdown-wait", 5)
         if self._process_stopped(1):
             return
 

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -353,7 +353,9 @@ class JMeterExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInstall
         """
         If JMeter is still running - let's stop it.
         """
-        max_attempts = self.settings.get("shutdown-wait", 5)
+        distr_multiplier = len(self.execution.get('distributed', [None]))  # 1 for regular, N of servers for distributed
+
+        max_attempts = self.settings.get("shutdown-wait", 5 * distr_multiplier)
         if self._process_stopped(1):
             return
 

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -44,7 +44,10 @@ scenarios:
 
 or simply `bzt tests/jmx/dummy.jmx`
 
-TODO: explain how multi-thread group will accept concurrency with maintained proportion
+In case when existing JMX file have multiple thread groups with different concurrency values while yaml config has its 
+own concurrency, the main one in yaml will be divided in proportion to the concurrency values in thread groups. 
+For example, if there are concurrency values 1 and 2 in two thread groups and 30 in yaml, the main will be divided in 
+the ratio of 1:2, which means 10 to the first thread group and 20 to the second.
 
 ## JMeter Properties and Variables
 There are two places to specify JMeter properties: global at module-level and local at scenario-level. Scenario properties are merged into global properties and resulting set comes as input for JMeter, see corresponding `.properties` file in artifacts.

--- a/site/dat/docs/changes/fix-docs-jmeter-mult-thread-groups.change
+++ b/site/dat/docs/changes/fix-docs-jmeter-mult-thread-groups.change
@@ -1,0 +1,1 @@
+replace "to do" in docs with an explanation about how concurrency is divided to several thread groups


### PR DESCRIPTION
Remove that todo about concurrency and multiple thread groups

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [x] Documentation update
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
