### PR TITLE
Log virtual_display.new_display_var after start()

### DIFF
--- a/bzt/modules/services.py
+++ b/bzt/modules/services.py
@@ -314,10 +314,12 @@ class VirtualDisplay(Service, Singletone):
             width = self.parameters.get("width", 1024)
             height = self.parameters.get("height", 768)
             self.virtual_display = Display(size=(width, height))
-            msg = "Starting virtual display[%s]: %s"
-            self.log.info(msg, self.virtual_display.size, self.virtual_display.new_display_var)
+            self.log.info("Trying to start virtual display...")
             self.virtual_display.start()
             VirtualDisplay.SHARED_VIRTUAL_DISPLAY = self.virtual_display
+
+            msg = "Started virtual display[%s]: %s"
+            self.log.info(msg, self.virtual_display.size, self.virtual_display.new_display_var)
 
             self.engine.shared_env.set({'DISPLAY': os.environ['DISPLAY']})   # backward compatibility
 


### PR DESCRIPTION
Looks like `self.virtual_display.new_display_var` appears after calling the `start()` method.
Updated logging to workaround this issue.