### PR TITLE
Add non-proxy-hosts proxy settings option

### DIFF
--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -1170,11 +1170,15 @@ class HTTPClient(object):
             return props
 
         proxy_url = parse.urlsplit(self.proxy_settings.get("address"))
+        non_proxy_hosts = self.proxy_settings.get("non-proxy-hosts")
         username = self.proxy_settings.get("username")
         pwd = self.proxy_settings.get("password")
+
         for protocol in ["http", "https"]:
             props[protocol + '.proxyHost'] = proxy_url.hostname
             props[protocol + '.proxyPort'] = proxy_url.port or 80
+            if non_proxy_hosts:
+                props[protocol + '.nonProxyHosts'] = non_proxy_hosts
             if username and pwd:
                 props[protocol + '.proxyUser'] = username
                 props[protocol + '.proxyPass'] = pwd

--- a/site/dat/docs/ConfigSyntax.md
+++ b/site/dat/docs/ConfigSyntax.md
@@ -109,6 +109,7 @@ settings:
     password: 12345
     ssl-cert: path/to/cert  # SSL server-side certificate. You can set it to `false` to disable cert validation.
     ssl-client-cert: path/to/cert  # SSL client-side certificate
+    non-proxy-hosts: blazedemo.com|localhost  # (JMeter only) hosts list to use without proxy 
   check-updates: true  # check for newer version of Taurus on startup
   verbose: false  # whenever you run bzt with -v option, it sets debug=true, 
                   # some modules might use it for debug features,

--- a/site/dat/docs/changes/add-nonproxy-settings.change
+++ b/site/dat/docs/changes/add-nonproxy-settings.change
@@ -1,0 +1,1 @@
+add proxy settings option for jmeter to ignore proxy for hosts list under this option

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -338,10 +338,11 @@ class TestHTTPClient(BZTestCase):
         obj = HTTPClient()
         obj.add_proxy_settings({"address": "http://localhost:3128",
                                 "username": "me",
-                                "password": "too"})
+                                "password": "too",
+                                "non-proxy-hosts": "localhost"})
         jvm_args = obj.get_proxy_props()
         for protocol in ['http', 'https']:
-            for key in ['proxyHost', 'proxyPort', 'proxyUser', 'proxyPass']:
+            for key in ['proxyHost', 'proxyPort', 'proxyUser', 'proxyPass', 'nonProxyHosts']:
                 combo_key = protocol + '.' + key
                 self.assertIn(combo_key, jvm_args)
 


### PR DESCRIPTION
Add an ability to setup hosts list for connection without proxy (JMeter only)

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
