### PR TITLE
Do not create personal config file if no_system_configs is set

### DIFF
--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -156,15 +156,18 @@ class CLI(object):
 
         if self.options.no_system_configs is None:
             self.options.no_system_configs = False
-
-        bzt_rc = os.path.expanduser(os.path.join('~', ".bzt-rc"))
-        if os.path.exists(bzt_rc):
-            self.log.debug("Using personal config: %s" % bzt_rc)
+            
+        if not self.options.no_system_configs:
+            bzt_rc = os.path.expanduser(os.path.join('~', ".bzt-rc"))
+            if os.path.exists(bzt_rc):
+                self.log.debug("Using personal config: %s" % bzt_rc)
+            else:
+                self.log.debug("Adding personal config: %s", bzt_rc)
+                self.log.info("No personal config found, creating one at %s", bzt_rc)
+                shutil.copy(os.path.join(RESOURCES_DIR, 'base-bzt-rc.yml'), bzt_rc)
         else:
-            self.log.debug("Adding personal config: %s", bzt_rc)
-            self.log.info("No personal config found, creating one at %s", bzt_rc)
-            shutil.copy(os.path.join(RESOURCES_DIR, 'base-bzt-rc.yml'), bzt_rc)
-
+            self.log.info("No system configs option set, skipping creation of config files.")
+            
         merged_config = self.engine.configure([bzt_rc] + configs, not self.options.no_system_configs)
 
         # apply aliases


### PR DESCRIPTION
From the CLI Documentation you get the impression that `--no-system-configs` skips the configuration files. What is surprising then, is that bzt goes and creates the `~/.bzt_rc` file for you.

It stands to reason if you explicitly define bzt to skip system configs, it shouldn't create them for you. We're currently running into a situation where we run the bzt docker container as a non-root user where the home directory is read only, and bzt will refuse to continue until this file exists.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
