### PR TITLE
Fix wildcard multiple parameter overrides issue with python 3.x

### DIFF
--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -490,9 +490,9 @@ class ConfigOverrider(object):
             for i in obj:
                 if isinstance(i, dict):
                     i = self.__apply_mult_override(i, key, replace_value)
-        if isinstance(obj, (list,dict)):            
+        if isinstance(obj, dict):            
             for k, v in obj.items():
-                if isinstance(v,dict):
+                if isinstance(v,(list,dict)):
                     obj[k] = self.__apply_mult_override(v, key, replace_value)
         if key in obj:
             obj[key] = replace_value

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -492,9 +492,8 @@ class ConfigOverrider(object):
                     i = self.__apply_mult_override(i, key, replace_value)
         if isinstance(obj, dict):            
             for k, v in obj.items():
-                if isinstance(v,(list,dict)):
-                    obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if key in obj:
+                 obj[k] = self.__apply_mult_override(v, key, replace_value)
+        if isinstance(obj,(list,dict)) and key in obj:
             obj[key] = replace_value
         return obj
 

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -495,6 +495,8 @@ class ConfigOverrider(object):
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
         if isinstance(obj,dict) and key in obj:
             obj[key] = replace_value
+        elif key in obj:
+            obj[key] = replace_value
         return obj
 
     def __apply_single_override(self, dest, name, value):

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -492,7 +492,7 @@ class ConfigOverrider(object):
                     i = self.__apply_mult_override(i, key, replace_value)
         if isinstance(obj, dict):            
             for k, v in obj.items():
-                if key in v:
+                if isinstance(v,dict) and key in v:
                     obj[k] = self.__apply_mult_override(v, key, replace_value)
         if key in obj:
             obj[key] = replace_value

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,7 +493,6 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
-
         if key in obj:
             obj[key] = replace_value
         return obj

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -492,10 +492,11 @@ class ConfigOverrider(object):
                     i = self.__apply_mult_override(i, key, replace_value)
         if isinstance(obj, dict):            
             for k, v in obj.items():
-                if isinstance(v,dict) and key in v:
-                    obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if key in obj:
+                obj[k] = self.__apply_mult_override(v, key, replace_value)
+        if isinstance(obj,dict) and key in obj:
             obj[key] = replace_value
+        elif key in obj:
+            obj[key] = replace_value 
         return obj
 
     def __apply_single_override(self, dest, name, value):

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -495,7 +495,7 @@ class ConfigOverrider(object):
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
         if isinstance(obj,dict) and key in obj:
             obj[key] = replace_value
-        elif key in obj:
+        elif isinstance(obj,list) and key in obj:
             obj[key] = replace_value 
         return obj
 

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,7 +493,7 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if isinstance(obj,(dict,list,tuple)) and key in obj:
+        if isinstance(obj,(dict,list,tuple,str)) and key in obj:
             obj[key] = replace_value
         return obj
 

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,9 +493,8 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if isinstance(obj,dict) and key in obj:
-            obj[key] = replace_value
-        elif key in obj:
+
+        if key in obj:
             obj[key] = replace_value
         return obj
 

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -492,8 +492,9 @@ class ConfigOverrider(object):
                     i = self.__apply_mult_override(i, key, replace_value)
         if isinstance(obj, dict):            
             for k, v in obj.items():
-                obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if isinstance(obj, dict) and key in obj:
+                if key in v:
+                    obj[k] = self.__apply_mult_override(v, key, replace_value)
+        if key in obj:
             obj[key] = replace_value
         return obj
 

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,7 +493,7 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if key in obj:
+        if isinstance(obj, dict) and key in obj:
             obj[key] = replace_value
         return obj
 

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -492,8 +492,9 @@ class ConfigOverrider(object):
                     i = self.__apply_mult_override(i, key, replace_value)
         if isinstance(obj, dict):            
             for k, v in obj.items():
