### PR TITLE
Fix/use buit-in dir

### DIFF
--- a/site/dat/docs/changes/fix-use-built-in-dir.change
+++ b/site/dat/docs/changes/fix-use-built-in-dir.change
@@ -1,0 +1,1 @@
+don't override built-in dir function

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,5 @@
 """ unit test """
 from tests.base import TEST_DIR, BUILD_DIR, RESOURCES_DIR, BASE_CONFIG, ROOT_LOGGER
-from tests.base import close_reader_file, local_paths_config, __dir__
+from tests.base import close_reader_file, local_paths_config, get_cwd
 from tests.cases import BZTestCase, ExecutorTestCase
 from tests.mocks import random_datapoint

--- a/tests/base.py
+++ b/tests/base.py
@@ -8,19 +8,19 @@ from bzt.utils import temp_file
 ROOT_LOGGER = logging.getLogger("")
 
 
-def _get_cwd():
+def get_cwd():
     filename = inspect.getouterframes(inspect.currentframe())[1][1]
     return os.path.dirname(filename)
 
 
 # execute tests regardless of working directory
-root_dir = _get_cwd() + '/../'
+root_dir = get_cwd() + '/../'
 os.chdir(root_dir)
 
-RESOURCES_DIR = os.path.join(_get_cwd(), 'resources') + os.path.sep
-BUILD_DIR = _get_cwd() + "/../build/tmp/"
-TEST_DIR = _get_cwd() + "/../build/test/"
-BASE_CONFIG = _get_cwd() + "/../bzt/resources/10-base-config.yml"
+RESOURCES_DIR = os.path.join(get_cwd(), 'resources') + os.path.sep
+BUILD_DIR = get_cwd() + "/../build/tmp/"
+TEST_DIR = get_cwd() + "/../build/test/"
+BASE_CONFIG = get_cwd() + "/../bzt/resources/10-base-config.yml"
 
 from bzt.cli import CLI
 from bzt.utils import EXE_SUFFIX, run_once

--- a/tests/base.py
+++ b/tests/base.py
@@ -8,19 +8,19 @@ from bzt.utils import temp_file
 ROOT_LOGGER = logging.getLogger("")
 
 
-def __dir__():
+def _get_cwd():
     filename = inspect.getouterframes(inspect.currentframe())[1][1]
     return os.path.dirname(filename)
 
 
 # execute tests regardless of working directory
-root_dir = __dir__() + '/../'
+root_dir = _get_cwd() + '/../'
 os.chdir(root_dir)
 
-RESOURCES_DIR = os.path.join(__dir__(), 'resources') + os.path.sep
-BUILD_DIR = __dir__() + "/../build/tmp/"
-TEST_DIR = __dir__() + "/../build/test/"
-BASE_CONFIG = __dir__() + "/../bzt/resources/10-base-config.yml"
+RESOURCES_DIR = os.path.join(_get_cwd(), 'resources') + os.path.sep
+BUILD_DIR = _get_cwd() + "/../build/tmp/"
+TEST_DIR = _get_cwd() + "/../build/test/"
+BASE_CONFIG = _get_cwd() + "/../bzt/resources/10-base-config.yml"
 
 from bzt.cli import CLI
 from bzt.utils import EXE_SUFFIX, run_once

--- a/tests/modules/test_Gatling.py
+++ b/tests/modules/test_Gatling.py
@@ -9,7 +9,7 @@ from bzt.modules.aggregator import DataPoint, KPISet
 from bzt.modules.gatling import GatlingExecutor, DataLogReader, is_gatling2
 from bzt.modules.provisioning import Local
 from bzt.utils import EXE_SUFFIX, get_full_path, is_windows
-from tests import ExecutorTestCase, BZTestCase, __dir__, RESOURCES_DIR, BUILD_DIR, close_reader_file, ROOT_LOGGER
+from tests import ExecutorTestCase, BZTestCase, get_cwd, RESOURCES_DIR, BUILD_DIR, close_reader_file, ROOT_LOGGER
 
 
 class TestGatlingExecutor(ExecutorTestCase):
@@ -452,7 +452,7 @@ class TestGatlingExecutor(ExecutorTestCase):
     def test_files_find_file(self):
         curdir = get_full_path(os.curdir)
         try:
-            os.chdir(__dir__() + "/../")
+            os.chdir(get_cwd() + "/../")
             self.obj.engine.file_search_paths.append(RESOURCES_DIR + "gatling/")
             self.obj.engine.config.merge({
                 "execution": {

--- a/tests/modules/test_services.py
+++ b/tests/modules/test_services.py
@@ -9,7 +9,7 @@ from bzt.engine import Service, Provisioning, EngineModule
 from bzt.modules.blazemeter import CloudProvisioning
 from bzt.modules.services import Unpacker, InstallChecker, AndroidEmulatorLoader, AppiumLoader
 from bzt.utils import get_files_recursive, EXE_SUFFIX, JavaVM, Node
-from tests import BZTestCase, __dir__, RESOURCES_DIR
+from tests import BZTestCase, get_cwd, RESOURCES_DIR
 from tests.mocks import EngineEmul, ModuleMock, BZMock
 
 
@@ -86,7 +86,7 @@ class TestZipFolder(BZTestCase):
         obj.parameters["files"] = ["java_package.zip"]
 
         # create archive and put it in artifact dir
-        source = __dir__() + "/../selenium/junit/java_package"
+        source = get_cwd() + "/../selenium/junit/java_package"
         zip_name = obj.engine.create_artifact('java_package', '.zip')
         with zipfile.ZipFile(zip_name, 'w') as zip_file:
             for filename in get_files_recursive(source):

--- a/tests/test_soapui2yaml.py
+++ b/tests/test_soapui2yaml.py
@@ -2,7 +2,7 @@ import yaml
 
 from bzt.soapui2yaml import SoapUI2YAML, process
 
-from tests import BZTestCase, __dir__, RESOURCES_DIR
+from tests import BZTestCase, get_cwd, RESOURCES_DIR
 from tests.mocks import EngineEmul
 
 
@@ -22,7 +22,7 @@ class TestConverter(BZTestCase):
         self.engine = EngineEmul()
 
     def _get_soapui2yaml(self, path, file_name=None, test_case=None):
-        return SoapUI2YAML(FakeOptions(file_name=file_name, test_case=test_case), __dir__() + path)
+        return SoapUI2YAML(FakeOptions(file_name=file_name, test_case=test_case), get_cwd() + path)
 
     def _get_tmp(self, prefix='test', suffix='.yml'):
         return self.engine.create_artifact(prefix, suffix)


### PR DESCRIPTION
don't override built-in _dir_ function

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
