### PR TITLE
Gatling pass fail criteria fix

### DIFF
--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -1082,7 +1082,10 @@ def shutdown_process(process_obj, log_obj):
                         child_proc.send_signal(kill_signal)
                     os.kill(process_obj.pid, kill_signal)
             else:
-                os.killpg(os.getpgid(process_obj.pid), kill_signal)
+                if(os.getpgid(process_obj.pid) != 0)
+                    os.killpg(os.getpgid(process_obj.pid), kill_signal)
+                else
+                    os.killpg(process_obj.pid, kill_signal)
         except OSError as exc:
             log_obj.debug("Failed to terminate process: %s", exc)
 

--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -1082,7 +1082,7 @@ def shutdown_process(process_obj, log_obj):
                         child_proc.send_signal(kill_signal)
                     os.kill(process_obj.pid, kill_signal)
             else:
-                os.killpg(process_obj.pid, kill_signal)
+                os.killpg(os.getpgid(process_obj.pid), kill_signal)
         except OSError as exc:
             log_obj.debug("Failed to terminate process: %s", exc)
 

--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -1082,10 +1082,8 @@ def shutdown_process(process_obj, log_obj):
                         child_proc.send_signal(kill_signal)
                     os.kill(process_obj.pid, kill_signal)
             else:
-                if(os.getpgid(process_obj.pid) != 0)
-                    os.killpg(os.getpgid(process_obj.pid), kill_signal)
-                else
-                    os.killpg(process_obj.pid, kill_signal)
+                os.killpg(process_obj.pid, kill_signal)
+                os.killpg(os.getpgid(process_obj.pid), kill_signal)
         except OSError as exc:
             log_obj.debug("Failed to terminate process: %s", exc)
 

--- a/site/dat/docs/Changelog.md
+++ b/site/dat/docs/Changelog.md
@@ -29,7 +29,7 @@
 - fix dialog replace call
 - fix locust jtl errors
 - fix usage statistics order on gettaurus.org
-
+- fix pass fail criteria for gatling
 - improve docs:
     - describe artifact directory (folder for test results & logs)
     - describe custom python packages install process on Windows
@@ -48,7 +48,7 @@
 - fix `virtual display` doc
 - fix exit flow on windows
 - fix result files encoding
-- fix video link and https access on site
+- fix video link and https access on site 
 
 ## 1.14.1<sup> 12 Feb 2020</sup>
 - add alert windows handling to apiritif

--- a/site/dat/docs/changes/fix-gatling-pass-fail-criteria.change
+++ b/site/dat/docs/changes/fix-gatling-pass-fail-criteria.change
@@ -1,0 +1,1 @@
+Fixed gatling pass fail criteria as the SIGTERM wasn't able to shut down the process so have used the group id PID instead of PID to shut down the process.


### PR DESCRIPTION

Description: After criteria get failed for Gatling Taurus is not able to Terminate the process of Gatling.
The current fix is picking the process group process id instead of process Id making it to work successfully.
