### PR TITLE
WAP-17684, make sure jmeter.log is not split due to a previous file

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -208,7 +208,12 @@ class JMeterExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInstall
         :raise TaurusConfigError:
         """
         super(JMeterExecutor, self).prepare()
-        self.jmeter_log = self.engine.create_artifact("jmeter", ".log")
+        log_name = os.path.join(self.engine.artifacts_dir, "jmeter.log")
+        if os.path.exists(log_name):
+            self.jmeter_log = log_name
+            self.engine.existing_artifact(self.jmeter_log, move=True)
+        else:
+            self.jmeter_log = self.engine.create_artifact("jmeter", ".log")
         self._set_remote_port()
         self.distributed_servers = self.execution.get('distributed', self.distributed_servers)
 

--- a/tests/modules/jmeter/test_JMeterExecutor.py
+++ b/tests/modules/jmeter/test_JMeterExecutor.py
@@ -2924,6 +2924,36 @@ class TestJMeterExecutor(ExecutorTestCase):
         self.assertIn("LOG ERROR: 2", diag_str)
         self.assertIn("LOG DEBUG: 3", diag_str)
 
+    def test_log_exists(self):
+        self.configure({
+            "execution": {
+                "iterations": 1,
+                "scenario": {
+                    "requests": [{
+                        "url": "http://blazedemo.com/"}]}}})
+        self.obj.prepare()
+        self.obj.env.set({'TEST_MODE': 'log'})
+        self.obj.env.set({'LOG_NAME': self.obj.jmeter_log})
+        self.obj.startup()
+        while not self.obj.check():
+            time.sleep(self.obj.engine.check_interval)
+        self.obj.prepare()
+        self.obj.env.set({'TEST_MODE': 'log'})
+        self.obj.env.set({'LOG_NAME': self.obj.jmeter_log})
+        self.obj.startup()
+        while not self.obj.check():
+            time.sleep(self.obj.engine.check_interval)
+        self.obj.shutdown()
+        self.obj.post_process()
+        expected_log_name = os.path.join(self.engine.artifacts_dir, "jmeter.log")
+        self.assertEquals(self.obj.jmeter_log, expected_log_name)
+        diagnostics = self.obj.get_error_diagnostics()
+        self.assertIsNotNone(diagnostics)
+        diag_str = "\n".join(diagnostics)
+        self.assertNotIn("LOG DEBUG: 1", diag_str)
+        self.assertIn("LOG ERROR: 2", diag_str)
+        self.assertIn("LOG DEBUG: 3", diag_str)
+
     def test_jmeter_version_comp(self):
         self.configure({
             "execution": {

--- a/tests/resources/jmeter/jmeter-fake.py
+++ b/tests/resources/jmeter/jmeter-fake.py
@@ -9,6 +9,10 @@ def get_mode():
     return os.environ.get("TEST_MODE")
 
 
+def get_log_name():
+    return os.environ.get("LOG_NAME", "jmeter.log")
+
+
 def get_artifacts_dir():
     return os.environ.get("TAURUS_ARTIFACTS_DIR", ".")
 
@@ -40,7 +44,7 @@ def files():
 def write_log():
     sys.stdout.write("STDOUT message\n")
     sys.stderr.write("STDERR message\n")
-    with open(os.path.join(get_artifacts_dir(), 'jmeter.log'), 'w') as fds:
+    with open(os.path.join(get_artifacts_dir(), get_log_name()), 'w') as fds:
         fds.write("LOG DEBUG: 1\n")
         fds.write("LOG ERROR: 2\n")
         fds.write("LOG DEBUG: 3\n")


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
