### PR TITLE
Add missing parameter to __on_request_failure locust event handler

### DIFF
--- a/bzt/resources/locustio-taurus-wrapper.py
+++ b/bzt/resources/locustio-taurus-wrapper.py
@@ -74,9 +74,9 @@ class LocustStarter(object):
         self.fhd.flush()
         self.__check_limits()
 
-    def __on_request_failure(self, request_type, name, response_time, exception):
+    def __on_request_failure(self, request_type, name, response_time, exception, response_length=0):
         self.num_requests -= 1
-        self.writer.writerow(self.__getrec(request_type, name, response_time, 0, exception))
+        self.writer.writerow(self.__getrec(request_type, name, response_time, response_length, exception))
         self.fhd.flush()
         self.__check_limits()
 

--- a/site/dat/docs/changes/locust-incorrect-errors-in-jtl.change
+++ b/site/dat/docs/changes/locust-incorrect-errors-in-jtl.change
@@ -1,0 +1,1 @@
+fixed issue with incorrect error description in kpi.jtl file after locust tests


### PR DESCRIPTION
Fixed issue with incorrect errors in kpi.jtl file after locust tests.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
