### PR TITLE
Support loop fields as numbers in quotes and concatenation with variables

### DIFF
--- a/bzt/resources/selenium_extras.py
+++ b/bzt/resources/selenium_extras.py
@@ -290,6 +290,9 @@ def get_loop_range(start, end, step):
     """
     :return: the range over which the loop will operate
     """
+    start = int(start)
+    end = int(end)
+    step = int(step)
     end = end + 1 if step > 0 else end - 1
     return range(start, end, step)
 

--- a/site/dat/docs/Apiritif.md
+++ b/site/dat/docs/Apiritif.md
@@ -290,7 +290,30 @@ For example:
 ``` 
 This will loop through the values \[5, 4, 3, 2, 1\] in the descending order.
 
-Note that you may also use variables in the `start`, `end` and `step` fields.
+Note that you may also use variables in the `start`, `end` and `step` fields. These fields may
+include numbers surrounded by quotes and one can even concatenate in this case numbers with variables.
+
+For example: 
+
+```yaml
+scenarios:
+  example:
+    browser: Chrome
+    timeout: 10s
+    variables:
+      step: 1
+      end: '00'
+    requests:
+      - label: example_loop
+        actions:
+          - go(http://blazedemo.com)
+          - loop: i
+            start: '1'
+            end: '1${end}' # will result in 100
+            step: ${step}
+            do: 
+              - clickById(id_${i}) 
+``` 
 
 ### Foreach
 

--- a/site/dat/docs/changes/fix-loop-string-fields.change
+++ b/site/dat/docs/changes/fix-loop-string-fields.change
@@ -1,0 +1,1 @@
+Support loop fields as numbers in quotes and concatenation with variables

--- a/tests/modules/selenium/test_selenium_builder.py
+++ b/tests/modules/selenium/test_selenium_builder.py
@@ -1338,7 +1338,8 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
                             {
                                 "loop": "i",
                                 "start": 1,
-                                "end": 10
+                                "end": 10,
+                                "do": []
                             }
                         ]}]}}})
 
@@ -1472,6 +1473,40 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
         exp_file = RESOURCES_DIR + "selenium/generated_from_requests_loop_variables.py"
         str_to_replace = (self.obj.engine.artifacts_dir + os.path.sep).replace('\\', '\\\\')
         self.assertFilesEqual(exp_file, self.obj.script, str_to_replace, "/somewhere/", python_files=True)
+
+    def test_loop_str_var_fields(self):
+        self.configure({
+            "execution": [{
+                "executor": "apiritif",
+                "scenario": "loc_sc"}],
+            "scenarios": {
+                "loc_sc": {
+                    "variables": {
+                        "step": 1
+                    },
+                    "requests": [{
+                        "actions": [
+                            {
+                                "loop": "i",
+                                "start": "1",
+                                "end": "10",
+                                "step": '1${step}',
+                                "do": [
+                                    "clickById(id)"
+                                ]
+                            }
+                        ]}]}}})
+
+        self.obj.prepare()
+        with open(self.obj.script) as fds:
+            content = fds.read()
+
+        target_lines = [
+            "for i in get_loop_range(1, 10, '1{}'.format(self.vars['step']))",
+            "self.vars['i'] = str(i)"
+        ]
+        for idx in range(len(target_lines)):
+            self.assertIn(target_lines[idx], content, msg="\n\n%s. %s" % (idx, target_lines[idx]))
 
     def test_assert_dialog_wrong_type(self):
         self.configure({


### PR DESCRIPTION
* Enable usage of strings / numbers in quotes inside 'start', 'end' and 'step' fields. 
* Allow concatenation with variables inside these fields

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
