### PR TITLE
Added the possibility to configure the download-link and version for Plugins-Manager and Command-Runner

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1353,9 +1353,9 @@ class JMeter(RequiredTool):
     JMeter tool
     """
     PLUGINS_MANAGER_VERSION = "1.3"
-    PLUGINS_MANAGER = 'https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-manager/' \
-                      '{ver}/jmeter-plugins-manager-{ver}.jar'.format(ver=PLUGINS_MANAGER_VERSION)
-    CMDRUNNER = 'https://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.2/cmdrunner-2.2.jar'
+    PLUGINS_MANAGER = 'https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-manager/{version}/jmeter-plugins-manager-{version}.jar'
+    COMMAND_RUNNER_VERSION = "2.2"
+    COMMAND_RUNNER = 'https://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/{version}/cmdrunner-{version}.jar'
     VERSION = "5.2.1"
 
     def __init__(self, config=None, props=None, **kwargs):
@@ -1369,6 +1369,14 @@ class JMeter(RequiredTool):
         download_link = settings.get("download-link", None)
         if download_link is not None:
             download_link = download_link.format(version=version)
+
+        plugins_manager_settings = settings.get("plugins-manager", {})
+        plugins_manager_version = plugins_manager_settings.get("version", JMeter.PLUGINS_MANAGER_VERSION)
+        self.plugins_manager = plugins_manager_settings.get("download-link", JMeter.PLUGINS_MANAGER).format(version=plugins_manager_version)
+
+        command_runner_settings = settings.get("command-runner", {})
+        command_runner_version = command_runner_settings.get("version", JMeter.COMMAND_RUNNER_VERSION)
+        self.command_runner = command_runner_settings.get("download-link", JMeter.COMMAND_RUNNER).format(version=command_runner_version)
 
         self.plugins = settings.get("plugins", [])
 
@@ -1520,13 +1528,13 @@ class JMeter(RequiredTool):
     def install(self):
         dest = get_full_path(self.tool_path, step_up=2)
         self.log.info("Will install %s into %s", self.tool_name, dest)
-        plugins_manager_name = os.path.basename(self.PLUGINS_MANAGER)
-        cmdrunner_name = os.path.basename(self.CMDRUNNER)
+        plugins_manager_name = os.path.basename(self.plugins_manager)
+        command_runner_name = os.path.basename(self.command_runner)
         plugins_manager_path = os.path.join(dest, 'lib', 'ext', plugins_manager_name)
-        cmdrunner_path = os.path.join(dest, 'lib', cmdrunner_name)
+        command_runner_path = os.path.join(dest, 'lib', command_runner_name)
         direct_install_tools = [  # source link and destination
-            [self.PLUGINS_MANAGER, plugins_manager_path],
-            [self.CMDRUNNER, cmdrunner_path]]
+            [self.plugins_manager, plugins_manager_path],
+            [self.command_runner, command_runner_path]]
         plugins_manager_cmd = self._pmgr_path()
 
         self.__install_jmeter(dest)

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -18,6 +18,12 @@ modules:
     - jpgc-json=2.2
     - jmeter-ftp
     - jpgc-casutg
+    plugins-manager:
+      download-link: https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-manager/{version}/jmeter-plugins-manager-{version}.jar
+      version: 1.3   # minimum 0.16
+    command-runner:
+      download-link: https://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/{version}/cmdrunner-{version}.jar
+      version: 2.2
 ```
 `force-ctg` allows you to switch off the usage of ConcurrentThreadGroup for jmx script modifications purpose. This group
 provide `steps` execution parameter but requires `Custom Thread Groups` plugin (installed by default)

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -23,7 +23,7 @@ modules:
       version: 1.3   # minimum 0.16
     command-runner:
       download-link: https://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/{version}/cmdrunner-{version}.jar
-      version: 2.2
+      version: 2.2   # minimum 2.0
 ```
 `force-ctg` allows you to switch off the usage of ConcurrentThreadGroup for jmx script modifications purpose. This group
 provide `steps` execution parameter but requires `Custom Thread Groups` plugin (installed by default)
@@ -37,6 +37,9 @@ jpgc-perfmon, jpgc-prmctl, jpgc-tst. Keep in mind: you can change plugins list o
 If you already have JMeter placed at `path` you need to remove it for plugins installation purpose.
 
 [JMeter Plugins Manager](#https://jmeter-plugins.org/wiki/PluginsManager/) allows you to install necessary plugins for your jmx file automatically and this feature doesn't require clean installation. You can turn it off with `detect-plugins` option. If you use your own installation of JMeter (with `path` option) make sure it includes `jmeter-plugins-manager` 0.16 or newer.
+If you want to change the URL from which the PluginsManager is downloaded or use a different version, configure `download-link` and/or `version` inside the `plugins-manager` block of the configuration.
+
+For the PluginsManager to work correctly, you will also need the CommandRunner. It can also be downloaded automatically in the default version from the default location (as shown in the example above) or it can be configured similar to the PluginsManager.
 
 ## Run Existing JMX File
 ```yaml

--- a/site/dat/docs/changes/feat-configurable-download-jmeter-tools.change
+++ b/site/dat/docs/changes/feat-configurable-download-jmeter-tools.change
@@ -1,0 +1,1 @@
+Added the possibility to configure download-link and version of the JMeter tools 'Plugins-Manager' and 'Command-Runner'

--- a/tests/unit/modules/jmeter/test_JMeterTool.py
+++ b/tests/unit/modules/jmeter/test_JMeterTool.py
@@ -2,6 +2,7 @@ import os
 from bzt.utils import EXE_SUFFIX
 
 from . import MockJMeter
+from bzt.modules.jmeter import JTLReader, FuncJTLReader, JMeter
 from tests.unit import BZTestCase, RESOURCES_DIR
 
 
@@ -46,3 +47,25 @@ class TestJMeterTool(BZTestCase):
 
         self.assertIn(jmx_file + " not found", self.log_recorder.warn_buff.getvalue())
 
+    def test_plugins_manager_and_command_runner_default_urls(self):
+        self.obj.__init__()
+        self.assertEqual(self.obj.plugins_manager, JMeter.PLUGINS_MANAGER.format(version=JMeter.PLUGINS_MANAGER_VERSION))
+        self.assertEqual(self.obj.command_runner, JMeter.COMMAND_RUNNER.format(version=JMeter.COMMAND_RUNNER_VERSION))
+
+    def test_plugins_manager_and_command_runner_configured_url(self):
+        plugins_manager_test_url = "http://somewhere.else/plugins-manager/{version}/plugins-manager.jar"
+        plugins_manager_test_version = "1.0"
+        command_runner_test_url = "http://somewhere.else/command-runner/{version}/command-runner.jar"
+        command_runner_test_version = "1.0"
+        self.obj.__init__(config={
+            "plugins-manager": {
+                "download-link": plugins_manager_test_url,
+                "version": plugins_manager_test_version
+            },
+            "command-runner": {
+                "download-link": command_runner_test_url,
+                "version": command_runner_test_version
+            }
+        })
+        self.assertEqual(self.obj.plugins_manager, plugins_manager_test_url.format(version=plugins_manager_test_version))
+        self.assertEqual(self.obj.command_runner, command_runner_test_url.format(version=command_runner_test_version))


### PR DESCRIPTION
This PR adds the possibility to configure the download-link and version for the JMeter Tools 'Plugins-Manager' and 'Command-Runner', similar to how JMeter itself can be configured.
This is useful if you are running Taurus on a computer that is not allowed to have direct access to the internet and needs to get all files from an internal mirror.

Since I don't have much Python experience, I couldn't figure out how to write tests for this change.

Quick checklist:
- [X] Description of PR explains the context of change
- [X] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [X] Documentation update
- [X] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
