### PR TITLE
fix-column-order-locust-kpi

### DIFF
--- a/bzt/resources/locustio-taurus-wrapper.py
+++ b/bzt/resources/locustio-taurus-wrapper.py
@@ -55,17 +55,17 @@ class LocustStarter(object):
 
         return OrderedDict([
             ('timeStamp', "%d" % (time.time() * 1000)),
-            ('label', name),
-            ('method', request_type),
             ('elapsed', response_time),
-            ('bytes', response_length),
+            ('label', name),
             ('responseCode', rcode),
             ('responseMessage', rmsg),
             ('success', 'true' if exc is None else 'false'),
+            ('bytes', response_length),
 
-            # NOTE: might be resource-consuming
+            # # NOTE: might be resource-consuming
+            ('grpThreads', runners.locust_runner.user_count if runners.locust_runner else 0),
             ('allThreads', runners.locust_runner.user_count if runners.locust_runner else 0),
-            ('Latency', 0),
+            ('Latency', 0)
         ])
 
     def __on_request_success(self, request_type, name, response_time, response_length):

--- a/site/dat/docs/changes/fix-kpi-jtl-column-order-locust-executor
+++ b/site/dat/docs/changes/fix-kpi-jtl-column-order-locust-executor
@@ -1,0 +1,1 @@
+fix column order in kpi.jtl file for locust executor

--- a/tests/modules/test_locustIOExecutor.py
+++ b/tests/modules/test_locustIOExecutor.py
@@ -299,7 +299,7 @@ class TestLocustIOExecutor(ExecutorTestCase):
                 jtl = fds.readlines()
 
             header_line = jtl[0].strip()
-            expected = "timeStamp,label,method,elapsed,bytes,responseCode,responseMessage,success,allThreads,Latency"
+            expected = "timeStamp,elapsed,label,responseCode,responseMessage,success,bytes,grpThreads,allThreads,Latency"
             self.assertEqual(header_line, expected)
 
     def test_jtl_quoting_issue(self):


### PR DESCRIPTION
Hello team! I have raised this pull request after an investigation of the results folder after locust executor run. 
At this moment headers of kpi.jtl file (locust executor) looks:
`timeStamp,label,method,elapsed,bytes,responseCode,responseMessage,success,allThreads,Latency`
kpi.jtl file is needed to create aggregated report using this command or similar:
`java -Djava.awt.headless=false -jar cmdrunner-2.2.jar --tool Reporter --generate-csv locust.csv --input-jtl 'kpi.jtl' --plugin-type AggregateReport`
And this command returns Java error, which said that order of columns in kpi.jtl input file is incorrect. After some investigation, I manually changed the order of columns and come up with the next one:
`timeStamp,elapsed,label,responseCode,responseMessage,success,bytes,grpThreads,allThreads,Latency`
I added grpThreads column - for locust executor is the same as allThreads, I was comparing it with jmeter executor.
These changes are not critical but it really helps customers to aggregate report from kpi.jtl without any custom scripts/wrappers. 
The order is similar to kpi.jtl after Jmeter executor.
Please let me know in case I missed something.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [x] Documentation update
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