-                obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if isinstance(obj,(dict,list,tuple)) and key in obj:
+                if isinstance(v,dict):
+                    obj[k] = self.__apply_mult_override(v, key, replace_value)
+        if key in obj:
             obj[key] = replace_value
         return obj
 

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,7 +493,7 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if isinstance(obj,(dict,list)) and key in obj:
+        if isinstance(obj,(dict,list,tuple)) and key in obj:
             obj[key] = replace_value
         return obj
 

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,7 +493,7 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if isinstance(obj,(dict,list,tuple,str)) and key in obj:
+        if isinstance(obj,(dict,list,tuple)) and key in obj:
             obj[key] = replace_value
         return obj
 

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -492,7 +492,7 @@ class ConfigOverrider(object):
                     i = self.__apply_mult_override(i, key, replace_value)
         if isinstance(obj, dict):            
             for k, v in obj.items():
-                 obj[k] = self.__apply_mult_override(v, key, replace_value)
+                obj[k] = self.__apply_mult_override(v, key, replace_value)
         if isinstance(obj, (list,dict,tuple)) and key in obj:
             obj[key] = replace_value
         return obj

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,7 +493,7 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                  obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if isinstance(obj,(list,dict,tuple)) and key in obj:
+        if isinstance(obj, (list,dict,tuple)) and key in obj:
             obj[key] = replace_value
         return obj
 

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,7 +493,7 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                  obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if isinstance(obj,(list,dict)) and key in obj:
+        if isinstance(obj,(list,dict,tuple)) and key in obj:
             obj[key] = replace_value
         return obj
 

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,7 +493,7 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if isinstance(obj, (list,dict,tuple)) and key in obj:
+        if isinstance(obj, (list,dict)) and key in obj:
             obj[key] = replace_value
         return obj
 

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -490,7 +490,7 @@ class ConfigOverrider(object):
             for i in obj:
                 if isinstance(i, dict):
                     i = self.__apply_mult_override(i, key, replace_value)
-        if isinstance(obj, dict):            
+        if isinstance(obj, (list,dict)):            
             for k, v in obj.items():
                 if isinstance(v,dict):
                     obj[k] = self.__apply_mult_override(v, key, replace_value)

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,10 +493,8 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if isinstance(obj,dict) and key in obj:
+        if isinstance(obj,(dict,list)) and key in obj:
             obj[key] = replace_value
-        elif isinstance(obj,list) and key in obj:
-            obj[key] = replace_value 
         return obj
 
     def __apply_single_override(self, dest, name, value):

--- a/tests/modules/test_consoleStatusReporter.py
+++ b/tests/modules/test_consoleStatusReporter.py
@@ -88,6 +88,7 @@ class TestConsoleStatusReporter(BZTestCase):
         obj.check()
         obj.shutdown()
         obj.post_process()
+        widget.update()
         self.assertNotIn('Failed', self.log_recorder.warn_buff.getvalue())
 
     def test_2(self):

--- a/tests/modules/test_consoleStatusReporter.py
+++ b/tests/modules/test_consoleStatusReporter.py
@@ -57,7 +57,6 @@ class TestConsoleStatusReporter(BZTestCase):
         widget = jmeter.get_widget()
         widget.update()
         jmeter.startup()
-        widget.finished=True
         widget.update()
         obj.engine.provisioning.executors = [jmeter]
         obj.settings["disable"] = False
@@ -105,7 +104,6 @@ class TestConsoleStatusReporter(BZTestCase):
         widget = jmeter.get_widget()
         widget.update()
         jmeter.startup()
-        widget.finished
         widget.update()
         obj.engine.provisioning.executors = [jmeter]
         obj.settings["disable"] = False

--- a/tests/modules/test_consoleStatusReporter.py
+++ b/tests/modules/test_consoleStatusReporter.py
@@ -57,6 +57,7 @@ class TestConsoleStatusReporter(BZTestCase):
         widget = jmeter.get_widget()
         widget.update()
         jmeter.startup()
+        widget.finished=True
         widget.update()
         obj.engine.provisioning.executors = [jmeter]
         obj.settings["disable"] = False
@@ -104,6 +105,7 @@ class TestConsoleStatusReporter(BZTestCase):
         widget = jmeter.get_widget()
         widget.update()
         jmeter.startup()
+        widget.finished
         widget.update()
         obj.engine.provisioning.executors = [jmeter]
         obj.settings["disable"] = False

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -328,7 +328,7 @@ class TestConfigOverrider(BZTestCase):
         self.assertEqual(self.config.get("dict"), {"1": 1, "3": 3})
 
     def test_override_multiple(self):
