### PR TITLE
added configuration properties for selenium/apiritif based tests for …

### DIFF
--- a/bzt/modules/apiritif/generator.py
+++ b/bzt/modules/apiritif/generator.py
@@ -1002,7 +1002,19 @@ from selenium.webdriver.common.keys import Keys
             ast.Assign(
                 targets=[ast.Name(id="options")],
                 value=ast_call(
-                    func=ast_attr("webdriver.FirefoxOptions")))]
+                    func=ast_attr("webdriver.FirefoxOptions"))),
+            ast.Expr(
+                ast_call(func=ast_attr("options.set_preference"),
+                         args=[ast.Str("network.proxy.type", kind=""), ast.Num(4, kind="")]))]
+
+        if self.scenario.get("window-size", None):
+            firefox_options.append(
+                ast.Expr(
+                    ast_call(
+                        func=ast_attr("options.add_argument"),
+                        args=[
+                            ast.Str("--width=%s" % self.scenario.get("window-size").split(",", 1)[1], kind=""),
+                            ast.Str("--height=%s" % self.scenario.get("window-size").split(",", 2)[2], kind="") ])))
 
         return firefox_options + self._get_headless_setup()
 
@@ -1020,17 +1032,45 @@ from selenium.webdriver.common.keys import Keys
                 ast_call(
                     func=ast_attr("options.add_argument"),
                     args=[ast.Str("%s" % "--disable-dev-shm-usage", kind="")]))]
+        if self.scenario.get("user-agent", None):
+            chrome_options.append(
+                ast.Expr(
+                    ast_call(
+                        func=ast_attr("options.add_argument"),
+                        args=[ast.Str("--user-agent=%s" % self.scenario.get("user-agent") , kind="")])))
+        if self.scenario.get("proxy-server", None):
+            chrome_options.append(
+                ast.Expr(
+                    ast_call(
+                        func=ast_attr("options.add_argument"),
+                        args=[
+                            ast.Str("--proxy-server=%s" % self.scenario.get("proxy-server"), kind="")])))
+        if self.scenario.get("window-size", None):
+            chrome_options.append(
+                ast.Expr(
+                    ast_call(
+                        func=ast_attr("options.add_argument"),
+                        args=[
+                            ast.Str("--window-size=%s" % self.scenario.get("window-size"), kind="")])))
 
         return chrome_options + self._get_headless_setup()
 
     def _get_firefox_profile(self):
-        return [
+        firefox_profile =  [
             ast.Assign(
                 targets=[ast.Name(id="profile")],
                 value=ast_call(func=ast_attr("webdriver.FirefoxProfile"))),
             ast.Expr(ast_call(
                 func=ast_attr("profile.set_preference"),
                 args=[ast.Str("webdriver.log.file", kind=""), ast.Str(self.wdlog, kind="")]))]
+
+        if self.scenario.get("user-agent", None):
+            firefox_profile.append(
+                ast.Expr(
+                    ast_call(
+                        func=ast_attr("profile.set_preference"),
+                        args=[ast.Str("general.useragent.override", kind=""), ast.Str( self.scenario.get("user-agent") , kind="")])))
+        return firefox_profile
 
     def _get_firefox_webdriver(self):
         return ast.Assign(

--- a/site/dat/docs/Apiritif.md
+++ b/site/dat/docs/Apiritif.md
@@ -85,6 +85,10 @@ execution:
 In `selenium` mode follow request features are supported:
 
   - `browser` for the following browser types: Chrome, Firefox, Ie, Opera, Android-Chrome, iOS-Safari, Remote
+  - `headless` for running tests without GUI overhead. available only for Chrome/Firefox and only on Selenium 3.8.0+, disabled by default
+  - `user-agent` for specifying a special user-agent to use for the browser session. available only for Chrome/Firefox  
+  - `window-size` for setting browser window size. available only for Chrome/Firefox 
+  - `proxy-server` for using a browser proxy. currently available only for Chrome
   - `remote` for local webdriver, local remote webdriver or [remote webdriver](#Remote-WebDriver)
   - `capabilities` of [remote webdriver](#Remote-WebDriver): `browser`, `version`, `javascript`, `platform`, `os\_version`, `selenium`, `device`, `app`
   - `request` only for GET method


### PR DESCRIPTION
…user-agent, proxy-server and window-size

The user-agent and proxy-server is needed or at least useful for testing in production like szenarios where a firewall/reverseproxy is present.
Adapting window-size is useful for responsive browser apps, that behave differently based on screensize und user-agent

config would be better situated in the webdriver section of modules, but would need huge code change. And headless which is similar is already under scenario - thats why I kept the change simple.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [x] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
