### PR TITLE
Fix errors empty engine in tests

### DIFF
--- a/site/dat/docs/changes/fix-empty-engine-in-tests.change
+++ b/site/dat/docs/changes/fix-empty-engine-in-tests.change
@@ -1,0 +1,1 @@
+fix tests when contain empty engine

--- a/tests/unit/modules/selenium/test_apiritif_builder.py
+++ b/tests/unit/modules/selenium/test_apiritif_builder.py
@@ -623,6 +623,7 @@ class TestApiritifScriptGeneration(ExecutorTestCase):
 
     def test_load_reader(self):
         reader = ApiritifLoadReader(self.obj.log)
+        reader.engine = EngineEmul()
 
         # add empty reader
         with tempfile.NamedTemporaryFile() as f_name:

--- a/tests/unit/modules/test_locustIOExecutor.py
+++ b/tests/unit/modules/test_locustIOExecutor.py
@@ -12,7 +12,7 @@ from bzt.modules.locustio import LocustIOExecutor, WorkersReader
 from bzt.modules.provisioning import Local
 
 
-from tests.unit import ExecutorTestCase, RESOURCES_DIR, ROOT_LOGGER
+from tests.unit import ExecutorTestCase, RESOURCES_DIR, ROOT_LOGGER, EngineEmul
 
 
 class TestLocustIOExecutor(ExecutorTestCase):
@@ -160,6 +160,7 @@ class TestLocustIOExecutor(ExecutorTestCase):
         self.obj.prepare()
         self.obj.reader = WorkersReader(RESOURCES_DIR + "locust/locust-workers.ldjson", 2, ROOT_LOGGER)
         self.obj.engine.aggregator = ConsolidatingAggregator()
+        self.obj.engine.aggregator.engine = EngineEmul()
         self.obj.engine.aggregator.add_underling(self.obj.reader)
         self.assertEqual(107, len(list(self.obj.engine.aggregator.datapoints(final_pass=True))))
         self.obj.post_process()


### PR DESCRIPTION
Add EngineEmul() to the tests where the engine is not initialized

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