-        self.config["items"] = [1, 2, 3]
+        self.config["items"] = [1, 2, 3] 
         self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"lislis":[1,2,3,4],"k1":"v3"}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -329,9 +329,9 @@ class TestConfigOverrider(BZTestCase):
 
     def test_override_multiple(self):
         self.config["items"] = [1, 2, 3]
-        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}, {"scenario1.default-address":"k1"}, {"scenario2.default-address":"k2"}],"lislis":[1,2,3,4],"k1":"v3"}
+        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}, {"k4.default-address":"k1"}, {"k5.default-address":"k2"}],"lislis":[1,2,3,4],"k1":"v3"}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
         self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}, {'scenario1.default-address': 'foo.com'}, {'scenario2.default-address': 'foo.com'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'})
+        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}, {'k4.default-address': 'foo.com'}, {'k5.default-address': 'foo.com'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -333,6 +333,5 @@ class TestConfigOverrider(BZTestCase):
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
         self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'},,'mapObj':[{'scenario1.default-address':'foo.com','scenario2.default-address':
-        'foo.com'})
+        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'},,'mapObj':[{'scenario1.default-address': 'foo.com','scenario2.default-address': 'foo.com'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -329,11 +329,11 @@ class TestConfigOverrider(BZTestCase):
 
     def test_override_multiple(self):
         self.config["items"] = [1, 2, 3]
-        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}, {"k4.default-address":"k1"}, {"k5.default-address":"k2"}],"lislis":[1,2,3,4],"k1":"v3"}
+        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}, {"default-address":"k4"}],"lislis":[1,2,3,4],"k1":"v3","default-address":"k5"}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
-        self.obj.apply_overrides(['dict.*k4=foo.com'], self.config)
+        self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)
         print ("dict values after override:")
         print (self.config["dict"])
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}, {'k4.default-address': 'foo.com'}, {'k5.default-address': 'foo.com'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'})
+        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}, {'default-address': 'foo.com'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2','default-address': 'foo.com'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -332,5 +332,5 @@ class TestConfigOverrider(BZTestCase):
         self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"lislis":[1,2,3,4],"k1":"v3","test.k4":"v4"}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2', 'dict.*k4=test-wildcard-override'], self.config)
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2', "test.k4": "test-wildcard-override")
+        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2', 'test.k4': 'test-wildcard-override')
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -331,6 +331,7 @@ class TestConfigOverrider(BZTestCase):
         self.config["items"] = [1, 2, 3]
         self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"lislis":[1,2,3,4],"k1":"v3","test.k4":"v4"}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
-        self.obj.apply_overrides(['dict.*k1=v2', 'dict.*k4=test-wildcard-override'], self.config)
+        self.obj.apply_overrides(['dict.*k1=v2'], self.config) 
+        self.obj.apply_overrides(['dict.*k4=test-wildcard-override'], self.config)
         self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2', 'test.k4': 'test-wildcard-override')
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -328,7 +328,7 @@ class TestConfigOverrider(BZTestCase):
         self.assertEqual(self.config.get("dict"), {"1": 1, "3": 3})
 
     def test_override_multiple(self):
-        self.config["items"] = [1, 2, 3] 
+        self.config["items"] = [1, 2, 3]
         self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"lislis":[1,2,3,4],"k1":"v3"}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -333,5 +333,5 @@ class TestConfigOverrider(BZTestCase):
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
         self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'},,'mapObj':[{'scenario1.default-address': 'foo.com','scenario2.default-address': 'foo.com'}])
+        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'}, 'mapObj':[{'scenario1.default-address': 'foo.com'}, {'scenario2.default-address': 'foo.com'}])
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -329,8 +329,10 @@ class TestConfigOverrider(BZTestCase):
 
     def test_override_multiple(self):
         self.config["items"] = [1, 2, 3]
-        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"lislis":[1,2,3,4],"k1":"v3"}
+        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"lislis":[1,2,3,4],"k1":"v3","mapObj":[{"scenario1.default-address":"k1","scenario2.default-address":"k2"}]}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'})
+        self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)
+        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'},,'mapObj':[{'scenario1.default-address':'foo.com','scenario2.default-address':
+        'foo.com'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -333,5 +333,5 @@ class TestConfigOverrider(BZTestCase):
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config) 
         self.obj.apply_overrides(['dict.*k4=test-wildcard-override'], self.config)
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2', 'test.k4': 'test-wildcard-override')
+        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2', 'test.k4': 'test-wildcard-override'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -332,7 +332,7 @@ class TestConfigOverrider(BZTestCase):
         self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}, {"k4.default-address":"k1"}, {"k5.default-address":"k2"}],"lislis":[1,2,3,4],"k1":"v3"}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
