### PR TITLE
Fixed dialogs replacement issues

### DIFF
--- a/bzt/resources/selenium_extras.py
+++ b/bzt/resources/selenium_extras.py
@@ -205,6 +205,7 @@ def dialogs_answer_on_next_alert(value):
     """
     Simulates click on OK button in the next alert
     """
+    dialogs_replace()
     if str(value).lower() == '#ok':
         _get_driver().execute_script("window.__webdriverNextAlert = true")
 
@@ -214,6 +215,7 @@ def dialogs_answer_on_next_prompt(value):
     :param value: The value to be used to answer the next 'window.prompt', if '#cancel' is provided then
     click on cancel button is simulated by returning null
     """
+    dialogs_replace()
     if str(value).lower() == '#cancel':
         _get_driver().execute_script("window.__webdriverNextPrompt = null")
     else:
@@ -225,6 +227,7 @@ def dialogs_answer_on_next_confirm(value):
     :param value: either '#ok' to click on OK button or '#cancel' to simulate click on Cancel button in the
     next 'window.confirm' method
     """
+    dialogs_replace()
     if str(value).lower() == '#ok':
         confirm = 'true'
     else:

--- a/site/dat/docs/changes/fix-dialogs-replace-call.change
+++ b/site/dat/docs/changes/fix-dialogs-replace-call.change
@@ -1,0 +1,2 @@
+fix for issue that the window.alert, window.prompt and window.confirm methods may not be patched
+call the dialogs_replace also before answering the next dialog


### PR DESCRIPTION
fix for issue that the window.alert, window.prompt and window.confirm… methods may not be patched

* call the dialogs_replace also before answering the next dialog
* this may happen when the user navigates to a different page using clicking on links etc.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
