### PR TITLE
Fix curly brackets error

### DIFF
--- a/bzt/modules/apiritif/generator.py
+++ b/bzt/modules/apiritif/generator.py
@@ -1347,9 +1347,10 @@ from selenium.webdriver.common.keys import Keys
 
     @staticmethod
     def _escape_js_blocks(value):  # escapes plain { with {{
-        for block in re.finditer(r"(?<!\$){.*}", value):
+        value = value.replace("{", "{{").replace("}", "}}")
+        for block in re.finditer(r"\${{[\w\d]*}}", value):
             start, end = block.start(), block.end()
-            line = "{" + value[start:end] + "}"
+            line = "$" + value[start+2:end-1]
             value = value[:start] + line + value[end:]
         return value
 

--- a/site/dat/docs/changes/fix-selenium-escape-brackets.change
+++ b/site/dat/docs/changes/fix-selenium-escape-brackets.change
@@ -1,0 +1,1 @@
+fix selenium curly brackets escape error


### PR DESCRIPTION
Fix error when escaping curly brackets in script and there are special characters (e.g. '\n') in between.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
