### PR TITLE
Fix non-Latin characters in results table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ install:
     gpg --keyserver hkp://keys.gnupg.net --recv-keys $RVM_KEY && rvm get stable || echo "rvm update fail"
   fi
 - gem install rspec
+- if [ "$TRAVIS_PYTHON_VERSION" = "3.9" ]; then sudo apt install python3.9-dev; fi
 - $PIP_INSTALL --upgrade pip
 - $PIP_INSTALL -r requirements.txt -r tests/ci/requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ install:
     gpg --keyserver hkp://keys.gnupg.net --recv-keys $RVM_KEY && rvm get stable || echo "rvm update fail"
   fi
 - gem install rspec
-- if [ "$TRAVIS_PYTHON_VERSION" = "3.9" ]; then sudo apt install python3.9-dev; fi
 - $PIP_INSTALL --upgrade pip
 - $PIP_INSTALL -r requirements.txt -r tests/ci/requirements.txt
 

--- a/bzt/modules/reporting.py
+++ b/bzt/modules/reporting.py
@@ -193,9 +193,6 @@ class FinalStatus(Reporter, AggregatorListener, FunctionalAggregatorListener):
                 if failed_samples_count:
                     self.log.info(report_template, failed_samples_count, sample_label)
 
-    def __console_safe_encode(self, text):
-        return text.encode(locale.getpreferredencoding(), errors='replace').decode('unicode_escape')
-
     def __get_sample_element(self, sample, label_name):
         failed_samples_count = sample['fail']
         success_samples_count = sample['succ']
@@ -205,10 +202,10 @@ class FinalStatus(Reporter, AggregatorListener, FunctionalAggregatorListener):
 
         errors = set()
         for err_desc in sample['errors']:
-            errors.add(self.__console_safe_encode(err_desc["msg"]))
+            errors.add(err_desc["msg"])
 
         return (
-            self.__console_safe_encode(label_name),
+            label_name,
             "FAIL" if failed_samples_count > 0 else "OK",
             "{0:.2f}%".format(round(success_samples_perc, 2)),
             "{0:.3f}".format(round(sample['avg_rt'], 3)),

--- a/site/dat/docs/changes/fix-results-table-encoding.change
+++ b/site/dat/docs/changes/fix-results-table-encoding.change
@@ -1,0 +1,1 @@
+fix when non-latin characters are not displayed properly in results table


### PR DESCRIPTION
Fix when non-Latin characters are not displayed properly in results table

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