-        self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)
+        self.obj.apply_overrides(['dict.*k4=foo.com'], self.config)
         print ("dict values after override:")
         print (self.config["dict"])
         self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}, {'k4.default-address': 'foo.com'}, {'k5.default-address': 'foo.com'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'})

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -333,6 +333,6 @@ class TestConfigOverrider(BZTestCase):
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
         self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)
-        print (self.config["dict"])
+        print ("dict values after override:"+ self.config["dict"])
         self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}, {'k4.default-address': 'foo.com'}, {'k5.default-address': 'foo.com'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -333,5 +333,6 @@ class TestConfigOverrider(BZTestCase):
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
         self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)
+        print dict
         self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}, {'k4.default-address': 'foo.com'}, {'k5.default-address': 'foo.com'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -329,9 +329,8 @@ class TestConfigOverrider(BZTestCase):
 
     def test_override_multiple(self):
         self.config["items"] = [1, 2, 3]
-        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"},{"k4":"v4"}],"lislis":[1,2,3,4],"k1":"v3","k4":"v4"}
+        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"lislis":[1,2,3,4],"k1":"v3"}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
-        self.obj.apply_overrides(['dict.*k1=v2'], self.config) 
-        self.obj.apply_overrides(['dict.*k4=test-wildcard-override'], self.config)
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'},{'k4':'test-wildcard-override'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2', 'k4': 'test-wildcard-override'})
+        self.obj.apply_overrides(['dict.*k1=v2'], self.config)
+        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -329,9 +329,9 @@ class TestConfigOverrider(BZTestCase):
 
     def test_override_multiple(self):
         self.config["items"] = [1, 2, 3]
-        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"mapObj":[{"scenario1.default-address":"k1"}, {"scenario2.default-address":"k2"}],"lislis":[1,2,3,4],"k1":"v3"}
+        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}, {"scenario1.default-address":"k1"}, {"scenario2.default-address":"k2"}],"lislis":[1,2,3,4],"k1":"v3"}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
         self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'mapObj': [{'scenario1.default-address': 'foo.com'}, {'scenario2.default-address': 'foo.com'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'})
+        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}, {'scenario1.default-address': 'foo.com'}, {'scenario2.default-address': 'foo.com'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -329,9 +329,9 @@ class TestConfigOverrider(BZTestCase):
 
     def test_override_multiple(self):
         self.config["items"] = [1, 2, 3]
-        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"},{"test":"v4"}],"lislis":[1,2,3,4],"k1":"v3","test":"v4"}
+        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"},{"k4":"v4"}],"lislis":[1,2,3,4],"k1":"v3","k4":"v4"}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config) 
-        self.obj.apply_overrides(['dict.*test=test-wildcard-override'], self.config)
+        self.obj.apply_overrides(['dict.*k4=test-wildcard-override'], self.config)
         self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'},{'test':'test-wildcard-override'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2', 'test': 'test-wildcard-override'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -333,5 +333,5 @@ class TestConfigOverrider(BZTestCase):
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config) 
         self.obj.apply_overrides(['dict.*k4=test-wildcard-override'], self.config)
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'},{'test':'test-wildcard-override'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2', 'test': 'test-wildcard-override'})
+        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'},{'k4':'test-wildcard-override'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2', 'k4': 'test-wildcard-override'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -329,9 +329,9 @@ class TestConfigOverrider(BZTestCase):
 
     def test_override_multiple(self):
         self.config["items"] = [1, 2, 3]
