### PR TITLE
Fix weekly and monthly usage statistic order on site

### DIFF
--- a/site/bzt-usage-stats/bzt_usage_stats.js
+++ b/site/bzt-usage-stats/bzt_usage_stats.js
@@ -5,9 +5,11 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     const respLaunchByWeek = await fetch('./week.php');
     const launchByWeek = await respLaunchByWeek.json();
+    launchByWeek.sort(weekSort);
 
     const respLaunchByMonth = await fetch('./month.php');
     const launchByMonth = await respLaunchByMonth.json();
+    launchByMonth.sort(monthSort);
 
     let form = document.querySelector("form")
     let out = form.querySelector("#out")
@@ -128,4 +130,55 @@ document.addEventListener("DOMContentLoaded", async () => {
         return { period_name: periodName, categories: categoriesArr, new_users: newUsersData, cloud_users: cloudUsersData, desktop_users: desctopUsersData }
     }
 
+    function weekSort(date1, date2) {
+        year1 = date1.year;
+        week1 = date1.week;
+
+        year2 = date2.year;
+        week2 = date2.week;
+
+        if (year1 === year2) {
+            if (week1 > week2) {
+                return 1;
+            }
+
+            if (week1 < week2) {
+                return -1;
+            }
+
+            return 0;
+        } else {
+            if (year1 > year2) {
+                return 1;
+            } else {
+                return -1;
+            }
+        }
+    }
+
+    function monthSort(date1, date2) {
+        month1 = date1.month.split('.')[0];
+        year1 = date1.month.split('.')[1];
+
+        month2 = date2.month.split('.')[0];
+        year2 = date2.month.split('.')[1];
+
+        if (year1 === year2) {
+            if (month1 > month2) {
+                return 1;
+            }
+
+            if (month1 < month2) {
+                return -1;
+            }
+
+            return 0;
+        } else {
+            if (year1 > year2) {
+                return 1;
+            } else {
+                return -1;
+            }
+        }
+    }
 })

--- a/site/dat/docs/changes/fix-week-and-month-statistic-order.change
+++ b/site/dat/docs/changes/fix-week-and-month-statistic-order.change
@@ -1,0 +1,1 @@
+fix usage statistic on site


### PR DESCRIPTION
Make weekly and monthly statistic order by year from previous years to
our time
e.g. [01.2020, 02.1020, 11.2019, 12.2019] => [11.2019, 12.2019, 01.2020,
02.1020]

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
