### PR TITLE
Fixed issue when curly bracket is inside the param of scripEval action

### DIFF
--- a/bzt/modules/apiritif/generator.py
+++ b/bzt/modules/apiritif/generator.py
@@ -693,8 +693,9 @@ from selenium.webdriver.common.keys import Keys
                     args=[self._gen_expr(param.strip())]))
 
         elif atype == "script" and tag == "eval":
+            escaped_param = self._escape_js_blocks(param)
             action_elements.append(ast_call(func=ast_attr("self.driver.execute_script"),
-                                            args=[self._gen_expr(param)]))
+                                            args=[self._gen_expr(escaped_param)]))
         elif atype == "rawcode":
             action_elements.append(ast.parse(param))
         elif atype == 'go':
@@ -1335,6 +1336,28 @@ from selenium.webdriver.common.keys import Keys
 
     def _gen_expr(self, value):
         return self.expr_compiler.gen_expr(value)
+
+    @staticmethod
+    # escapes the { with {{
+    def _escape_js_blocks(value):
+        result_list = []
+        inside_var = False
+        for i in range(len(value)):
+            if value[i] == '{':
+                if i == 0 or value[i-1] != '$':
+                    result_list.append('{{')
+                else:
+                    inside_var = True
+                    result_list.append(value[i])
+            elif value[i] == '}':
+                if inside_var:
+                    result_list.append(value[i])
+                    inside_var = False
+                else:
+                    result_list.append('}}')
+            else:
+                result_list.append(value[i])
+        return ''.join(result_list)
 
     def _gen_target_setup(self, key, value):
         return ast.Expr(ast_call(

--- a/bzt/modules/apiritif/generator.py
+++ b/bzt/modules/apiritif/generator.py
@@ -1339,8 +1339,7 @@ from selenium.webdriver.common.keys import Keys
 
     @staticmethod
     def _escape_js_blocks(value):  # escapes plain { with {{
-        blocks = re.finditer(r"(?<!\$){.*}", value)
-        for block in blocks:
+        for block in re.finditer(r"(?<!\$){.*}", value):
             start, end = block.start(), block.end()
             line = "{" + value[start:end] + "}"
             value = value[:start] + line + value[end:]

--- a/bzt/modules/apiritif/generator.py
+++ b/bzt/modules/apiritif/generator.py
@@ -1338,26 +1338,13 @@ from selenium.webdriver.common.keys import Keys
         return self.expr_compiler.gen_expr(value)
 
     @staticmethod
-    # escapes the { with {{
-    def _escape_js_blocks(value):
-        result_list = []
-        inside_var = False
-        for i in range(len(value)):
-            if value[i] == '{':
-                if i == 0 or value[i-1] != '$':
-                    result_list.append('{{')
-                else:
-                    inside_var = True
-                    result_list.append(value[i])
-            elif value[i] == '}':
-                if inside_var:
-                    result_list.append(value[i])
-                    inside_var = False
-                else:
-                    result_list.append('}}')
-            else:
-                result_list.append(value[i])
-        return ''.join(result_list)
+    def _escape_js_blocks(value):  # escapes plain { with {{
+        blocks = re.finditer(r"(?<!\$){.*}", value)
+        for block in blocks:
+            start, end = block.start(), block.end()
+            line = "{" + value[start:end] + "}"
+            value = value[:start] + line + value[end:]
+        return value
 
     def _gen_target_setup(self, key, value):
         return ast.Expr(ast_call(

--- a/site/dat/docs/changes/fix-scripteval-js-blocks.change
+++ b/site/dat/docs/changes/fix-scripteval-js-blocks.change
@@ -1,0 +1,1 @@
+fixed issue when curly bracket is inside the param of scripEval action

--- a/tests/unit/modules/selenium/test_selenium_builder.py
+++ b/tests/unit/modules/selenium/test_selenium_builder.py
@@ -64,7 +64,7 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
                             {"typeByName(\"toPort\")": "B"},
 
                             # exec, rawcode, go, edit
-                            "scriptEval(\"alert('This is Sparta');\")",
+                            "scriptEval(\"{alert('This is ${sparta}');}\")",
                             {"rawCode": "for i in range(10):\n  if i % 2 == 0:\n    print(i)"},
                             "go(http:\\blazemeter.com)",
                             {"editContentById(editor)": "lo-la-lu"},
@@ -111,7 +111,7 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
             "get_attribute('value').strip(),\'123 Beautiful st.\'.strip())",
             "self.driver.find_element(var_loc_keys[0],var_loc_keys[1]).clear()",
             "self.driver.find_element(var_loc_keys[0],var_loc_keys[1]).send_keys('B')",
-            "self.driver.execute_script(\"alert('This is Sparta');\")",
+            "self.driver.execute_script(\"{{alert(\'Thisis{}\');}}\".format(self.vars[\'sparta\']))",
             "for i in range(10):",
             "if ((i % 2) == 0):",
             print_i,


### PR DESCRIPTION
* escapes the occurences of curly brackets with double curly brackets unless it is a reference to a variable like ${var}

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
