### PR TITLE
fix classes instantiation

### DIFF
--- a/bzt/modules/blazemeter/__init__.py
+++ b/bzt/modules/blazemeter/__init__.py
@@ -16,4 +16,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from bzt.modules.blazemeter.blazemeter_reporter import BlazeMeterUploader
-from bzt.modules.blazemeter.cloud_provisioning import CloudProvisioning
+from bzt.modules.blazemeter.cloud_provisioning import CloudProvisioning, ServiceStubScreenshoter, ServiceStubCaptureHAR

--- a/bzt/modules/blazemeter/cloud_provisioning.py
+++ b/bzt/modules/blazemeter/cloud_provisioning.py
@@ -63,7 +63,8 @@ CLOUD_CONFIG_BLACK_LIST = {
     "version": True,
     "modules": {
         "jmeter": {
-            "path": True
+            "path": True,
+            "protocol-handlers": True
         },
         "ab": {
             "path": True


### PR DESCRIPTION
1. remove protocol-handlers classes in cloud case
2. return Stub classes for backward compatibility

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
