### PR TITLE
ckrams-default-overrides-wildcard-issue

### DIFF
--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,7 +493,11 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if key in obj:
+# pull request ckrams-patch-1
+# fix issues when during visting see non string valued key
+        if isinstance(obj, str) and key in obj:
+# end fix
+# end pull request changes for ckrams-patch-1
             obj[key] = replace_value
         return obj
 

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,7 +493,11 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if key in obj:
+# pull request ckrams-patch-3
+# fix issues when during visting see non string valued key
+        if isinstance(obj, str) and key in obj:
+# end fix
+# end pull request changes for ckrams-patch-3
             obj[key] = replace_value
         return obj
 

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,11 +493,7 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
-# pull request ckrams-patch-1
-# fix issues when during visting see non string valued key
-        if isinstance(obj, str) and key in obj:
-# end fix
-# end pull request changes for ckrams-patch-1
+        if key in obj:
             obj[key] = replace_value
         return obj
 

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -330,7 +330,9 @@ class TestConfigOverrider(BZTestCase):
     def test_override_multiple(self):
         self.config["items"] = [1, 2, 3]
         self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"lislis":[1,2,3,4],"k1":"v3"}
+        self.config["dict2"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"lislis":[1,2,3,4],"k1":"v3"}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
         self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'})
+        self.assertEqual(self.config.get("dict2"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [x] Documentation update
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
