### PR TITLE
Made then branch optional in if conditions

### DIFF
--- a/bzt/modules/apiritif/generator.py
+++ b/bzt/modules/apiritif/generator.py
@@ -806,15 +806,15 @@ from selenium.webdriver.common.keys import Keys
         return ast_call(func=ast_attr("self.driver.execute_script"), args=[self._gen_expr("return %s;" % js_expr)])
 
     def _gen_condition_mngr(self, param, action_config):
-        if not action_config.get('then'):
-            raise TaurusConfigError("Missing then branch in if statement")
-
         test = ast.Assign(targets=[ast.Name(id='test', ctx=ast.Store())],
                           value=self._gen_eval_js_expression(param))
 
         body = []
-        for action in action_config.get('then'):
-            body.append(self._gen_action(action))
+        if action_config.get('then'):
+            for action in action_config.get('then'):
+                body.append(self._gen_action(action))
+        else:
+            body.append(ast.Pass())
 
         orelse = []
         if action_config.get('else'):

--- a/site/dat/docs/Apiritif.md
+++ b/site/dat/docs/Apiritif.md
@@ -198,8 +198,8 @@ You can see full example [here](#Sample-scenario-using-multiple-locators).
 Apiritif allows to control execution flow using `if` blocks. These blocks enable 
 conditional execution of actions.
 
-Each `if` block should contain a mandatory `then` field, and an optional `else` field. Both `then` and `else` fields
-should contain list of actions.
+Each `if` block can contain `then` and/or `else` field. Both `then` and `else` fields
+may contain a list of actions.
 
 Here's a simple example:
 

--- a/site/dat/docs/changes/fix-if-make-then-optional.change
+++ b/site/dat/docs/changes/fix-if-make-then-optional.change
@@ -1,0 +1,1 @@
+made the then branch optional in if condition in Apiritif


### PR DESCRIPTION
A requirement from Blazemeter Scriptless team - they don't want to fail tests if the branches are omitted by users or also e.g. to be able to use just if-else without then. 

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
