### PR TITLE
Fixed unnecessary long wait time when multiple locators are used

### DIFF
--- a/bzt/modules/apiritif/generator.py
+++ b/bzt/modules/apiritif/generator.py
@@ -232,8 +232,7 @@ from selenium.webdriver.common.keys import Keys
                 gen_subscript(var_w_locator, 1)
             ])
 
-    @staticmethod
-    def _gen_get_locators(var_name, locators):
+    def _gen_get_locators(self, var_name, locators):
         args = []
         for loc in locators:
             locator_type = list(loc.keys())[0]
@@ -243,7 +242,7 @@ from selenium.webdriver.common.keys import Keys
         return ast.Assign(
             targets=[ast.Name(id=var_name, ctx=ast.Store())],
             value=ast_call(func="self.loc_mng.get_locator",
-                           args=[ast.List(elts=args)]))
+                           args=[ast.List(elts=args), ast.Str(self._get_scenario_timeout())]))
 
     def _gen_locator(self, tag, selector):
         return ast_call(
@@ -652,6 +651,9 @@ from selenium.webdriver.common.keys import Keys
 
         return browser
 
+    def _get_scenario_timeout(self):
+        return dehumanize_time(self.scenario.get("timeout", "30s"))
+
     def _gen_webdriver(self):
         self.log.debug("Generating setUp test method")
         browser = self._check_platform()
@@ -729,11 +731,10 @@ from selenium.webdriver.common.keys import Keys
                 value=ast_call(
                     func=ast_attr("webdriver.%s" % browser))))  # todo bring 'browser' to correct case
 
-        scenario_timeout = self.scenario.get("timeout", "30s")
         body.append(ast.Expr(
             ast_call(
                 func=ast_attr("self.driver.implicitly_wait"),
-                args=[ast.Num(dehumanize_time(scenario_timeout))])))
+                args=[ast.Num(self._get_scenario_timeout())])))
 
         mgr = "WindowManager"
         if mgr in self.selenium_extras:

--- a/bzt/modules/apiritif/generator.py
+++ b/bzt/modules/apiritif/generator.py
@@ -232,7 +232,8 @@ from selenium.webdriver.common.keys import Keys
                 gen_subscript(var_w_locator, 1)
             ])
 
-    def _gen_get_locators(self, var_name, locators):
+    @staticmethod
+    def _gen_get_locators(var_name, locators):
         args = []
         for loc in locators:
             locator_type = list(loc.keys())[0]
