### PR TITLE
US674966-avoid-of-dockerhub-autobuilds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,11 +14,11 @@ pipeline {
                     scmVars = checkout scm
                     commitHash = scmVars.GIT_COMMIT
                     tagName = sh(returnStdout: true, script: "git tag --points-at HEAD").trim()
-                    isTag = !tagName.isEmpty()
+                    isRelease = !tagName.isEmpty()
                     IMAGE_TAG = env.JOB_NAME + "." + env.BUILD_NUMBER
                     IMAGE_TAG = IMAGE_TAG.toLowerCase()
                     imageName = "blazemeter/taurus"
-                    extraImageTag = isTag ? "${imageName}:${tagName} -t ${imageName}:latest" : "${imageName}:unstable"
+                    extraImageTag = isRelease ? "${imageName}:${tagName} -t ${imageName}:latest" : "${imageName}:unstable"
                 }
             }
         }
@@ -50,7 +50,7 @@ pipeline {
                        sed -ri "s/OS: /Rev: ${commitHash}; OS: /" bzt/cli.py
                        """
 
-                    if (!isTag) {
+                    if (!isRelease) {
                         sh """
                            sed -ri "s/VERSION = .([^\\"]+)./VERSION = '\\1.${BUILD_NUMBER}'/" bzt/__init__.py
                            """
@@ -82,7 +82,7 @@ pipeline {
                            -u root \
                            -v /var/run/docker.sock:/var/run/docker.sock \
                            -v `pwd`:/bzt -t deploy-image \
-                           ${isTag}
+                           ${isRelease}
                           """
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         stage("Docker Image Build") {
             steps {
                 sh """
-                   docker build -t ${JOB_NAME} -t ${extraImageTag}.
+                   docker build -t ${JOB_NAME} -t ${extraImageTag} .
                    """
             }
         }

--- a/tests/ci/JobDsl_master.groovy
+++ b/tests/ci/JobDsl_master.groovy
@@ -4,7 +4,22 @@ pipelineJob('TAURUS-COMMUNITY-MASTER'){
         disableConcurrentBuilds()
     }
     triggers {
-        scm('*/5 * * * *')
+        genericTrigger {
+            genericVariables {
+                genericVariable {
+                    key("ref")
+                    value("\$.ref")
+                }
+                genericVariable {
+                    key("commit")
+                    value("\$.after")
+                }
+            }
+            causeString('job triggered with $ref, commit hash - $commit')
+            token('Q6QyWaD4rdY42Kqt')
+            regexpFilterText('$ref')
+            regexpFilterExpression('^(refs/heads/master|refs/tags/.+)$')
+        }
     }
     logRotator {
         daysToKeep(30)
@@ -12,8 +27,8 @@ pipelineJob('TAURUS-COMMUNITY-MASTER'){
     }
     definition {
         cpsScm {
-            scm{
-                git{
+            scm {
+                git {
                     remote {
                         url('http://github.com/Blazemeter/taurus.git')
                         branch('*/master')

--- a/tests/ci/JobDsl_stable.groovy
+++ b/tests/ci/JobDsl_stable.groovy
@@ -16,7 +16,7 @@ pipelineJob('TAURUS-COMMUNITY-STABLE'){
                 }
             }
             causeString('job triggered with $ref, commit hash - $commit')
-            token('Q6QyWaD4rdY42Kqt')
+            token('')
             regexpFilterText('$ref')
             regexpFilterExpression('^(refs/tags/.+)$')
         }


### PR DESCRIPTION
Taurus repo in settings --> webhooks contains webhook generic-webhook-trigger
This webhook triggers the Jenkins job TAURUS-COMMUNITY-MASTER based on push event - pushing a commit to any branch or pushing new tag. Described trigger options added to a file test/ci/JobDsl_master.groovy - "triggers" block.

Changes in Jenkinsfile:
1. Improved the logic of understanding the trigger event - commit to the master branch or pushing a new tag. Added command `git tag --points-at HEAD` which shows if the current commit has any tags.
2. Added extra tags option to a `docker build` command in order to have an image `blazemeter/taurus` ready for pushing to DockerHub.
3. Added `Docker Image Push` stage to push image to DockerHub if the previous stage `Integration Tests` passed.