### PR TITLE
support all browserNames for remote webdriver

### DIFF
--- a/bzt/modules/apiritif/generator.py
+++ b/bzt/modules/apiritif/generator.py
@@ -884,14 +884,12 @@ from selenium.webdriver.common.keys import Keys
         browser = self.capabilities.get("browserName", "")
         browser = self.scenario.get("browser", browser)
         browser = browser.lower()  # todo: whether we should take browser as is? (without lower case)
+        local_browsers = ["firefox", "chrome", "ie", "opera"] + mobile_browsers
 
         browser_platform = None
         if browser:
             browser_split = browser.split("-")
             browser = browser_split[0]
-            browsers = ["firefox", "chrome", "ie", "opera"] + mobile_browsers
-            if browser not in browsers:
-                raise TaurusConfigError("Unsupported browser name: %s" % browser)
             if len(browser_split) > 1:
                 browser_platform = browser_split[1]
 
@@ -911,7 +909,8 @@ from selenium.webdriver.common.keys import Keys
             browser = "remote"  # Force to use remote web driver
         elif not browser:
             browser = "firefox"
-
+        elif browser not in local_browsers:   # browser isn't supported
+            raise TaurusConfigError("Unsupported browser name: %s" % browser)
         return browser
 
     def _get_scenario_timeout(self):

--- a/site/dat/docs/support-remote-browsernames.change
+++ b/site/dat/docs/support-remote-browsernames.change
@@ -1,0 +1,1 @@
+support all browserNames for remote webdriver

--- a/tests/modules/selenium/test_selenium_builder.py
+++ b/tests/modules/selenium/test_selenium_builder.py
@@ -508,6 +508,42 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
         exp_file = RESOURCES_DIR + "selenium/generated_from_requests_remote.py"
         self.assertFilesEqual(exp_file, self.obj.script, python_files=True)
 
+    def test_build_script_remote_ie(self):
+        self.configure({
+            "execution": [{
+                "executor": "selenium",
+                "scenario": "loc_sc_remote"}],
+            "scenarios": {
+                "loc_sc_remote": {
+                    "remote": "http://user:key@remote_web_driver_host:port/wd/hub",
+                    "capabilities": {"browserName": "ie"},
+                    "requests": [{"url": "/"}]}}})
+
+        self.obj.prepare()
+        with open(self.obj.script) as script:
+            content = script.read()
+
+        sample = "desired_capabilities={'browserName': 'internet explorer'}"
+        self.assertIn(sample, content)
+
+    def test_build_script_remote_edge(self):
+        self.configure({
+            "execution": [{
+                "executor": "selenium",
+                "scenario": "loc_sc_remote"}],
+            "scenarios": {
+                "loc_sc_remote": {
+                    "remote": "http://user:key@remote_web_driver_host:port/wd/hub",
+                    "capabilities": {"browserName": "edge"},
+                    "requests": [{"url": "/"}]}}})
+
+        self.obj.prepare()
+        with open(self.obj.script) as script:
+            content = script.read()
+
+        sample = "desired_capabilities={'browserName': 'MicrosoftEdge'}"
+        self.assertIn(sample, content)
+
     def test_build_script_appium_browser(self):
         self.configure({
             "execution": [{

--- a/tests/modules/selenium/test_selenium_builder.py
+++ b/tests/modules/selenium/test_selenium_builder.py
@@ -508,7 +508,8 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
         exp_file = RESOURCES_DIR + "selenium/generated_from_requests_remote.py"
         self.assertFilesEqual(exp_file, self.obj.script, python_files=True)
 
-    def test_build_script_remote_ie(self):
+    def test_remote_without_browser_validation(self):
+        browser_name = "some strange browser"
         self.configure({
             "execution": [{
                 "executor": "selenium",
@@ -516,32 +517,14 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
             "scenarios": {
                 "loc_sc_remote": {
                     "remote": "http://user:key@remote_web_driver_host:port/wd/hub",
-                    "capabilities": {"browserName": "ie"},
+                    "capabilities": {"browserName": browser_name},
                     "requests": [{"url": "/"}]}}})
 
         self.obj.prepare()
         with open(self.obj.script) as script:
             content = script.read()
 
-        sample = "desired_capabilities={'browserName': 'internet explorer'}"
-        self.assertIn(sample, content)
-
-    def test_build_script_remote_edge(self):
-        self.configure({
-            "execution": [{
-                "executor": "selenium",
-                "scenario": "loc_sc_remote"}],
-            "scenarios": {
-                "loc_sc_remote": {
-                    "remote": "http://user:key@remote_web_driver_host:port/wd/hub",
-                    "capabilities": {"browserName": "edge"},
-                    "requests": [{"url": "/"}]}}})
-
-        self.obj.prepare()
-        with open(self.obj.script) as script:
-            content = script.read()
-
-        sample = "desired_capabilities={'browserName': 'MicrosoftEdge'}"
+        sample = "desired_capabilities={'browserName': '%s'}" % browser_name
         self.assertIn(sample, content)
 
     def test_build_script_appium_browser(self):


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
