### PR TITLE
Add csv-jtl-flags option

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -495,26 +495,26 @@ class JMeterExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInstall
 
     def __add_result_writers(self, jmx):
         version = LooseVersion(self.tool.version)
-        flags = {}
+        csv_flags = self.settings.get('csv-jtl-flags')
         if version < LooseVersion("2.13"):
-            flags['^connectTime'] = False
+            csv_flags['^connectTime'] = False
 
         self.kpi_jtl = self.engine.create_artifact("kpi", ".jtl")
-        kpi_lst = jmx.new_kpi_listener(self.kpi_jtl, flags)
+        kpi_lst = jmx.new_kpi_listener(self.kpi_jtl, csv_flags)
         self.__add_listener(kpi_lst, jmx)
 
         verbose = self.engine.config.get(SETTINGS).get("verbose", False)
         jtl_log_level = self.execution.get('write-xml-jtl', "full" if verbose else 'error')
 
-        flags = self.settings.get('xml-jtl-flags')
+        xml_flags = self.settings.get('xml-jtl-flags')
 
         if jtl_log_level == 'error':
             self.log_jtl = self.engine.create_artifact("error", ".jtl")
-            log_lst = jmx.new_xml_listener(self.log_jtl, False, flags)
+            log_lst = jmx.new_xml_listener(self.log_jtl, False, xml_flags)
             self.__add_listener(log_lst, jmx)
         elif jtl_log_level == 'full':
             self.log_jtl = self.engine.create_artifact("trace", ".jtl")
-            log_lst = jmx.new_xml_listener(self.log_jtl, True, flags)
+            log_lst = jmx.new_xml_listener(self.log_jtl, True, xml_flags)
             self.__add_listener(log_lst, jmx)
 
     def __force_tran_parent_sample(self, jmx):

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -984,6 +984,88 @@ modules:
 
 Remember: some logging information might be used by `[assertions](#Assertions)` so change log verbosity can affect them.
 