-        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}], "mapObj":[{"scenario1.default-address":"k1"},{"scenario2.default-address":"k2"}], "lislis":[1,2,3,4],"k1":"v3"}
+        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"mapObj":[{"scenario1.default-address":"k1"}, {"scenario2.default-address":"k2"}],"lislis":[1,2,3,4],"k1":"v3"}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
         self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'mapObj':[{'scenario1.default-address': 'foo.com'},{'scenario2.default-address': 'foo.com'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'})
+        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'mapObj': [{'scenario1.default-address': 'foo.com'}, {'scenario2.default-address': 'foo.com'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -333,6 +333,6 @@ class TestConfigOverrider(BZTestCase):
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
         self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)
-        print dict
+        print (dict)
         self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}, {'k4.default-address': 'foo.com'}, {'k5.default-address': 'foo.com'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -333,5 +333,5 @@ class TestConfigOverrider(BZTestCase):
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
         self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'},,'mapObj':[{'scenario1.default-address': 'foo.com','scenario2.default-address': 'foo.com'})
+        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'},,'mapObj':[{'scenario1.default-address': 'foo.com','scenario2.default-address': 'foo.com'}])
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -332,6 +332,6 @@ class TestConfigOverrider(BZTestCase):
         self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"lislis":[1,2,3,4],"k1":"v3","test.k4":"v4"}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config) 
-        self.obj.apply_overrides(['dict.*k4=test-wildcard-override'], self.config)
+        self.obj.apply_overrides(['dict.test.*k4=test-wildcard-override'], self.config)
         self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2', 'test.k4': 'test-wildcard-override'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -329,9 +329,9 @@ class TestConfigOverrider(BZTestCase):
 
     def test_override_multiple(self):
         self.config["items"] = [1, 2, 3]
-        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"},{"test.k4":"v4"}],"lislis":[1,2,3,4],"k1":"v3"}
+        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"},{"test":"v4"}],"lislis":[1,2,3,4],"k1":"v3","test":"v4"}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config) 
-        self.obj.apply_overrides(['dict.*test.k4=test-wildcard-override'], self.config)
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2', 'test.k4': 'test-wildcard-override'})
+        self.obj.apply_overrides(['dict.*test=test-wildcard-override'], self.config)
+        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'},{'test':'test-wildcard-override'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2', 'test': 'test-wildcard-override'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -333,5 +333,5 @@ class TestConfigOverrider(BZTestCase):
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
         self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'mapObj':[{'scenario1.default-address': 'foo.com'},{'scenario2.default-address': 'foo.com'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2')
+        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'mapObj':[{'scenario1.default-address': 'foo.com'},{'scenario2.default-address': 'foo.com'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'))
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -329,7 +329,7 @@ class TestConfigOverrider(BZTestCase):
 
     def test_override_multiple(self):
         self.config["items"] = [1, 2, 3]
-        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"lislis":[1,2,3,4],"k1":"v3","mapObj":[{"scenario1.default-address":"k1","scenario2.default-address":"k2"}]}
+        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"lislis":[1,2,3,4],"k1":"v3","mapObj":[{"scenario1.default-address":"k1"},{"scenario2.default-address":"k2"}]}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
         self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -328,10 +328,10 @@ class TestConfigOverrider(BZTestCase):
         self.assertEqual(self.config.get("dict"), {"1": 1, "3": 3})
 
     def test_override_multiple(self):
-        self.config["items"] = [1, 2, 3] 
-        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"lislis":[1,2,3,4],"k1":"v3","mapObj":[{"scenario1.default-address":"k1"},{"scenario2.default-address":"k2"}]}
+        self.config["items"] = [1, 2, 3]
+        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}], "mapObj":[{"scenario1.default-address":"k1"},{"scenario2.default-address":"k2"}], "lislis":[1,2,3,4],"k1":"v3"}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
         self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2', 'mapObj':[{'scenario1.default-address': 'foo.com'},{'scenario2.default-address': 'foo.com'}])
+        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'mapObj':[{'scenario1.default-address': 'foo.com'},{'scenario2.default-address': 'foo.com'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2')
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -333,6 +333,6 @@ class TestConfigOverrider(BZTestCase):
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
         self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)
-        print (dict)
+        print (self.config["dict"])
         self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}, {'k4.default-address': 'foo.com'}, {'k5.default-address': 'foo.com'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -333,7 +333,5 @@ class TestConfigOverrider(BZTestCase):
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
         self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)
-        print ("dict values after override:")
-        print (self.config["dict"])
         self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}, {'default-address': 'foo.com'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2','default-address': 'foo.com'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -333,6 +333,7 @@ class TestConfigOverrider(BZTestCase):
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
         self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)
