### PR TITLE
Change scope of upload_artifacts to allow for user override

### DIFF
--- a/bzt/modules/blazemeter.py
+++ b/bzt/modules/blazemeter.py
@@ -217,6 +217,7 @@ class BlazeMeterUploader(Reporter, AggregatorListener, MonitoringListener, Singl
         self.monitoring_buffer = MonitoringBuffer(monitoring_buffer_limit, self.log)
         self.browser_open = self.settings.get("browser-open", self.browser_open)
         self.public_report = self.settings.get("public-report", self.public_report)
+        self.upload_artifacts = self.parameters.get("upload-artifacts", self.upload_artifacts)
         self._dpoint_serializer.multi = self.settings.get("report-times-multiplier", self._dpoint_serializer.multi)
         token = self.settings.get("token", "")
         if not token:
@@ -244,7 +245,6 @@ class BlazeMeterUploader(Reporter, AggregatorListener, MonitoringListener, Singl
             self._session.data_signature = self.parameters.get("signature", exc)
             self._session.kpi_target = self.parameters.get("kpi-target", self._session.kpi_target)
             self.send_data = self.parameters.get("send-data", self.send_data)
-            self.upload_artifacts = self.parameters.get("upload-artifacts", self.upload_artifacts)
         else:
             try:
                 self._user.ping()  # to check connectivity and auth


### PR DESCRIPTION
Change scope of upload_artifacts to allow for user override in blazemeter module. i.e. upload-artifacts=false will prevent uploading artifacts.zip.

Example:

```
execution:
- hold-for: 10s
  scenario: bad-test

scenarios:
  bad-test:
    requests:
    - http://blazedemo.com

reporting:
  - module: blazemeter
    report-name: bad-test
    upload-artifacts: false
```

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