@@ -242,7 +243,7 @@ from selenium.webdriver.common.keys import Keys
         return ast.Assign(
             targets=[ast.Name(id=var_name, ctx=ast.Store())],
             value=ast_call(func="self.loc_mng.get_locator",
-                           args=[ast.List(elts=args), ast.Str(self._get_scenario_timeout())]))
+                           args=[ast.List(elts=args)]))
 
     def _gen_locator(self, tag, selector):
         return ast_call(
@@ -758,7 +759,7 @@ from selenium.webdriver.common.keys import Keys
             targets=[ast_attr("self.loc_mng")],
             value=ast_call(
                 func=ast.Name(id=mgr),
-                args=[ast_attr("self.driver")])))
+                args=[ast_attr("self.driver"), ast.Str(self._get_scenario_timeout())])))
 
         if self.window_size:  # FIXME: unused in fact ?
             body.append(ast.Expr(

--- a/bzt/resources/selenium_extras.py
+++ b/bzt/resources/selenium_extras.py
@@ -97,14 +97,14 @@ class LocatorsManager:
         'linktext': By.LINK_TEXT
     }
 
-    def __init__(self, driver):
+    def __init__(self, driver, timeout=30):
         self.driver = driver
+        self.timeout = timeout
 
-    def get_locator(self, locators, timeout):
+    def get_locator(self, locators):
         """
         :param locators: List of Dictionaries holding the locators, e.g. [{'id': 'elem_id'},
         {css: 'my_cls'}]
-        :param timeout: the current value of implicit wait, need to be restored back after execution
         :return: first valid locator from the passed List, if no locator is valid then returns the
         first one
         """
@@ -125,5 +125,5 @@ class LocatorsManager:
             locator = first_locator
 
         # restore the implicit wait value
-        self.driver.implicitly_wait(timeout)
+        self.driver.implicitly_wait(self.timeout)
         return locator

--- a/site/dat/docs/changes/fix-apiritif-multiple-locators-wait-time.change
+++ b/site/dat/docs/changes/fix-apiritif-multiple-locators-wait-time.change
@@ -1,0 +1,1 @@
+fix unnecessary long wait time when multiple locators are used

--- a/tests/modules/selenium/test_selenium_builder.py
+++ b/tests/modules/selenium/test_selenium_builder.py
@@ -691,9 +691,9 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
             content = fds.read()
 
         target_lines = [
-            "var_loc_keys=self.loc_mng.get_locator([{'name':'btn1',}])self.driver.find_element"
+            "var_loc_keys=self.loc_mng.get_locator([{'name':'btn1',}],30.0)self.driver.find_element"
             "(var_loc_keys[0],var_loc_keys[1]).click()",
-            "var_loc_keys=self.loc_mng.get_locator([{'id':'Id_123',}])self.driver.find_element"
+            "var_loc_keys=self.loc_mng.get_locator([{'id':'Id_123',}],30.0)self.driver.find_element"
             "(var_loc_keys[0],var_loc_keys[1]).clear()",
             "self.driver.find_element(var_loc_keys[0],var_loc_keys[1]).send_keys('London')"
         ]
@@ -730,8 +730,8 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
             content = fds.read()
 
         target_lines = [
-            "source=self.loc_mng.get_locator([{'xpath':'/xpath/to',}])",
-            "target=self.loc_mng.get_locator([{'css':'mycss',},{'id':'ID',}])"
+            "source=self.loc_mng.get_locator([{'xpath':'/xpath/to',}],30.0)",
+            "target=self.loc_mng.get_locator([{'css':'mycss',},{'id':'ID',}],30.0)"
             "ActionChains(self.driver).drag_and_drop(self.driver.find_element(source[0],source[1]),"
             "self.driver.find_element(target[0],target[1])).perform()"
         ]

--- a/tests/modules/selenium/test_selenium_builder.py
+++ b/tests/modules/selenium/test_selenium_builder.py
@@ -691,9 +691,9 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
             content = fds.read()
 
         target_lines = [
-            "var_loc_keys=self.loc_mng.get_locator([{'name':'btn1',}],30.0)self.driver.find_element"
+            "var_loc_keys=self.loc_mng.get_locator([{'name':'btn1',}])self.driver.find_element"
             "(var_loc_keys[0],var_loc_keys[1]).click()",
-            "var_loc_keys=self.loc_mng.get_locator([{'id':'Id_123',}],30.0)self.driver.find_element"
+            "var_loc_keys=self.loc_mng.get_locator([{'id':'Id_123',}])self.driver.find_element"
             "(var_loc_keys[0],var_loc_keys[1]).clear()",
             "self.driver.find_element(var_loc_keys[0],var_loc_keys[1]).send_keys('London')"
         ]
@@ -730,8 +730,8 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
             content = fds.read()
 
         target_lines = [
-            "source=self.loc_mng.get_locator([{'xpath':'/xpath/to',}],30.0)",
-            "target=self.loc_mng.get_locator([{'css':'mycss',},{'id':'ID',}],30.0)"
+            "source=self.loc_mng.get_locator([{'xpath':'/xpath/to',}])",
+            "target=self.loc_mng.get_locator([{'css':'mycss',},{'id':'ID',}])"
             "ActionChains(self.driver).drag_and_drop(self.driver.find_element(source[0],source[1]),"
             "self.driver.find_element(target[0],target[1])).perform()"
         ]


### PR DESCRIPTION
Set the implicit wait time to 0 when the primary locator fails otherwise the implicit wait was involved for each consecutive locator and the execution time was longer than needed.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
