### PR TITLE
Add 'timeout' and 'concurrency' features to Vegeta

### DIFF
--- a/bzt/modules/vegeta.py
+++ b/bzt/modules/vegeta.py
@@ -81,6 +81,12 @@ class VegetaExecutor(ScenarioExecutor, FileLister, WidgetProvider, HavingInstall
         if load.hold:
             cmdline += ['-duration', str(int(load.hold)) + "s"]
 
+        if load.concurrency:
+            cmdline += ['-max-workers', str(int(load.concurrency))]
+
+        if self.scenario and 'timeout' in self.scenario:
+            cmdline += ['-timeout', str(int(self.scenario.get('timeout'))) + "s"]
+
         self.process = self._execute(cmdline, stdout=PIPE, shell=False)
         with open(self.kpi_file, 'wb') as f:
             self._execute(["vegeta", "encode", "-to=csv"], stdin=self.process.stdout, stdout=f, shell=False)

--- a/bzt/modules/vegeta.py
+++ b/bzt/modules/vegeta.py
@@ -118,6 +118,9 @@ class VegetaExecutor(ScenarioExecutor, FileLister, WidgetProvider, HavingInstall
         if not self.vegeta.check_if_installed():
             self.vegeta.install()
 
+    def resource_files(self):
+        return [self.get_script_path(required=True)]
+
 
 class VegetaLogReader(ResultsReader):
     def __init__(self, filename, parent_logger):
@@ -133,13 +136,13 @@ class VegetaLogReader(ResultsReader):
 
             _tstamp = int(log_vals[0][:10])
             _url = log_vals[10]
-            _concur = 0
+            _concur = 1
             _etime = float(log_vals[2]) / 1000000000.0
             _con_time = 0
             _latency = 0
             _rstatus = log_vals[1]
             _error = log_vals[5] or None
-            _bytes = int(log_vals[3])
+            _bytes = int(log_vals[4])
 
             yield _tstamp, _url, _concur, _etime, _con_time, _latency, _rstatus, _error, '', _bytes
 

--- a/site/dat/docs/Vegeta.md
+++ b/site/dat/docs/Vegeta.md
@@ -20,6 +20,7 @@ execution:
 - executor: vegeta
   throughput: 100  # number of desired requests rate
   hold-for: 60s    # execution duration
+  concurrency: 100  # maximum number of workers
   scenario:
     script: vegeta.txt  # has to be a valid Vegeta script
 ```
@@ -34,6 +35,7 @@ execution:
 
 scenarios:
   vegeta-test:
+    timeout: 30
     requests:
       - url: http://localhost:8000
         method: HEAD

--- a/site/dat/docs/changes/fix-add-timeout-to-vegeta.change
+++ b/site/dat/docs/changes/fix-add-timeout-to-vegeta.change
@@ -1,0 +1,1 @@
+add 'timeout' and 'concurrency' feature to Vegeta

--- a/tests/unit/modules/test_vegeta.py
+++ b/tests/unit/modules/test_vegeta.py
@@ -98,6 +98,25 @@ class TestVegetaExecutor(ExecutorTestCase):
         })
         self.assertCmd('-duration', '30s')
 
+    def test_concurrency(self):
+        self.simple_run({
+            'execution': {
+                'concurrency': '100',
+                'scenario': {'script': VEGETA_SCRIPT},
+                'executor': 'vegeta'
+            }
+        })
+        self.assertCmd('-max-workers', '100')
+
+    def test_timeout(self):
+        self.simple_run({
+            'execution': {
+                'scenario': {'script': VEGETA_SCRIPT, 'timeout': 30},
+                'executor': 'vegeta'
+            }
+        })
+        self.assertCmd('-timeout', '30s')
+
     def test_script(self):
         self.simple_run({
             'execution': {


### PR DESCRIPTION
* parameters
* tests
* docs
* changefile

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [x] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
