### PR TITLE
allow configuration of SELENIUM_TOOLS_DIR via modules.selenium.path

### DIFF
--- a/bzt/modules/selenium.py
+++ b/bzt/modules/selenium.py
@@ -281,7 +281,7 @@ class ChromeDriver(RequiredTool):
     def __init__(self, config=None, **kwargs):
         settings = config or {}
         version = str(settings.get('version', self.VERSION))
-        base_dir = get_full_path(SeleniumExecutor.SELENIUM_TOOLS_DIR)
+        base_dir = get_full_path(settings.get('path', SeleniumExecutor.SELENIUM_TOOLS_DIR))
         filename = 'chromedriver.exe' if is_windows() else 'chromedriver'
         tool_path = os.path.join(base_dir, 'chromedriver', version, filename)
 
@@ -331,7 +331,7 @@ class GeckoDriver(RequiredTool):
     def __init__(self, config=None, **kwargs):
         settings = config or {}
         version = str(settings.get('version', self.VERSION))
-        base_dir = get_full_path(SeleniumExecutor.SELENIUM_TOOLS_DIR)
+        base_dir = get_full_path(settings.get('path', SeleniumExecutor.SELENIUM_TOOLS_DIR))
         filename = 'geckodriver.exe' if is_windows() else 'geckodriver'
         tool_path = os.path.join(base_dir, 'geckodriver', version, filename)
 


### PR DESCRIPTION
we now can provide where selenium tools are provided;

e.g.

```
---

modules:
  selenium:
    path: /opt/bzt/selenium
```

will configure tools to be installed under /opt/bzt/selenium

being able to globally set the path where tools get installed is IMO a better approach and to not assume/hardcoe `~/.bzt` in many of the  module -- per: https://groups.google.com/g/codename-taurus/c/-8svTZqpaOc