+### CSV file content configuration
+
+By default, the kpi.jtl file does not have enough fields for JMeter's HTML dashboard generator to operate.   
+You can change this with option `csv-jtl-flags` like this:
+
+```yaml
+modules:
+  jmeter:
+    csv-jtl-flags:
+      saveAssertionResultsFailureMessage: true
+      sentBytes: true
+
+services:
+- module: shellexec
+  post-process:
+  - '[ -f "${TAURUS_ARTIFACTS_DIR}/kpi.jtl" ] && /path/to/jmeter -g "${TAURUS_ARTIFACTS_DIR}/kpi.jtl" -o "${TAURUS_ARTIFACTS_DIR}/dashboard" -j "${TAURUS_ARTIFACTS_DIR}/generate_report.log" '
+```
+
+Next example shows all the default flags with default values (you don't have to use full dictionary if you want to change some from them):
+
+```yaml
+modules:
+  jmeter:
+    csv-jtl-flags:
+      xml: false
+      fieldNames: true
+      time: true
+      timestamp: true
+      latency: true
+      connectTime: true
+      success: true
+      label: true
+      code: true
+      message: true
+      threadName: true
+      dataType: false
+      encoding: false
+      assertions: false
+      subresults: false
+      responseData: false
+      samplerData: false
+      responseHeaders: false
+      requestHeaders: false
+      responseDataOnError: false
+      saveAssertionResultsFailureMessage: false
+      bytes: true
+      hostname: true
+      threadCounts: true
+      url: false
+```
+
+You can also add flags which are not listed above, as long as JMeter recognizes them:
+
+```yaml
+modules:
+  jmeter:
+    csv-jtl-flags:
+      sentBytes: true
+      idleTime: true
+```
+
+Note: JMeter dashboard generator **requires** the following settings:
+
+```yaml
+modules:
+  jmeter:
+    csv-jtl-flags:
+      time: true
+      timestamp: true
+      latency: true
+      connectTime: true
+      success: true
+      label: true
+      code: true
+      message: true
+      threadName: true
+      saveAssertionResultsFailureMessage: true
+      bytes: true
+      threadCounts: true
+      sentBytes: true  # JMeter 4.0 or above
+```
+
 ## JMeter JVM Memory Limit
 
 You can tweak JMeter's memory limit (aka, `-Xmx` JVM option) with `memory-xmx` setting.

--- a/site/dat/docs/changes/feat-csv-jtl-flags.change
+++ b/site/dat/docs/changes/feat-csv-jtl-flags.change
@@ -1,0 +1,1 @@
+Add 'csv-jtl-flags' jmqeter option

--- a/site/dat/docs/changes/feat-csv-jtl-flags.change
+++ b/site/dat/docs/changes/feat-csv-jtl-flags.change
@@ -1,1 +1,1 @@
-Add 'csv-jtl-flags' jmqeter option
+add `csv-jtl-flags` option for tuning of logging verbosity

--- a/tests/modules/jmeter/test_JMeterExecutor.py
+++ b/tests/modules/jmeter/test_JMeterExecutor.py
@@ -88,11 +88,11 @@ class TestJMeterExecutor(ExecutorTestCase):
         selector = 'jmeterTestPlan>hashTree>hashTree>ThreadGroup'
         selector += '>stringProp[name=ThreadGroup\.num_threads]'
         thr = jmx.get(selector)
-        self.assertEqual(4, len(thr))  # tg with concurrency=0 must be disabled
-        self.assertEqual('20', thr[0].text)  # 2 -> 20
-        self.assertEqual("false", thr[1].getparent().attrib["enabled"])  # 0 -> disable tg
-        self.assertEqual('10', thr[2].text)  # ${some_var} -> 1 -> 10
-        self.assertEqual('30', thr[3].text)  # {__P(prop, 3)} -> 3 -> 30
+        self.assertEqual(4, len(thr))   # tg with concurrency=0 must be disabled
+        self.assertEqual('20', thr[0].text)    # 2 -> 20
+        self.assertEqual("false", thr[1].getparent().attrib["enabled"]) # 0 -> disable tg
+        self.assertEqual('10', thr[2].text)    # ${some_var} -> 1 -> 10
+        self.assertEqual('30', thr[3].text)    # {__P(prop, 3)} -> 3 -> 30
 
     def test_jmx_2tg(self):
         self.configure({"execution": {
@@ -254,20 +254,20 @@ class TestJMeterExecutor(ExecutorTestCase):
                         {
                             'url': 'http://zero.com',
                             "method": "get",
-                            'body-file': body_file0  # ignore because method is GET
+                            'body-file': body_file0     # ignore because method is GET
                         }, {
                             'url': 'http://first.com',
                             "method": "${put_method}",
-                            'body-file': body_file1  # handle as body-file
+                            'body-file': body_file1     # handle as body-file
                         }, {
                             'url': 'http://second.com',
                             'method': 'post',
-                            'body': 'body2',  # handle only 'body' as both are mentioned (body and body-file)
+                            'body': 'body2',    # handle only 'body' as both are mentioned (body and body-file)
                             'body-file': body_file2
                         }, {
                             'url': 'https://the third.com',
                             'method': 'post',
-                            'body-file': '${J_VAR}'  # write variable as body-file
+                            'body-file': '${J_VAR}'     # write variable as body-file
                         }
                     ]}}})
         res_files = self.obj.get_resource_files()
@@ -498,11 +498,11 @@ class TestJMeterExecutor(ExecutorTestCase):
         uniform_timer = jmx.tree.find(".//UniformRandomTimer[@testname='Think-Time']")
         gaussian_timer = jmx.tree.find(".//GaussianRandomTimer[@testname='Think-Time']")
         poisson_timer = jmx.tree.find(".//PoissonRandomTimer[@testname='Think-Time']")
-
+        
         ctd = "ConstantTimer.delay"
         rtr = "RandomTimer.range"
         str_prop = ".//stringProp[@name='%s']"
-
+        
         const_delay = constant_timer.find(str_prop % ctd).text
         self.assertEqual("750", const_delay)
 
@@ -888,7 +888,7 @@ class TestJMeterExecutor(ExecutorTestCase):
     def test_distributed_props(self):
         self.sniff_log(self.obj.log)
 
-        self.configure({"execution": {"scenario": {"script": RESOURCES_DIR + "/jmeter/jmx/http.jmx"}}})
+        self.configure({"execution":{"scenario": {"script": RESOURCES_DIR + "/jmeter/jmx/http.jmx"}}})
         self.obj.distributed_servers = ["127.0.0.1", "127.0.0.1"]
         self.obj.settings['properties'] = BetterDict.from_dict({"a": 1})
 
