### PR TITLE
Fix error: "Cannot read property 'some' of undefined" when server returns no response

### DIFF
--- a/bzt/resources/newman-reporter-taurus.js
+++ b/bzt/resources/newman-reporter-taurus.js
@@ -154,8 +154,8 @@ class TaurusReporter {
                 responseBodySize: 0,
                 requestCookiesSize: 0
             };
-            sample.assertions = assertions;
         }
+        sample.assertions = assertions;
 
         // Calculate status from assertions
         const assertionFailed = sample.assertions.some((ast) => ast.isFailed);


### PR DESCRIPTION
…urns no response

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
