### PR TITLE
Fix wildcard override

### DIFF
--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -493,8 +493,10 @@ class ConfigOverrider(object):
         if isinstance(obj, dict):            
             for k, v in obj.items():
                 obj[k] = self.__apply_mult_override(v, key, replace_value)
-        if key in obj:
+        if isinstance(obj, dict) and key in obj:
             obj[key] = replace_value
+        if isinstance(obj, list) and key in obj:
+            obj[obj.index(key)] = replace_value
         return obj
 
     def __apply_single_override(self, dest, name, value):

--- a/site/dat/docs/changes/fix-wildcard-bool-error.change
+++ b/site/dat/docs/changes/fix-wildcard-bool-error.change
@@ -1,0 +1,1 @@
+fix wildcard override

--- a/tests/test_CLI.py
+++ b/tests/test_CLI.py
@@ -200,7 +200,7 @@ class TestCLI(BZTestCase):
         self.verbose = False
         ret = self.get_ret_code([
             RESOURCES_DIR + "json/mock_normal.json",
-            ])
+        ])
         self.assertEquals(0, ret)
         log_lines = open(os.path.join(self.obj.engine.artifacts_dir, "bzt.log")).readlines()
         checking = False
@@ -328,9 +328,17 @@ class TestConfigOverrider(BZTestCase):
         self.assertEqual(self.config.get("dict"), {"1": 1, "3": 3})
 
     def test_override_multiple(self):
-        self.config["items"] = [1, 2, 3]
-        self.config["dict"] = {"listObj":[{"k1":"v1"}, {"k2":"v2"}, {"k3":"v3"}],"lislis":[1,2,3,4],"k1":"v3"}
-        self.obj.apply_overrides(['items.*1=v2'], self.config)
-        self.obj.apply_overrides(['dict.*k1=v2'], self.config)
-        self.assertEqual(self.config.get("dict"), {'listObj': [{'k1': 'v2'}, {'k2': 'v2'}, {'k3': 'v3'}], 'lislis': [1, 2, 3, 4], 'k1': 'v2'})
-        self.assertEqual(self.config.get("items"), [1, 2, 3])
+        self.config["vals_dict"] = {
+            "nums_list": ['one', 'two', 'three'],
+            "dicts_list": [{"k1": "v1"}, {"k2": "v2"}, {"k3": "v3"}],
+            "k1": "v1",
+            "bool_value": True}
+
+        self.obj.apply_overrides(['vals_dict.*one=zero'], self.config)
+        self.obj.apply_overrides(['vals_dict.*k1=v2'], self.config)
+
+        self.assertEqual(self.config.get("vals_dict"), {
+            "nums_list": ['zero', 'two', 'three'],
+            "dicts_list": [{"k1": "v2"}, {"k2": "v2"}, {"k3": "v3"}],
+            "k1": "v2",
+            "bool_value": True})


### PR DESCRIPTION
* fix error when bool in yaml block and the block is being overridden
* fix separate processing of lists and dicts
* upgrade test

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
