### PR TITLE
return pg back

### DIFF
--- a/bzt/modules/gatling.py
+++ b/bzt/modules/gatling.py
@@ -422,7 +422,7 @@ class GatlingExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInstal
 
     def startup(self):
         self._set_env()
-        self.process = self._execute(self._get_cmdline(), pgrp=False)
+        self.process = self._execute(self._get_cmdline())
 
     def _get_cmdline(self):
         cmdline = [self.tool.tool_path]

--- a/site/dat/docs/changes/fix-gatling-launch.change
+++ b/site/dat/docs/changes/fix-gatling-launch.change
@@ -1,0 +1,1 @@
+return back gatling pg creation


### PR DESCRIPTION
looks like zinc is fixed and we can use process group again
it allows to stop all gatling processes (e.g. by passfail signal)

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
