### PR TITLE
Remove updates check when version is DEV

### DIFF
--- a/bzt/engine/engine.py
+++ b/bzt/engine/engine.py
@@ -717,7 +717,7 @@ class Engine(object):
             self.log.debug("Taurus updates info: %s", data)
             mine = LooseVersion(VERSION)
             latest = LooseVersion(data['latest'])
-            if mine < latest or data['needsUpgrade']:
+            if mine != "DEV" and (mine < latest or data['needsUpgrade']):
                 msg = "There is newer version of Taurus %s available, consider upgrading. " \
                       "What's new: http://gettaurus.org/docs/Changelog/"
                 self.log.warning(msg, latest)

--- a/examples/fix-update-version-check.change
+++ b/examples/fix-update-version-check.change
@@ -1,0 +1,1 @@
+remove updates check when version is dev


### PR DESCRIPTION
No version check and comparison error when version is DEV

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
