### PR TITLE
Fix address in passfail validation when not default

### DIFF
--- a/bzt/bza.py
+++ b/bzt/bza.py
@@ -516,7 +516,7 @@ class Test(BZAObject):
         return res['result']
 
     def get_passfail_validation(self):
-        url = f"https://a.blazemeter.com/api/v4/tests/{self['id']}/validations"
+        url = f"https://{self.address}/api/v4/tests/{self['id']}/validations"
         resp = self._request(url, method='GET')
         return resp['result'][0]['warnings'] + resp['result'][0]['fileWarnings']
 

--- a/bzt/bza.py
+++ b/bzt/bza.py
@@ -516,7 +516,7 @@ class Test(BZAObject):
         return res['result']
 
     def get_passfail_validation(self):
-        url = f"https://{self.address}/api/v4/tests/{self['id']}/validations"
+        url = f"{self.address}/api/v4/tests/{self['id']}/validations"
         resp = self._request(url, method='GET')
         return resp['result'][0]['warnings'] + resp['result'][0]['fileWarnings']
 

--- a/site/dat/docs/changes/fix-cloud-passfail-validation-address.change
+++ b/site/dat/docs/changes/fix-cloud-passfail-validation-address.change
@@ -1,0 +1,1 @@
+fix address in passfail validation when not default


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
