### PR TITLE
Fixed issue for assertDialog of type alert 

### DIFF
--- a/bzt/resources/selenium_extras.py
+++ b/bzt/resources/selenium_extras.py
@@ -186,7 +186,7 @@ def dialogs_get_next_alert():
     return _get_driver().execute_script("""
                 if (!window.__webdriverAlerts) { return null } 
                 var t = window.__webdriverAlerts.shift(); 
-                if (t) { t = t.replace(/\\n/g, ' '); }
+                if (t) { t = t.toString().replace(/\\n/g, ' '); }
                 return t;
               """)
 

--- a/site/dat/docs/changes/fix-assert-dialog-alert-boolean.change
+++ b/site/dat/docs/changes/fix-assert-dialog-alert-boolean.change
@@ -1,0 +1,2 @@
+Fixed issue for assertDialog of type alert when an alert is displayed with true of false values that were
+treated as booleans instead of as strings


### PR DESCRIPTION
when a browser alert is displayed with true of false values that were treated as booleans instead of as strings

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
