### PR TITLE
test_requests.py file should save as UTF-8

### DIFF
--- a/bzt/modules/apiritif/generator.py
+++ b/bzt/modules/apiritif/generator.py
@@ -1420,7 +1420,7 @@ from selenium.webdriver.common.keys import Keys
         self.tree = self._build_tree()
 
     def save(self, filename):
-        with open(filename, 'wt') as fds:
+        with open(filename, 'wt', encoding='utf8') as fds:
             fds.write("# coding=utf-8\n")
             fds.write(astunparse.unparse(self.tree))
 


### PR DESCRIPTION
fixed for  'utf-8' codec can't decode byte 0x....

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