-        print ("dict values after override:"+ self.config["dict"])
+        print ("dict values after override:")
+        print (self.config["dict"])
         self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}, {'k4.default-address': 'foo.com'}, {'k5.default-address': 'foo.com'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -332,5 +332,5 @@ class TestConfigOverrider(BZTestCase):
         self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"lislis":[1,2,3,4],"k1":"v3","test.k4":"v4"}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2', 'dict.*k4=test-wildcard-override'], self.config)
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'}, "test.k4": "test-wildcard-override")
+        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2', "test.k4": "test-wildcard-override")
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -329,7 +329,7 @@ class TestConfigOverrider(BZTestCase):
 
     def test_override_multiple(self):
         self.config["items"] = [1, 2, 3]
-        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}, {"default-address":"k4"}],"lislis":[1,2,3,4],"k1":"v3","default-address":"k5"}
+        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}, {"default-address":"v1"}],"lislis":[1,2,3,4],"k1":"v3","default-address":"v2"}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
         self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -329,9 +329,9 @@ class TestConfigOverrider(BZTestCase):
 
     def test_override_multiple(self):
         self.config["items"] = [1, 2, 3]
-        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"lislis":[1,2,3,4],"k1":"v3","test.k4":"v4"}
+        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"},{"test.k4":"v4"}],"lislis":[1,2,3,4],"k1":"v3"}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config) 
-        self.obj.apply_overrides(['dict.test.*k4=test-wildcard-override'], self.config)
+        self.obj.apply_overrides(['dict.*test.k4=test-wildcard-override'], self.config)
         self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2', 'test.k4': 'test-wildcard-override'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -329,8 +329,9 @@ class TestConfigOverrider(BZTestCase):
 
     def test_override_multiple(self):
         self.config["items"] = [1, 2, 3]
-        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"lislis":[1,2,3,4],"k1":"v3"}
+        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"lislis":[1,2,3,4],"k1":"v3","test.k4":"v4"}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'})
+        self.obj.apply_overrides(['dict.*k4=test-wildcard-override'], self.config)
+        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'}, {"test.k4":"test-wildcard-override"})
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -331,7 +331,6 @@ class TestConfigOverrider(BZTestCase):
         self.config["items"] = [1, 2, 3]
         self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"lislis":[1,2,3,4],"k1":"v3","test.k4":"v4"}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
-        self.obj.apply_overrides(['dict.*k1=v2'], self.config)
-        self.obj.apply_overrides(['dict.*k4=test-wildcard-override'], self.config)
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'}, {"test.k4":"test-wildcard-override"})
+        self.obj.apply_overrides(['dict.*k1=v2', 'dict.*k4=test-wildcard-override'], self.config)
+        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'}, "test.k4": "test-wildcard-override")
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -333,5 +333,5 @@ class TestConfigOverrider(BZTestCase):
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
         self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'}, 'mapObj':[{'scenario1.default-address': 'foo.com'}, {'scenario2.default-address': 'foo.com'}])
+        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2', 'mapObj':[{'scenario1.default-address': 'foo.com'},{'scenario2.default-address': 'foo.com'}])
         self.assertEqual(self.config.get("items"), [1, 2, 3])

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -328,7 +328,7 @@ class TestConfigOverrider(BZTestCase):
         self.assertEqual(self.config.get("dict"), {"1": 1, "3": 3})
 
     def test_override_multiple(self):
-        self.config["items"] = [1, 2, 3]
+        self.config["items"] = [1, 2, 3] 
         self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"lislis":[1,2,3,4],"k1":"v3","mapObj":[{"scenario1.default-address":"k1"},{"scenario2.default-address":"k2"}]}
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -333,5 +333,5 @@ class TestConfigOverrider(BZTestCase):
         self.obj.apply_overrides(['items.*1=v2'], self.config)
         self.obj.apply_overrides(['dict.*k1=v2'], self.config)
         self.obj.apply_overrides(['dict.*default-address=foo.com'], self.config)
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'mapObj':[{'scenario1.default-address': 'foo.com'},{'scenario2.default-address': 'foo.com'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'))
+        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'mapObj':[{'scenario1.default-address': 'foo.com'},{'scenario2.default-address': 'foo.com'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'})
         self.assertEqual(self.config.get("items"), [1, 2, 3])


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [x] Documentation update
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
