### PR TITLE
Fixed switching windows by index, incl. auto switching

### DIFF
--- a/bzt/modules/apiritif/generator.py
+++ b/bzt/modules/apiritif/generator.py
@@ -110,6 +110,7 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
+from collections import OrderedDict
 """
 
     BY_TAGS = ("byName", "byID", "byCSS", "byXPath", "byLinkText", "byElement", "byShadow")
@@ -364,9 +365,12 @@ from selenium.webdriver.common.keys import Keys
                 func=ast_attr("self.driver.maximize_window"),
                 args=args))
         elif atype == "open":
+            method = "open_window"
+            self.selenium_extras.add(method)
             elements.append(ast_call(
-                func=ast_attr("self.driver.execute_script"),
-                args=[self._gen_expr("window.open('%s');" % param)]))
+                func=ast_attr(method),
+                args=[ast.Str(param, kind="")]
+            ))
         elif atype == "close":
             method = "close_window"
             self.selenium_extras.add(method)
@@ -537,6 +541,10 @@ from selenium.webdriver.common.keys import Keys
                         self._gen_dynamic_locator("var_loc_keys", selectors),
                         action)),
                 args=args))
+            if atype == "click":
+                method = "check_opened_new_window"
+                self.selenium_extras.add(method)
+                elements.append(ast_call(func=ast_attr(method)))
         return elements
 
     def _gen_edit_mngr(self, param, locators):
@@ -641,6 +649,14 @@ from selenium.webdriver.common.keys import Keys
 
         return elements
 
+    def _go_to_url(self, url):
+        method = "go"
+        self.selenium_extras.add(method)
+        return [ast_call(
+            func=ast_attr(method),
+            args=[self._gen_expr(url.strip())]
+        )]
+
     def _gen_select_mngr(self, param, selectors):
         elements = [self._gen_get_locator_call("var_loc_select", selectors), ast_call(
             func=ast_attr(
@@ -693,9 +709,7 @@ from selenium.webdriver.common.keys import Keys
             action_elements.append(ast.parse(param))
         elif atype == 'go':
             if param:
-                action_elements.append(ast_call(func=ast_attr("self.driver.get"),
-                                                args=[self._gen_expr(param.strip())]))
-                action_elements.append(self._gen_replace_dialogs())
+                action_elements.append(self._go_to_url(param))
         elif atype == "editcontent":
             action_elements.extend(self._gen_edit_mngr(param, selectors))
         elif atype.startswith('wait'):
@@ -799,18 +813,6 @@ from selenium.webdriver.common.keys import Keys
             args=[ast.Name(id='dialog'), ast.Str(value, kind=""), ast.Str("Dialog message didn't match", kind="")]))
 
         return elements
-
-    def _gen_replace_dialogs(self):
-        """
-        Generates the call to DialogsManager to replace dialogs
-        """
-        method = "dialogs_replace"
-        self.selenium_extras.add(method)
-        return [
-            gen_empty_line_stmt(),
-            ast_call(
-                func=ast_attr(method))
-        ]
 
     @staticmethod
     def _convert_to_number(arg):
@@ -1219,7 +1221,7 @@ from selenium.webdriver.common.keys import Keys
         if target_init:
             if self.test_mode == "selenium":
                 stored_vars["driver"] = "self.driver"
-                stored_vars["windows"] = "{}"
+                stored_vars["windows"] = "OrderedDict()"
 
         has_ds = bool(list(self.scenario.get_data_sources()))
         stored_vars['scenario_name'] = [ast.Str(self.label, kind="")]
@@ -1473,13 +1475,8 @@ from selenium.webdriver.common.keys import Keys
                     url = default_address + req.url
                 else:
                     url = req.url
-
-                lines.append(ast.Expr(
-                    ast_call(
-                        func=ast_attr("self.driver.get"),
-                        args=[self._gen_expr(url)])))
-                lines.append(self._gen_replace_dialogs())
-
+                lines.append(gen_empty_line_stmt())
+                lines.append(self._go_to_url(url))
             else:
                 method = req.method.lower()
                 named_args = self._extract_named_args(req)

--- a/site/dat/docs/Apiritif.md
+++ b/site/dat/docs/Apiritif.md
@@ -819,10 +819,6 @@ These actions require a value parameter, the possible values are:
   - `win\_ser\_local`: Go to the initial window.
   - `no value`: When no value is assigned, it means that the selection action is assigned over the last created window, and if the close action is used, it will also be over the last one created.
 
-Note: When any action command opens a new window (like click on a link with target window assigned), 
-the action of selecting the window must always be declared, otherwise the actions executed by the execution 
-will be performed on the default window or the last one used with `switchWindow` command.
-
 Or using the [alternative syntax](#Alternative-syntax-supporting-multiple-locators):
 ```yaml
 - type: switchWindow

--- a/site/dat/docs/changes/fix-switch-windows.change
+++ b/site/dat/docs/changes/fix-switch-windows.change
@@ -1,0 +1,1 @@
+fixed switching windows by index, includes fix to automatically switch windows when a new one opens

--- a/tests/modules/selenium/test_selenium_builder.py
+++ b/tests/modules/selenium/test_selenium_builder.py
@@ -88,7 +88,7 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
 
         target_lines = [
             "switch_window('0')",
-            """self.driver.execute_script("window.open('some.url');")""",
+            "open_window('some.url')",
             "close_window()",
             "close_window('win_ser_local')",
             "switch_frame('index=1')",
@@ -115,7 +115,7 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
             "for i in range(10):",
             "if ((i % 2) == 0):",
             print_i,
-            "self.driver.get('http:\\\\blazemeter.com')",
+            "go('http:\\\\blazemeter.com')",
             "ifself.driver.find_element(var_edit_content[0], var_edit_content[1])."
             "get_attribute('contenteditable'):"
             "self.driver.execute_script((\"arguments[0].innerHTML=\'%s\';\"%\'lo-la-lu\'),"
@@ -764,7 +764,7 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
 
         target_lines = [
             "with apiritif.smart_transaction('http://blazedemo.com/测试')",
-            "self.driver.get('http://blazedemo.com/测试')"
+            "go('http://blazedemo.com/测试')"
         ]
 
         for idx in range(len(target_lines)):

--- a/tests/modules/selenium/test_selenium_executor.py
+++ b/tests/modules/selenium/test_selenium_executor.py
@@ -399,7 +399,7 @@ class TestSeleniumStuff(SeleniumTestCase):
         self.obj.prepare()
         with open(os.path.join(self.obj.engine.artifacts_dir, os.path.basename(self.obj.script))) as fds:
             script = fds.read()
-        urls = re.findall(r"\.get\('(.+)'\)", script)
+        urls = re.findall(r"go\('(.+)'\)", script)
         self.assertEqual("http://blazedemo.com/", urls[0])
         self.assertEqual("http://absolute.address.com/somepage", urls[1])
         self.assertEqual("http://blazedemo.com/reserve.php", urls[2])

--- a/tests/resources/selenium/external_logging.py
+++ b/tests/resources/selenium/external_logging.py
@@ -19,8 +19,8 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import add_logging_handlers, get_locator, dialogs_replace
-
+from collections import OrderedDict
+from bzt.resources.selenium_extras import go, get_locator, add_logging_handlers
 
 class TestSample(unittest.TestCase):
 
@@ -35,15 +35,14 @@ class TestSample(unittest.TestCase):
         self.driver = webdriver.Chrome(service_log_path='/somewhere/webdriver.log', options=options)
         self.driver.implicitly_wait(timeout)
         add_logging_handlers()
-        apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows={},
+        apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows=OrderedDict(),
                                        scenario_name='sample')
+
 
     def _1_Test(self):
         with apiritif.smart_transaction('Test'):
             apiritif.external_log('start: go(http://blazedemo.com/)')
-            self.driver.get('http://blazedemo.com/')
-
-            dialogs_replace()
+            go('http://blazedemo.com/')
             apiritif.external_log('end: go(http://blazedemo.com/)')
             apiritif.external_log('start: log(leaving blazedemo)')
             apiritif.external_log('leaving blazedemo')

--- a/tests/resources/selenium/generated_from_requests.py
+++ b/tests/resources/selenium/generated_from_requests.py
@@ -19,10 +19,8 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import dialogs_get_next_alert, switch_window, switch_frame, dialogs_replace, \
-    dialogs_answer_on_next_alert, dialogs_get_next_confirm, dialogs_get_next_prompt, wait_for, get_locator, \
-    dialogs_answer_on_next_confirm, dialogs_answer_on_next_prompt, close_window
-
+from collections import OrderedDict
+from bzt.resources.selenium_extras import dialogs_get_next_alert, dialogs_answer_on_next_confirm, switch_window, close_window, get_locator, dialogs_get_next_confirm, open_window, check_opened_new_window, dialogs_get_next_prompt, go, dialogs_answer_on_next_alert, switch_frame, dialogs_answer_on_next_prompt, wait_for
 reader_1 = apiritif.CSVReaderPerThread('first.csv', loop=True)
 reader_2 = apiritif.CSVReaderPerThread('second.csv', loop=False)
 
@@ -44,13 +42,13 @@ class TestLocSc(unittest.TestCase):
         profile.set_preference('webdriver.log.file', '/somewhere/webdriver.log')
         self.driver = webdriver.Firefox(profile, options=options)
         self.driver.implicitly_wait(timeout)
-        apiritif.put_into_thread_store(timeout=timeout, data_sources=True, func_mode=True, scenario_name='loc_sc',
-                                       windows={}, driver=self.driver)
+        apiritif.put_into_thread_store(timeout=timeout, func_mode=True, driver=self.driver, windows=OrderedDict(),
+                                       scenario_name='loc_sc', data_sources=True)
+
 
     def _1_(self):
         with apiritif.smart_transaction('/'):
-            self.driver.get('http://blazedemo.com/')
-            dialogs_replace()
+            go('http://blazedemo.com/')
             wait_for('present', [{'xpath': "//input[@type='submit']"}], 3.5)
             wait_for('present', [{'xpath': "//input[@name='test,name']"}], 80.0)
             self.assertEqual(self.driver.title, 'BlazeDemo')
@@ -126,13 +124,15 @@ class TestLocSc(unittest.TestCase):
             self.driver.find_element(
                 var_loc_keys[0],
                 var_loc_keys[1]).click()
+            check_opened_new_window()
 
             var_loc_keys = get_locator([{'xpath': '//div[3]/form/select[2]//option[6]'}])
             self.driver.find_element(
                 var_loc_keys[0],
                 var_loc_keys[1]).click()
+            check_opened_new_window()
             switch_window('0')
-            self.driver.execute_script("window.open('some.url');")
+            open_window('some.url')
             switch_window('win_ser_local')
             switch_window('win_ser_1')
             switch_window('that_window')
@@ -186,6 +186,7 @@ class TestLocSc(unittest.TestCase):
             self.driver.find_element(
                 var_loc_keys[0],
                 var_loc_keys[1]).click()
+            check_opened_new_window()
 
             self.vars['Title'] = self.driver.title
 
@@ -205,9 +206,7 @@ class TestLocSc(unittest.TestCase):
 
             self.vars['var_eval'] = self.driver.execute_script('return 0 == false;')
             self.assertTrue(self.driver.execute_script('return 10 === 2*5;'), '10 === 2*5')
-            self.driver.get('http:\\blazemeter.com')
-
-            dialogs_replace()
+            go('http:\\blazemeter.com')
 
             dialog = dialogs_get_next_alert()
             self.assertIsNotNone(dialog, 'No dialog of type alert appeared')

--- a/tests/resources/selenium/generated_from_requests_appium_browser.py
+++ b/tests/resources/selenium/generated_from_requests_appium_browser.py
@@ -19,8 +19,8 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import wait_for, get_locator, dialogs_replace
-
+from collections import OrderedDict
+from bzt.resources.selenium_extras import wait_for, go, get_locator
 
 class TestLocScAppium(unittest.TestCase):
 
@@ -35,13 +35,13 @@ class TestLocScAppium(unittest.TestCase):
                                                              'platformName': 'android'},
                                        options=options)
         self.driver.implicitly_wait(timeout)
-        apiritif.put_into_thread_store(scenario_name='loc_sc_appium', timeout=timeout, driver=self.driver, windows={},
-                                       func_mode=False)
+        apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows=OrderedDict(),
+                                       scenario_name='loc_sc_appium')
+
 
     def _1_(self):
         with apiritif.smart_transaction('/'):
-            self.driver.get('http://blazedemo.com/')
-            dialogs_replace()
+            go('http://blazedemo.com/')
             wait_for('present', [{'xpath': "//input[@type='submit']"}], 3.5)
             self.assertEqual(self.driver.title, 'BlazeDemo')
             body = self.driver.page_source

--- a/tests/resources/selenium/generated_from_requests_flow_markers.py
+++ b/tests/resources/selenium/generated_from_requests_flow_markers.py
@@ -19,8 +19,8 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import dialogs_replace, get_locator, wait_for, add_flow_markers
-
+from collections import OrderedDict
+from bzt.resources.selenium_extras import add_flow_markers, go, get_locator, wait_for
 
 class TestLocSc(unittest.TestCase):
 
@@ -37,13 +37,13 @@ class TestLocSc(unittest.TestCase):
             options=options)
         self.driver.implicitly_wait(timeout)
         add_flow_markers()
-        apiritif.put_into_thread_store(driver=self.driver, scenario_name='loc_sc', timeout=timeout, windows={},
-                                       func_mode=False)
+        apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows=OrderedDict(),
+                                       scenario_name='loc_sc')
+
 
     def _1_(self):
         with apiritif.smart_transaction('/'):
-            self.driver.get('http://blazedemo.com/')
-            dialogs_replace()
+            go('http://blazedemo.com/')
             wait_for('present', [{'xpath': "//input[@type='submit']"}], 3.5)
             self.assertEqual(self.driver.title, 'BlazeDemo')
             body = self.driver.page_source

--- a/tests/resources/selenium/generated_from_requests_foreach.py
+++ b/tests/resources/selenium/generated_from_requests_foreach.py
@@ -19,8 +19,8 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import get_elements, get_locator
-
+from collections import OrderedDict
+from bzt.resources.selenium_extras import get_elements, check_opened_new_window, get_locator
 
 class TestLocSc(unittest.TestCase):
 
@@ -36,8 +36,9 @@ class TestLocSc(unittest.TestCase):
             service_log_path='/somewhere/webdriver.log',
             options=options)
         self.driver.implicitly_wait(timeout)
-        apiritif.put_into_thread_store(driver=self.driver, timeout=timeout, func_mode=False, windows={},
+        apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows=OrderedDict(),
                                        scenario_name='loc_sc')
+
 
     def _1_Foreach_test(self):
         with apiritif.smart_transaction('Foreach test'):
@@ -56,22 +57,20 @@ class TestLocSc(unittest.TestCase):
                 if el.get_attribute('contenteditable'):
                     self.driver.execute_script(("arguments[0].innerHTML = '%s';" % 'new text'), el)
                 else:
-                    raise NoSuchElementException((
-                                                             "The element '%s' (tag name: '%s', text: '%s') is not a contenteditable element" % (
-                                                     'el', el.tag_name, el.text)))
+                    raise NoSuchElementException(("The element '%s' (tag name: '%s', text: '%s') is not a contenteditable element" % ('el', el.tag_name, el.text)))
 
                 if el.get_attribute('contenteditable'):
                     self.driver.execute_script(("arguments[0].innerHTML = '%s';" % 'new text'), el)
                 else:
-                    raise NoSuchElementException((
-                                                             "The element '%s' (tag name: '%s', text: '%s') is not a contenteditable element" % (
-                                                     'el', el.tag_name, el.text)))
+                    raise NoSuchElementException(("The element '%s' (tag name: '%s', text: '%s') is not a contenteditable element" % ('el', el.tag_name, el.text)))
                 el.click()
+                check_opened_new_window()
 
                 var_loc_keys = get_locator([{'css': 'input-cls'}, {'xpath': '//input'}], el)
                 el.find_element(
                     var_loc_keys[0],
                     var_loc_keys[1]).click()
+                check_opened_new_window()
                 ActionChains(self.driver).double_click(el).perform()
                 ActionChains(self.driver).double_click(el).perform()
                 ActionChains(self.driver).click_and_hold(el).perform()

--- a/tests/resources/selenium/generated_from_requests_if_then_else.py
+++ b/tests/resources/selenium/generated_from_requests_if_then_else.py
@@ -19,8 +19,8 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import get_locator, dialogs_replace
-
+from collections import OrderedDict
+from bzt.resources.selenium_extras import check_opened_new_window, go, get_locator
 
 class TestLocSc(unittest.TestCase):
 
@@ -36,14 +36,13 @@ class TestLocSc(unittest.TestCase):
             service_log_path='/somewhere/webdriver.log',
             options=options)
         self.driver.implicitly_wait(timeout)
-        apiritif.put_into_thread_store(scenario_name='loc_sc', timeout=timeout, func_mode=False, windows={},
-                                       driver=self.driver)
+        apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows=OrderedDict(),
+                                       scenario_name='loc_sc')
+
 
     def _1_Conditions_test(self):
         with apiritif.smart_transaction('Conditions test'):
-            self.driver.get('http://blazedemo.com')
-
-            dialogs_replace()
+            go('http://blazedemo.com')
 
             test = self.driver.execute_script('return document.getElementsByName("fromPort")[0].length > 0;')
             if test:
@@ -52,6 +51,7 @@ class TestLocSc(unittest.TestCase):
                 self.driver.find_element(
                     var_loc_keys[0],
                     var_loc_keys[1]).click()
+                check_opened_new_window()
                 sleep(1.0)
 
                 test = self.driver.execute_script('return document.getElementsByClassName("table")[0].rows.length > 5;')
@@ -61,9 +61,9 @@ class TestLocSc(unittest.TestCase):
                     self.driver.find_element(
                         var_loc_keys[0],
                         var_loc_keys[1]).click()
+                    check_opened_new_window()
 
-                    test = self.driver.execute_script(
-                        'return document.getElementById("{}").value === \'\';'.format(self.vars['input_name_id']))
+                    test = self.driver.execute_script('return document.getElementById("{}").value === \'\';'.format(self.vars['input_name_id']))
                     if test:
 
                         var_loc_keys = get_locator([{'id': self.vars['input_name_id']}])
@@ -87,6 +87,7 @@ class TestLocSc(unittest.TestCase):
                     self.driver.find_element(
                         var_loc_keys[0],
                         var_loc_keys[1]).click()
+                    check_opened_new_window()
                     sleep(5.0)
             else:
 
@@ -112,6 +113,7 @@ class TestLocSc(unittest.TestCase):
                     self.driver.find_element(
                         var_loc_keys[0],
                         var_loc_keys[1]).click()
+                    check_opened_new_window()
 
     def test_locsc(self):
         self._1_Conditions_test()

--- a/tests/resources/selenium/generated_from_requests_loop_variables.py
+++ b/tests/resources/selenium/generated_from_requests_loop_variables.py
@@ -19,8 +19,8 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import get_loop_range, get_locator
-
+from collections import OrderedDict
+from bzt.resources.selenium_extras import check_opened_new_window, get_loop_range, get_locator
 
 class TestLocSc(unittest.TestCase):
 
@@ -35,11 +35,13 @@ class TestLocSc(unittest.TestCase):
         profile.set_preference('webdriver.log.file', '/somewhere/webdriver.log')
         self.driver = webdriver.Firefox(profile, options=options)
         self.driver.implicitly_wait(timeout)
-        apiritif.put_into_thread_store(timeout=timeout, func_mode=False, scenario_name='loc_sc', windows={},
-                                       driver=self.driver)
+        apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows=OrderedDict(),
+                                       scenario_name='loc_sc')
+
 
     def _1_None(self):
         with apiritif.smart_transaction('None'):
+
             for i in get_loop_range(self.vars['start'], self.vars['end'], self.vars['step']):
                 self.vars['i'] = str(i)
 
@@ -47,6 +49,7 @@ class TestLocSc(unittest.TestCase):
                 self.driver.find_element(
                     var_loc_keys[0],
                     var_loc_keys[1]).click()
+                check_opened_new_window()
 
     def test_locsc(self):
         self._1_None()

--- a/tests/resources/selenium/generated_from_requests_remote.py
+++ b/tests/resources/selenium/generated_from_requests_remote.py
@@ -19,8 +19,8 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import dialogs_replace, get_locator, wait_for, add_flow_markers
-
+from collections import OrderedDict
+from bzt.resources.selenium_extras import wait_for, add_flow_markers, go, get_locator
 
 class TestLocScRemote(unittest.TestCase):
 
@@ -39,13 +39,13 @@ class TestLocScRemote(unittest.TestCase):
                                        options=options)
         self.driver.implicitly_wait(timeout)
         add_flow_markers()
-        apiritif.put_into_thread_store(driver=self.driver, scenario_name='loc_sc_remote', timeout=timeout, windows={},
-                                       func_mode=False)
+        apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows=OrderedDict(),
+                                       scenario_name='loc_sc_remote')
+
 
     def _1_(self):
         with apiritif.smart_transaction('/'):
-            self.driver.get('http://blazedemo.com/')
-            dialogs_replace()
+            go('http://blazedemo.com/')
             wait_for('present', [{'xpath': "//input[@type='submit']"}], 3.5)
             self.assertEqual(self.driver.title, 'BlazeDemo')
             body = self.driver.page_source

--- a/tests/resources/selenium/generated_from_requests_shadow.py
+++ b/tests/resources/selenium/generated_from_requests_shadow.py
@@ -19,7 +19,8 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import find_element_by_shadow, get_locator
+from collections import OrderedDict
+from bzt.resources.selenium_extras import find_element_by_shadow, check_opened_new_window, get_locator
 
 class TestLocSc(unittest.TestCase):
 
@@ -33,7 +34,8 @@ class TestLocSc(unittest.TestCase):
         options.add_argument('--disable-dev-shm-usage')
         self.driver = webdriver.Chrome(service_log_path='/somewhere/webdriver.log', options=options)
         self.driver.implicitly_wait(timeout)
-        apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows={}, scenario_name='loc_sc')
+        apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows=OrderedDict(),
+                                       scenario_name='loc_sc')
 
 
     def _1_Shadow_locators_test(self):
@@ -60,8 +62,10 @@ class TestLocSc(unittest.TestCase):
                 raise NoSuchElementException(("The element (shadow: '%s') is not a contenteditable element" % ('c-basic, lightning-accordion-section, .slds-button',)))
 
             find_element_by_shadow('c-basic, lightning-accordion-section, .slds-button').click()
+            check_opened_new_window()
 
             find_element_by_shadow('c-basic, lightning-accordion-section, .slds-button').click()
+            check_opened_new_window()
 
             ActionChains(self.driver).double_click(find_element_by_shadow('c-basic, lightning-accordion-section, .slds-button')).perform()
 

--- a/tests/resources/selenium/generated_from_requests_v2.py
+++ b/tests/resources/selenium/generated_from_requests_v2.py
@@ -19,10 +19,8 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import close_window, dialogs_answer_on_next_alert, dialogs_get_next_alert, \
-    dialogs_get_next_confirm, switch_window, wait_for, dialogs_get_next_prompt, get_locator, switch_frame, \
-    dialogs_answer_on_next_confirm, dialogs_answer_on_next_prompt, dialogs_replace
-
+from collections import OrderedDict
+from bzt.resources.selenium_extras import dialogs_get_next_alert, dialogs_answer_on_next_confirm, switch_window, close_window, get_locator, dialogs_answer_on_next_alert, open_window, check_opened_new_window, dialogs_get_next_confirm, go, dialogs_get_next_prompt, switch_frame, dialogs_answer_on_next_prompt, wait_for
 
 class TestLocSc(unittest.TestCase):
 
@@ -37,14 +35,13 @@ class TestLocSc(unittest.TestCase):
         profile.set_preference('webdriver.log.file', '/somewhere/webdriver.log')
         self.driver = webdriver.Firefox(profile, options=options)
         self.driver.implicitly_wait(timeout)
-        apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows={},
+        apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows=OrderedDict(),
                                        scenario_name='loc_sc')
+
 
     def _1_Test_V2(self):
         with apiritif.smart_transaction('Test V2'):
-            self.driver.get('http://blazedemo.com')
-
-            dialogs_replace()
+            go('http://blazedemo.com')
             self.driver.set_window_size('750', '750')
             switch_window(0)
 
@@ -100,9 +97,9 @@ class TestLocSc(unittest.TestCase):
             self.driver.find_element(
                 var_loc_keys[0],
                 var_loc_keys[1]).click()
+            check_opened_new_window()
 
-            var_loc_keys = get_locator([{'xpath': '/doc/abc'}, {
-                'css': 'body > div.container > table > tbody > tr:nth-child(1) > td:nth-child(2) > input'}])
+            var_loc_keys = get_locator([{'xpath': '/doc/abc'}, {'css': 'body > div.container > table > tbody > tr:nth-child(1) > td:nth-child(2) > input'}])
             self.driver.find_element(
                 var_loc_keys[0],
                 var_loc_keys[1]).send_keys(Keys.ENTER)
@@ -152,7 +149,7 @@ class TestLocSc(unittest.TestCase):
 
             filename = os.path.join(os.getenv('TAURUS_ARTIFACTS_DIR'), ('screenshot-%d.png' % (time() * 1000)))
             self.driver.save_screenshot(filename)
-            self.driver.execute_script("window.open('vacation.html');")
+            open_window('vacation.html')
             self.driver.maximize_window()
             switch_frame('index=1')
             switch_frame('relative=parent')


### PR DESCRIPTION
Fixed problem regarding switching windows by index. The issue is that the code previously used driver.window_handles array to select window by the index, however the order in this array is not guaranteed and is completely random. So the windows object was modified to contain all the windows in the order they are opened.

Also changed the behaviour when opening new windows to automatically switch to the new window instead of forcing users to declare the switchWindow action. 

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
