### PR TITLE
add ability to customize the classname of testcases on JUnit XML reports

### DIFF
--- a/site/dat/docs/changes/add-time-attribute-on-junit-xml-reports
+++ b/site/dat/docs/changes/add-time-attribute-on-junit-xml-reports
@@ -1,0 +1,1 @@
+Add "time" element on Junit XMLreports, whenever using sample-lables as data-source

--- a/site/dat/docs/changes/feat-new-classname-param-for-junit-xml-module
+++ b/site/dat/docs/changes/feat-new-classname-param-for-junit-xml-module
@@ -1,0 +1,1 @@
+Add support for new "classname" parameter on junit-xml module to customize testcase element on JUnit XML report


### PR DESCRIPTION
This PR implements the ability of customizing the classname attribute on the <testcase> elements generated by the "junit-xml" module.
This is allows users to have better control over these elements which can be used as unique identifiers in tools that process them. For example, a test management tool as shown in the following example using Xray:

https://confluence.xpand-it.com/display/XRAY/Load+testing+and+functional+testing+with+Taurus


The only doubt here is related with the logic on [this line:](https://github.com/bitcoder/taurus/blob/master/bzt/modules/reporting.py#L531) which I've simplified to just 

`
class_name = self.parameters.get("classname", "bzt")
`

I didn't fully understand the logic behind the get_bza_report_info(). So if previous logic has some valid reason and you have a suggestion on how to keep the previous behaviour and allow also the new one (where the user can enforce the classname attribute), please let me know. I'm no Python expert but maybe you can help adjusting the code.



The PR also implements the ability to include duration of testcase using the average response time, if using sample-labels, which is valuable information for performance testing.




Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
