### PR TITLE
WAP-16606 No link for "Unable to locate element" error in report

### DIFF
--- a/bzt/resources/selenium_extras.py
+++ b/bzt/resources/selenium_extras.py
@@ -17,11 +17,13 @@ BYS = {
 }
 
 
-def get_locator(locators, ignore_implicit_wait=False):
+def get_locator(locators, ignore_implicit_wait=False, raise_exception=False):
     """
     :param locators: List of Dictionaries holding the locators, e.g. [{'id': 'elem_id'},
     {css: 'my_cls'}]
     :param ignore_implicit_wait: set it to True to set the implicit wait immediately to 0
+    :param raise_exception: set it to True to get the NoSuchElementException in case no elements are matching any
+    of the passed locators, if set to False then the first locator is returned in that case
     :return: first valid locator from the passed List, if no locator is valid then returns the
     first one
     """
@@ -43,9 +45,12 @@ def get_locator(locators, ignore_implicit_wait=False):
             locator = (BYS[locator_type.lower()], locator_value)
             break
     else:
-        driver.implicitly_wait(timeout)
-        msg = "Element not found: (%s, %s)" % first_locator
-        raise NoSuchElementException(msg)
+        if raise_exception:
+            driver.implicitly_wait(timeout)
+            msg = "Element not found: (%s, %s)" % first_locator
+            raise NoSuchElementException(msg)
+        else:
+            locator = first_locator
 
     # restore the implicit wait value
     driver.implicitly_wait(timeout)
@@ -240,7 +245,7 @@ def _wait_for_positive(condition, locators, wait_timeout):
     while True:
         locator = None
         try:
-            locator = get_locator(locators, True)
+            locator = get_locator(locators, ignore_implicit_wait=True, raise_exception=True)
         except NoSuchElementException:
             pass
         if locator:
@@ -261,7 +266,7 @@ def _wait_for_negative(condition, locators, wait_timeout):
     present_locs = []
     for locator in locators:
         try:
-            present_locs.append(get_locator([locator], True))
+            present_locs.append(get_locator([locator], ignore_implicit_wait=True, raise_exception=True))
         except NoSuchElementException:
             pass
     if not present_locs:

--- a/site/dat/docs/changes/fix-no-link-in-error-report.change
+++ b/site/dat/docs/changes/fix-no-link-in-error-report.change
@@ -1,0 +1,1 @@
+WAP-16606 No link for "Unable to locate element" error in report

--- a/tests/modules/selenium/test_python_executors.py
+++ b/tests/modules/selenium/test_python_executors.py
@@ -46,9 +46,17 @@ class TestLocatorsMagager(BZTestCase):
 
         apiritif.put_into_thread_store(driver=driver, timeout=timeout, func_mode=False)
 
+        # exception should be raised when raise_exception is True
         missing_locators = [{'css': 'missing_css'}, {'xpath': 'missing_xpath'}]
-        self.assertRaises(NoSuchElementException, get_locator, missing_locators)
+        self.assertRaises(NoSuchElementException, get_locator, missing_locators, False, True)
         self.assertEqual(30, driver.waiting_time)
+
+        # exception should not be raised when raise_exception is False
+        driver.waiting_time = 0
+        locators = get_locator(missing_locators, ignore_implicit_wait=True, raise_exception=False)
+        self.assertEqual(locators, (BYS['css'], 'missing_css'))
+        # actual waiting time is 0 when setting ignore_implicit_wait to True
+        self.assertEqual(0, driver.waiting_time)
 
         driver.waiting_time = 0
         existed_locators = [{'css': 'existed_css'}]


### PR DESCRIPTION
Restore the behaviour before the multiple locators were introduced - don't raise the exception manually in get_locator but leave it on the webdriver itself.
There is a problem in how the exceptions are shown in the Blazemeter UI - seems that only exceptions raised directly by the webdriver are properly shown with a link to the error.


Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
