### PR TITLE
Fix/rampup exclude fixes

### DIFF
--- a/bzt/modules/aggregator.py
+++ b/bzt/modules/aggregator.py
@@ -871,7 +871,7 @@ class ConsolidatingAggregator(Aggregator, ResultsProvider):
         ramp_ups = [0]
         for execution in self.engine.config['execution']:
             if 'ramp-up' in execution:
-                ramp_ups.append(execution['ramp-up'])
+                ramp_ups.append(dehumanize_time(execution['ramp-up']))
         return max(ramp_ups)
 
     def _ramp_up_exclude(self):

--- a/bzt/modules/blazemeter.py
+++ b/bzt/modules/blazemeter.py
@@ -678,7 +678,7 @@ class DatapointSerializer(object):
         # - elements of 'intervals' are described in __get_interval()
         #   every interval contains info about response codes have gotten on it.
         report_items = BetterDict()
-        if data_buffer:
+        if data_buffer and report_items:
             self.owner.first_ts = min(self.owner.first_ts, data_buffer[0][DataPoint.TIMESTAMP])
             self.owner.last_ts = max(self.owner.last_ts, data_buffer[-1][DataPoint.TIMESTAMP])
 
@@ -694,9 +694,8 @@ class DatapointSerializer(object):
                 time_stamp = dpoint[DataPoint.TIMESTAMP]
                 for label, kpi_set in iteritems(dpoint[DataPoint.CURRENT]):
                     exc = TaurusInternalException('Cumulative KPISet is non-consistent')
-                    if report_items:
-                        report_item = report_items.get(label, exc)
-                        report_item['intervals'].append(self.__get_interval(kpi_set, time_stamp))
+                    report_item = report_items.get(label, exc)
+                    report_item['intervals'].append(self.__get_interval(kpi_set, time_stamp))
 
         report_items = [report_items[key] for key in sorted(report_items.keys())]  # convert dict to list
         data = {"labels": report_items, "sourceID": id(self.owner)}

--- a/bzt/modules/blazemeter.py
+++ b/bzt/modules/blazemeter.py
@@ -678,7 +678,7 @@ class DatapointSerializer(object):
         # - elements of 'intervals' are described in __get_interval()
         #   every interval contains info about response codes have gotten on it.
         report_items = BetterDict()
-        if data_buffer and report_items:
+        if data_buffer:
             self.owner.first_ts = min(self.owner.first_ts, data_buffer[0][DataPoint.TIMESTAMP])
             self.owner.last_ts = max(self.owner.last_ts, data_buffer[-1][DataPoint.TIMESTAMP])
 
@@ -690,12 +690,13 @@ class DatapointSerializer(object):
 
             # fill 'Timeline Report' tab with intervals data
             # intervals are received in the additive way
-            for dpoint in data_buffer:
-                time_stamp = dpoint[DataPoint.TIMESTAMP]
-                for label, kpi_set in iteritems(dpoint[DataPoint.CURRENT]):
-                    exc = TaurusInternalException('Cumulative KPISet is non-consistent')
-                    report_item = report_items.get(label, exc)
-                    report_item['intervals'].append(self.__get_interval(kpi_set, time_stamp))
+            if report_items:
+                for dpoint in data_buffer:
+                    time_stamp = dpoint[DataPoint.TIMESTAMP]
+                    for label, kpi_set in iteritems(dpoint[DataPoint.CURRENT]):
+                        exc = TaurusInternalException('Cumulative KPISet is non-consistent')
+                        report_item = report_items.get(label, exc)
+                        report_item['intervals'].append(self.__get_interval(kpi_set, time_stamp))
 
         report_items = [report_items[key] for key in sorted(report_items.keys())]  # convert dict to list
         data = {"labels": report_items, "sourceID": id(self.owner)}

--- a/bzt/modules/blazemeter.py
+++ b/bzt/modules/blazemeter.py
@@ -694,8 +694,9 @@ class DatapointSerializer(object):
                 time_stamp = dpoint[DataPoint.TIMESTAMP]
                 for label, kpi_set in iteritems(dpoint[DataPoint.CURRENT]):
                     exc = TaurusInternalException('Cumulative KPISet is non-consistent')
-                    report_item = report_items.get(label, exc)
-                    report_item['intervals'].append(self.__get_interval(kpi_set, time_stamp))
+                    if report_items:
+                        report_item = report_items.get(label, exc)
+                        report_item['intervals'].append(self.__get_interval(kpi_set, time_stamp))
 
         report_items = [report_items[key] for key in sorted(report_items.keys())]  # convert dict to list
         data = {"labels": report_items, "sourceID": id(self.owner)}

--- a/site/dat/docs/changes/fix-rampup-exclude-fixes.change
+++ b/site/dat/docs/changes/fix-rampup-exclude-fixes.change
@@ -1,0 +1,1 @@
+fix ramp-up errors

