### PR TITLE
allow to set provisioning context for shellexec tasks

### DIFF
--- a/bzt/modules/shellexec.py
+++ b/bzt/modules/shellexec.py
@@ -18,8 +18,9 @@ from subprocess import CalledProcessError, PIPE
 from bzt import TaurusConfigError, RCProvider
 from bzt.six import communicate
 from bzt.engine import Service
-from bzt.utils import ensure_is_dict, Environment, shutdown_process, shell_exec
-
+from bzt.utils import ensure_is_dict, Environment, shutdown_process, shell_exec, BetterDict
+from bzt.modules.provisioning import Local
+from bzt.modules.blazemeter import CloudProvisioning
 
 class ShellExecutor(Service):
     """
@@ -87,11 +88,36 @@ class ShellExecutor(Service):
             container.append(task)
             self.log.debug("Added %s task: %s", stage, stage_task)
 
+    def _filter_prov_context(self):
+        def filter_conf(conf):
+            if not any(key in conf for key in prov_configs.items()):        # if no specific provisioning is configured
+                conf = BetterDict.from_dict({prov_configs['local']: conf})  # all configuration is local
+
+            return conf.get(current_prov)
+
+        current_prov = self.engine.config.get("provisioning")
+        modules = self.engine.config.get("modules")
+        prov_classes = {'local': Local, 'cloud': CloudProvisioning}
+
+        prov_configs = {}
+        for prov in prov_classes:
+            class_name = prov_classes[prov].__module__ + '.' + prov_classes[prov].__name__
+            for module in modules:  # llo
+                if modules[module] == class_name or (
+                        isinstance(modules[module], dict) and modules[module].get("class") == class_name):
+                    prov_configs[prov] = module
+                    break
+
+        self.settings = filter_conf(self.settings)
+        self.parameters = filter_conf(self.parameters)
+
     def prepare(self):
         """
         Configure Tasks
         :return:
         """
+        self._filter_prov_context()
+
         self.env.set(self.settings.get('env'))
 
         self._load_tasks('prepare', self.prepare_tasks)

--- a/bzt/modules/shellexec.py
+++ b/bzt/modules/shellexec.py
@@ -90,7 +90,7 @@ class ShellExecutor(Service):
 
     def _filter_prov_context(self):
         def filter_conf(conf):
-            if not any(key in conf for key in prov_configs.items()):        # if no specific provisioning is configured
+            if not any(key in conf for key in prov_configs.values()):        # if no specific provisioning is configured
                 conf = BetterDict.from_dict({prov_configs['local']: conf})  # all configuration is local
 
             return conf.get(current_prov)

--- a/site/dat/docs/ShellExec.md
+++ b/site/dat/docs/ShellExec.md
@@ -60,10 +60,13 @@ Notes:
  - Background tasks will be shut down forcefully on mirror stages (see [Lifecycle](Lifecycle.md)) if they were not finished yet.
  - Background tasks on Check stage will not start until same previous task completed.
  - Special environment variable `TAURUS\_ARTIFACTS\_DIR` is set for every command, containing path to current artifacts directory
- - Special environment variables `TAURUS\_EXIT\_CODE` and `TAURUS\_STOPPING\_REASON` is set for every command after Taurus begins shutdown, containing exit code and possible failure explanation
- - There is module setting `default-cwd` for `shellexec` module that allows to change `cwd` default value for all tasks
- - There is module setting `env` which contains dictionary for additional environment variables for commands
+ - Special environment variables `TAURUS\_EXIT\_CODE` and `TAURUS\_STOPPING\_REASON` is set for every command after
+ Taurus begins shutdown, containing exit code and possible failure explanation
 
+##Module Settings
+Some 'global' settings can be specified in the `modules` block as usual.
+There are `default-cwd` for `shellexec` module that allows to change `cwd` default value for all tasks
+and `env` which contains dictionary for additional environment variables for commands
 ```yaml
 modules:
   shellexec:
@@ -71,4 +74,19 @@ modules:
     env:
       VARNAME: value
       VARNAME2: value2
+```
+
+ ##Provisioning Context Configuration
+ By default all tasks will be handled on the host where test is executed. In `Cloud Provisioning` case you ask (locally)
+ to run test in the BM Cloud and all task will be executed there. It's possible to specify target provisioning
+ for tasks or module settings, just use provisioning nicks for that:
+```yaml
+services:
+- module: shellexec
+  prepare:
+  - command: echo # will be executed with test together
+- module: shellexec
+  cloud:
+    prepare:
+    - command: kill_them_all # only on your local host when you start cloud test
 ```

--- a/site/dat/docs/changes/fix-prov-context-services.change
+++ b/site/dat/docs/changes/fix-prov-context-services.change
@@ -1,1 +1,1 @@
-allow to specify where exactly shellexec must me processed
+allow to specify where exactly shellexec must be processed

--- a/site/dat/docs/changes/fix-prov-context-services.change
+++ b/site/dat/docs/changes/fix-prov-context-services.change
@@ -1,0 +1,1 @@
+allow to specify where exactly shellexec and env relsolving must me processed

--- a/site/dat/docs/changes/fix-prov-context-services.change
+++ b/site/dat/docs/changes/fix-prov-context-services.change
@@ -1,1 +1,1 @@
-allow to specify where exactly shellexec and env relsolving must me processed
+allow to specify where exactly shellexec must me processed

--- a/tests/modules/test_shellexec.py
+++ b/tests/modules/test_shellexec.py
@@ -16,7 +16,12 @@ class TaskTestCase(BZTestCase):
         self.obj = ShellExecutor()
         self.obj.parameters = BetterDict()
         self.obj.engine = EngineEmul()
-        self.obj.engine.config.merge({"provisioning": "local"})
+        self.obj.engine.config.merge({
+            "provisioning": "local",
+            "modules": {
+                "local": {"class": "bzt.modules.provisioning.Local"},
+                "cloud": {"class": "bzt.modules.blazemeter.CloudProvisioning"},
+            }})
         self.obj.engine.default_cwd = os.getcwd()
         self.sniff_log(self.obj.log)
 

--- a/tests/modules/test_shellexec.py
+++ b/tests/modules/test_shellexec.py
@@ -84,7 +84,7 @@ class TestBlockingTasks(TaskTestCase):
         self.obj.parameters.merge({"prepare": [task]})
         self.obj.prepare()
 
-    def test_default_prov_context_local(self):
+    def test_default_prov_context_for_local(self):
         command = "my_echo"
         var_name, var_value = "VAR_NAME", "VAR_VALUE"
         self.obj.parameters.merge({"startup": [{"command": command}]})
@@ -95,10 +95,12 @@ class TestBlockingTasks(TaskTestCase):
         commands = [task.command for task in self.obj.prepare_tasks + self.obj.startup_tasks +
                     self.obj.check_tasks + self.obj.shutdown_tasks + self.obj.postprocess_tasks]
         env_vars = self.obj.env.get()
+
+        # handle as usual
         self.assertEqual(env_vars.get(var_name), var_value)
         self.assertIn(command, commands)
 
-    def test_default_prov_context_cloud(self):
+    def test_default_prov_context_for_cloud(self):
         command = "my_echo"
         var_name, var_value = "VAR_NAME", "VAR_VALUE"
         self.obj.parameters.merge({"startup": [{"command": command}]})
@@ -110,14 +112,19 @@ class TestBlockingTasks(TaskTestCase):
         commands = [task.command for task in self.obj.prepare_tasks + self.obj.startup_tasks +
                     self.obj.check_tasks + self.obj.shutdown_tasks + self.obj.postprocess_tasks]
         env_vars = self.obj.env.get()
+
+        # mustn't be processed for cloud provisioning case
         self.assertNotEqual(env_vars.get(var_name), var_value)
         self.assertNotIn(command, commands)
 
     def test_same_prov_context(self):
         command = "my_echo"
         var_name, var_value = "VAR_NAME", "VAR_VALUE"
+        target_prov = "cloud"
+
         self.obj.parameters.merge({"cloud": {"startup": [{"command": command}]}})
         self.obj.settings.get("env", force_set=True).update({var_name: var_value})
+        self.obj.settings = BetterDict.from_dict({target_prov: self.obj.settings})
         self.obj.engine.config.merge({"provisioning": "cloud"})
 
         self.obj.prepare()
@@ -125,14 +132,19 @@ class TestBlockingTasks(TaskTestCase):
         commands = [task.command for task in self.obj.prepare_tasks + self.obj.startup_tasks +
                     self.obj.check_tasks + self.obj.shutdown_tasks + self.obj.postprocess_tasks]
         env_vars = self.obj.env.get()
+
+        # must be handled because current prov specified as target
         self.assertEqual(env_vars.get(var_name), var_value)
         self.assertIn(command, commands)
 
     def test_different_prov_context(self):
         command = "my_echo"
         var_name, var_value = "VAR_NAME", "VAR_VALUE"
-        self.obj.parameters.merge({"cloud": {"startup": [{"command": command}]}})
+        target_prov = "cloud"
+
+        self.obj.parameters.merge({target_prov: {"startup": [{"command": command}]}})
         self.obj.settings.get("env", force_set=True).update({var_name: var_value})
+        self.obj.settings = BetterDict.from_dict({target_prov: self.obj.settings})
         self.obj.engine.config.merge({"provisioning": "local"})     # the same as setUp value, just for emphasizing
 
         self.obj.prepare()
@@ -140,6 +152,8 @@ class TestBlockingTasks(TaskTestCase):
         commands = [task.command for task in self.obj.prepare_tasks + self.obj.startup_tasks +
                     self.obj.check_tasks + self.obj.shutdown_tasks + self.obj.postprocess_tasks]
         env_vars = self.obj.env.get()
+
+        # mustn't be handled because settings are specified for different prov
         self.assertNotEqual(env_vars.get(var_name), var_value)
         self.assertNotIn(command, commands)
 

--- a/tests/resources/yaml/wrong_cmd.yml
+++ b/tests/resources/yaml/wrong_cmd.yml
@@ -1,6 +1,5 @@
 execution:
   iteration: 1
-  #executor: mock
   scenario:
     requests:
     - http://blazedemo.com
@@ -13,5 +12,4 @@ services:
 modules:
   shellexec:
     class: bzt.modules.shellexec.ShellExecutor
-  mock:
-    class: mock
+

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -9,7 +9,7 @@ from tests import BZTestCase, RESOURCES_DIR
 
 from bzt.cli import CLI, ConfigOverrider, get_option_parser
 from bzt.engine import Configuration
-import bzt.modules.provisioning
+import bzt.modules.shellexec
 from tests.mocks import EngineEmul, ModuleMock
 
 
@@ -49,8 +49,8 @@ class TestCLI(BZTestCase):
                 "local": {"class": "bzt.modules.provisioning.Local"},
                 "cloud": {"class": "bzt.modules.blazemeter.CloudProvisioning"},
             }})
-        saved_local = bzt.modules.provisioning.Local
-        bzt.modules.provisioning.Local = ModuleMock
+        saved_local = bzt.modules.shellexec.Local
+        bzt.modules.shellexec.Local = ModuleMock
         try:
             ret = self.get_ret_code([RESOURCES_DIR + "yaml/wrong_cmd.yml"])
             self.assertEquals(1, ret)
@@ -66,7 +66,7 @@ class TestCLI(BZTestCase):
             self.assertIn(good_err, log_content)
             self.assertNotIn(bad_err, log_content)
         finally:
-            bzt.modules.provisioning.Local = saved_local
+            bzt.modules.shellexec.Local = saved_local
 
     def test_unicode_logging(self):
         """ check whether unicode symbols are logged correctly into file """

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -9,6 +9,7 @@ from tests import BZTestCase, RESOURCES_DIR
 
 from bzt.cli import CLI, ConfigOverrider, get_option_parser
 from bzt.engine import Configuration
+import bzt.modules.provisioning
 from tests.mocks import EngineEmul, ModuleMock
 
 
@@ -42,19 +43,30 @@ class TestCLI(BZTestCase):
         self.assertEquals(0, ret)
 
     def test_call_proc_error(self):
-        ret = self.get_ret_code([RESOURCES_DIR + "yaml/wrong_cmd.yml"])
-        self.assertEquals(1, ret)
+        self.obj.engine.config.merge({
+            "provisioning": "mock",
+            "modules": {
+                "local": {"class": "bzt.modules.provisioning.Local"},
+                "cloud": {"class": "bzt.modules.blazemeter.CloudProvisioning"},
+            }})
+        saved_local = bzt.modules.provisioning.Local
+        bzt.modules.provisioning.Local = ModuleMock
+        try:
+            ret = self.get_ret_code([RESOURCES_DIR + "yaml/wrong_cmd.yml"])
+            self.assertEquals(1, ret)
 
-        #from shellexec
-        good_err = "DEBUG EngineEmul] Command 'wrong_cmd' returned non-zero exit status 1"
+            # from shellexec
+            good_err = "DEBUG EngineEmul] Command 'wrong_cmd' returned non-zero exit status 1"
 
-        # from CalledProcessError constructor in reraise()
-        bad_err = "__init__() missing 1 required positional argument: 'cmd'"
+            # from CalledProcessError constructor in reraise()
+            bad_err = "__init__() missing 1 required positional argument: 'cmd'"
 
-        log_file = os.path.join(self.obj.engine.artifacts_dir, "bzt.log")
-        log_content = codecs.open(log_file, encoding="utf-8").read()
-        self.assertIn(good_err, log_content)
-        self.assertNotIn(bad_err, log_content)
+            log_file = os.path.join(self.obj.engine.artifacts_dir, "bzt.log")
+            log_content = codecs.open(log_file, encoding="utf-8").read()
+            self.assertIn(good_err, log_content)
+            self.assertNotIn(bad_err, log_content)
+        finally:
+            bzt.modules.provisioning.Local = saved_local
 
     def test_unicode_logging(self):
         """ check whether unicode symbols are logged correctly into file """


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [x] Documentation update
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