@@ -1058,8 +1058,8 @@ class TestJMeterExecutor(ExecutorTestCase):
         ramp_up = tg.find(".//stringProp[@name='ThreadGroup.ramp_time']")
         conc = tg.find(".//stringProp[@name='ThreadGroup.num_threads']")
         delay = tg.find(".//boolProp[@name='ThreadGroup.delayedStart']")
-        self.assertEqual(conc.text, '${__P(val_c)}')  # concurrency should be saved
-        self.assertEqual(ramp_up.text, '0')  # ramp-up should be removed
+        self.assertEqual(conc.text, '${__P(val_c)}')    # concurrency should be saved
+        self.assertEqual(ramp_up.text, '0')             # ramp-up should be removed
 
         delay = delay is not None and delay.text == "true"
         self.assertTrue(delay)
@@ -1376,21 +1376,21 @@ class TestJMeterExecutor(ExecutorTestCase):
             "scenario": {
                 "requests": [
                     {
-                        "url": "http://blazedemo1.com",  # header + complicated dict = json
+                        "url": "http://blazedemo1.com",         # header + complicated dict = json
                         "method": "POST",
                         "headers": {"Content-Type": "application/json"},
                         "body": {"key1": {"key2": "val3"}}
                     }, {
-                        "url": "http://blazedemo2.com",  # no header + easy dict = form
+                        "url": "http://blazedemo2.com",         # no header + easy dict = form
                         "method": "POST",
                         "body": {"key4": "val5"}
                     }, {
-                        "url": "http://blazedemo3.com",  # no header + complicated dict = json
+                        "url": "http://blazedemo3.com",         # no header + complicated dict = json
                         "method": "POST",
                         "body": {
                             "key6": {"key7": "val8"}}
                     }, {
-                        "url": "http://blazedemo4.com",  # header + easy dict = json
+                        "url": "http://blazedemo4.com",         # header + easy dict = json
                         "method": "POST",
                         "headers": {"Content-Type": "application/json"},
                         "body": {"key9": "val10"}
@@ -1441,24 +1441,6 @@ class TestJMeterExecutor(ExecutorTestCase):
         self.assertEqual(jmx.get('ResultCollector[testname="Trace Writer"]'), [])
         self.assertEqual(jmx.get('ResultCollector[testname="Errors Writer"]'), [])
 
-    def test_jtl_flags(self):
-        self.configure({"execution": {
-            "write-xml-jtl": "error",
-            "scenario": {
-                "requests": [{
-                    "url": "http://blazedemo.com"}]}}})
-        self.obj.settings.merge({'xml-jtl-flags': {
-            'responseData': True,
-            'message': False}})
-        self.obj.prepare()
-        xml_tree = etree.fromstring(open(self.obj.modified_jmx, "rb").read())
-        writers = xml_tree.findall(".//ResultCollector[@testname='Errors Writer']")
-        self.assertEqual(1, len(writers))
-        self.assertEqual('false', writers[0].find('objProp/value/samplerData').text)
-        self.assertEqual('false', writers[0].find('objProp/value/message').text)
-        self.assertEqual('true', writers[0].find('objProp/value/responseData').text)
-        self.assertEqual('true', writers[0].find('objProp/value/bytes').text)
-
     def test_csv_jtl_flags(self):
         self.configure({"execution": {
             "write-xml-jtl": "error",
@@ -1478,6 +1460,24 @@ class TestJMeterExecutor(ExecutorTestCase):
         self.assertEqual('true', writers[0].find('objProp/value/sentBytes').text)
         self.assertEqual('true', writers[0].find('objProp/value/idleTime').text)
         self.assertEqual('false', writers[0].find('objProp/value/dataType').text)
+
+    def test_jtl_flags(self):
+        self.configure({"execution": {
+            "write-xml-jtl": "error",
+            "scenario": {
+                "requests": [{
+                    "url": "http://blazedemo.com"}]}}})
+        self.obj.settings.merge({'xml-jtl-flags': {
+            'responseData': True,
+            'message': False}})
+        self.obj.prepare()
+        xml_tree = etree.fromstring(open(self.obj.modified_jmx, "rb").read())
+        writers = xml_tree.findall(".//ResultCollector[@testname='Errors Writer']")
+        self.assertEqual(1, len(writers))
+        self.assertEqual('false', writers[0].find('objProp/value/samplerData').text)
+        self.assertEqual('false', writers[0].find('objProp/value/message').text)
+        self.assertEqual('true', writers[0].find('objProp/value/responseData').text)
+        self.assertEqual('true', writers[0].find('objProp/value/bytes').text)
 
     def test_jmx_modification_unicode(self):
         cfg_selector = ('Home Page>HTTPsampler.Arguments>Arguments.arguments'

--- a/tests/modules/jmeter/test_JMeterExecutor.py
+++ b/tests/modules/jmeter/test_JMeterExecutor.py
@@ -88,11 +88,11 @@ class TestJMeterExecutor(ExecutorTestCase):
         selector = 'jmeterTestPlan>hashTree>hashTree>ThreadGroup'
         selector += '>stringProp[name=ThreadGroup\.num_threads]'
         thr = jmx.get(selector)
-        self.assertEqual(4, len(thr))   # tg with concurrency=0 must be disabled
-        self.assertEqual('20', thr[0].text)    # 2 -> 20
-        self.assertEqual("false", thr[1].getparent().attrib["enabled"]) # 0 -> disable tg
-        self.assertEqual('10', thr[2].text)    # ${some_var} -> 1 -> 10
-        self.assertEqual('30', thr[3].text)    # {__P(prop, 3)} -> 3 -> 30
+        self.assertEqual(4, len(thr))  # tg with concurrency=0 must be disabled
+        self.assertEqual('20', thr[0].text)  # 2 -> 20
+        self.assertEqual("false", thr[1].getparent().attrib["enabled"])  # 0 -> disable tg
+        self.assertEqual('10', thr[2].text)  # ${some_var} -> 1 -> 10
+        self.assertEqual('30', thr[3].text)  # {__P(prop, 3)} -> 3 -> 30
 
     def test_jmx_2tg(self):
         self.configure({"execution": {
@@ -254,20 +254,20 @@ class TestJMeterExecutor(ExecutorTestCase):
                         {
                             'url': 'http://zero.com',
                             "method": "get",
-                            'body-file': body_file0     # ignore because method is GET
+                            'body-file': body_file0  # ignore because method is GET
                         }, {
                             'url': 'http://first.com',
                             "method": "${put_method}",
-                            'body-file': body_file1     # handle as body-file
+                            'body-file': body_file1  # handle as body-file
                         }, {
                             'url': 'http://second.com',
                             'method': 'post',
-                            'body': 'body2',    # handle only 'body' as both are mentioned (body and body-file)
+                            'body': 'body2',  # handle only 'body' as both are mentioned (body and body-file)
                             'body-file': body_file2
                         }, {
                             'url': 'https://the third.com',
                             'method': 'post',
-                            'body-file': '${J_VAR}'     # write variable as body-file
+                            'body-file': '${J_VAR}'  # write variable as body-file
                         }
                     ]}}})
         res_files = self.obj.get_resource_files()
@@ -498,11 +498,11 @@ class TestJMeterExecutor(ExecutorTestCase):
         uniform_timer = jmx.tree.find(".//UniformRandomTimer[@testname='Think-Time']")
         gaussian_timer = jmx.tree.find(".//GaussianRandomTimer[@testname='Think-Time']")
         poisson_timer = jmx.tree.find(".//PoissonRandomTimer[@testname='Think-Time']")
-        
+
         ctd = "ConstantTimer.delay"
         rtr = "RandomTimer.range"
         str_prop = ".//stringProp[@name='%s']"
-        
+
         const_delay = constant_timer.find(str_prop % ctd).text
         self.assertEqual("750", const_delay)
 
@@ -888,7 +888,7 @@ class TestJMeterExecutor(ExecutorTestCase):
     def test_distributed_props(self):
         self.sniff_log(self.obj.log)
 
-        self.configure({"execution":{"scenario": {"script": RESOURCES_DIR + "/jmeter/jmx/http.jmx"}}})
+        self.configure({"execution": {"scenario": {"script": RESOURCES_DIR + "/jmeter/jmx/http.jmx"}}})
         self.obj.distributed_servers = ["127.0.0.1", "127.0.0.1"]
         self.obj.settings['properties'] = BetterDict.from_dict({"a": 1})
 
@@ -1058,8 +1058,8 @@ class TestJMeterExecutor(ExecutorTestCase):
         ramp_up = tg.find(".//stringProp[@name='ThreadGroup.ramp_time']")
         conc = tg.find(".//stringProp[@name='ThreadGroup.num_threads']")
         delay = tg.find(".//boolProp[@name='ThreadGroup.delayedStart']")
-        self.assertEqual(conc.text, '${__P(val_c)}')    # concurrency should be saved
-        self.assertEqual(ramp_up.text, '0')             # ramp-up should be removed
+        self.assertEqual(conc.text, '${__P(val_c)}')  # concurrency should be saved
+        self.assertEqual(ramp_up.text, '0')  # ramp-up should be removed
 
         delay = delay is not None and delay.text == "true"
         self.assertTrue(delay)
@@ -1376,21 +1376,21 @@ class TestJMeterExecutor(ExecutorTestCase):
             "scenario": {
                 "requests": [
                     {
-                        "url": "http://blazedemo1.com",         # header + complicated dict = json
+                        "url": "http://blazedemo1.com",  # header + complicated dict = json
                         "method": "POST",
                         "headers": {"Content-Type": "application/json"},
                         "body": {"key1": {"key2": "val3"}}
                     }, {
-                        "url": "http://blazedemo2.com",         # no header + easy dict = form
+                        "url": "http://blazedemo2.com",  # no header + easy dict = form
                         "method": "POST",
                         "body": {"key4": "val5"}
                     }, {
-                        "url": "http://blazedemo3.com",         # no header + complicated dict = json
+                        "url": "http://blazedemo3.com",  # no header + complicated dict = json
                         "method": "POST",
                         "body": {
                             "key6": {"key7": "val8"}}
                     }, {
-                        "url": "http://blazedemo4.com",         # header + easy dict = json
+                        "url": "http://blazedemo4.com",  # header + easy dict = json
                         "method": "POST",
                         "headers": {"Content-Type": "application/json"},
                         "body": {"key9": "val10"}
@@ -1458,6 +1458,26 @@ class TestJMeterExecutor(ExecutorTestCase):
         self.assertEqual('false', writers[0].find('objProp/value/message').text)
         self.assertEqual('true', writers[0].find('objProp/value/responseData').text)
         self.assertEqual('true', writers[0].find('objProp/value/bytes').text)
+
+    def test_csv_jtl_flags(self):
+        self.configure({"execution": {
+            "write-xml-jtl": "error",
+            "scenario": {
+                "requests": [{
+                    "url": "http://blazedemo.com"}]}}})
+        self.obj.settings.merge({'csv-jtl-flags': {
+            'saveAssertionResultsFailureMessage': True,
+            'sentBytes': True,
+            'idleTime': True,
+            'dataType': False}})
+        self.obj.prepare()
+        xml_tree = etree.fromstring(open(self.obj.modified_jmx, "rb").read())
+        writers = xml_tree.findall(".//ResultCollector[@testname='KPI Writer']")
+        self.assertEqual(1, len(writers))
+        self.assertEqual('true', writers[0].find('objProp/value/saveAssertionResultsFailureMessage').text)
+        self.assertEqual('true', writers[0].find('objProp/value/sentBytes').text)
+        self.assertEqual('true', writers[0].find('objProp/value/idleTime').text)
+        self.assertEqual('false', writers[0].find('objProp/value/dataType').text)
 
     def test_jmx_modification_unicode(self):
         cfg_selector = ('Home Page>HTTPsampler.Arguments>Arguments.arguments'


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside

---

The default settings of new_kpi_listener don't have enough fields for generating JMeter dashboard report.  That may be a 'gotcha' to pepole who familiar with JMeter's `jmeter.save.saveservice.XXX` settings.

This new `csv-jtl-flags` option let users decide what to enable or not. 

### Config file example

Minimal config to enable dashboard:

```
modules:
  jmeter:
    csv-jtl-flags:
      saveAssertionResultsFailureMessage: true
      sentBytes: true
```

JMeter 5.2.1 default behavior: (execpt for hostname)

```
modules:
  jmeter:
    csv-jtl-flags:
      time: true
      timestamp: true
      latency: true
      connectTime: true
      success: true
      label: true
      code: true
      message: true
      threadName: true
      dataType: true
      assertions: true
      subresults: true
      saveAssertionResultsFailureMessage: true
      bytes: true
      hostname: true
      threadCounts: true
      url: true
      sentBytes: true
      idleTime: true
      
    properties:
      jmeter.save.saveservice.autoflush: false
```

Related: https://github.com/Blazemeter/taurus/pull/774