--- a/tests/unit/modules/test_blazeMeterUploader.py
+++ b/tests/unit/modules/test_blazeMeterUploader.py
@@ -534,4 +534,3 @@ class TestMonitoringBuffer(BZTestCase):
             mon_buffer.record_data(mon)
         unpacked = sum(item['interval'] for item in viewvalues(mon_buffer.data['local']))
         self.assertEqual(unpacked, ITERATIONS)
-

--- a/tests/unit/modules/test_blazeMeterUploader.py
+++ b/tests/unit/modules/test_blazeMeterUploader.py
@@ -8,7 +8,7 @@ from tempfile import mkstemp
 from io import BytesIO
 from urllib.error import HTTPError
 
-from bzt import TaurusException, TaurusInternalException
+from bzt import TaurusException
 from bzt.bza import Master, Session
 from bzt.modules.aggregator import DataPoint, KPISet
 from bzt.modules.blazemeter import BlazeMeterUploader

--- a/tests/unit/modules/test_blazeMeterUploader.py
+++ b/tests/unit/modules/test_blazeMeterUploader.py
@@ -8,7 +8,7 @@ from tempfile import mkstemp
 from io import BytesIO
 from urllib.error import HTTPError
 
-from bzt import TaurusException
+from bzt import TaurusException, TaurusInternalException
 from bzt.bza import Master, Session
 from bzt.modules.aggregator import DataPoint, KPISet
 from bzt.modules.blazemeter import BlazeMeterUploader
@@ -408,6 +408,38 @@ class TestBlazeMeterUploader(BZTestCase):
         self.assertEquals('https://a.blazemeter.com/api/v4/tests', mock.requests[6]['url'])
         self.assertEquals('POST', mock.requests[6]['method'])
 
+    def test_excluded_cumulative(self):
+        mock = BZMock()
+        mock.mock_get.update({
+            'https://a.blazemeter.com/api/v4/tests?projectId=1&name=Taurus+Test': {"result": []},
+        })
+        mock.mock_post.update({
+            'https://a.blazemeter.com/api/v4/projects': {"result": {'id': 1}},
+            'https://a.blazemeter.com/api/v4/tests': {"result": {'id': 1}},
+            'https://a.blazemeter.com/api/v4/tests/1/start-external': {"result": {
+                "session": {'id': 1, "testId": 1, "userId": 1},
+                "master": {'id': 1},
+                "signature": "sign"
+            }},
+            'https://data.blazemeter.com/api/v4/image/1/files?signature=sign': {"result": True},
+            'https://data.blazemeter.com/submit.php?session_id=1&signature=sign&test_id=1&user_id=1' +
+            '&pq=0&target=labels_bulk&update=1': {},
+            'https://data.blazemeter.com/submit.php?session_id=1&signature=sign&test_id=1&user_id=1&pq=0&target=engine_health&update=1': {
+                'result': {'session': {}}}
+        })
+
+        obj = BlazeMeterUploader()
+        mock.apply(obj._user)
+        obj.parameters['project'] = 'Proj name'
+        obj.settings['token'] = '123'
+        obj.settings['browser-open'] = 'none'
+        obj.engine = EngineEmul()
+        obj.prepare()
+        obj.startup()
+        obj.aggregated_second(random_datapoint(10))
+        obj.kpi_buffer[-1][DataPoint.CUMULATIVE] = {}  # remove cumulative when ramp-up data is excluded
+        obj.post_process()  # no 'Cumulative KPISet is non-consistent' exception here
+
 
 class TestBlazeMeterClientUnicode(BZTestCase):
     def test_unicode_request(self):
@@ -502,3 +534,4 @@ class TestMonitoringBuffer(BZTestCase):
             mon_buffer.record_data(mon)
         unpacked = sum(item['interval'] for item in viewvalues(mon_buffer.data['local']))
         self.assertEqual(unpacked, ITERATIONS)
+

--- a/tests/unit/modules/test_consolidatingAggregator.py
+++ b/tests/unit/modules/test_consolidatingAggregator.py
@@ -302,7 +302,7 @@ class TestConsolidatingAggregator(BZTestCase):
         self.obj.engine.config['settings']['ramp-up-exclude'] = True
         self.obj.engine.config['execution'] = [
             {'scenario': 'first', 'ramp-up': 50},
-            {'scenario': 'second', 'ramp-up': 1},
+            {'scenario': 'second', 'ramp-up': '1s'},
             {'scenario': 'third'}
         ]
         self.obj.engine.config['scenarios'] = BetterDict.from_dict({


### PR DESCRIPTION
Fixed errors:
1) error when ramp-up is not entirely numeric;
2) empty cloud data led to "Cumulative KPISet is non-consistent" error.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
