### PR TITLE
Wild card override fix for python 3.x with TypeError: argument of type 'int' or 'bool' is not iterable

### DIFF
--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,7 +493,7 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if key in obj:
+        if isinstance(obj, (dict,list)) and key in obj:
             obj[key] = replace_value
         return obj
 

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,7 +493,7 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if isinstance(obj, (dict,list)) and key in obj:
+        if key in obj:
             obj[key] = replace_value
         return obj
 

--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,7 +493,7 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if isinstance(obj, (dict,list)) and key in obj:
+        if isinstance(obj, (list,dict)) and key in obj:
             obj[key] = replace_value
         return obj
 


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [X] Description of PR explains the context of change
- [X] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
