### PR TITLE
move XXX_with_retry into bza interface

### DIFF
--- a/bzt/bza.py
+++ b/bzt/bza.py
@@ -16,8 +16,7 @@ from urllib.parse import urlencode
 import requests
 from requests.exceptions import ReadTimeout
 
-from bzt import ManualShutdown, TaurusException
-from bzt import TaurusNetworkError
+from bzt import ManualShutdown, TaurusException, TaurusNetworkError
 from bzt.resources.version import VERSION
 from bzt.utils import to_json, MultiPartForm
 

--- a/bzt/bza.py
+++ b/bzt/bza.py
@@ -5,17 +5,59 @@ it may become separate library in the future. Things like imports and logging sh
 import base64
 import json
 import logging
+import time
+import traceback
 from collections import OrderedDict
+from functools import wraps
+from ssl import SSLError
+from urllib.error import URLError
 from urllib.parse import urlencode
 
 import requests
+from requests.exceptions import ReadTimeout
 
-from bzt import TaurusNetworkError, ManualShutdown, TaurusException
-from bzt.utils import to_json, MultiPartForm
+from bzt import ManualShutdown, TaurusException
+from bzt import TaurusNetworkError
 from bzt.resources.version import VERSION
+from bzt.utils import to_json, MultiPartForm
+
+NETWORK_PROBLEMS = (IOError, URLError, SSLError, ReadTimeout, TaurusNetworkError)
 
 BZA_TEST_DATA_RECEIVED = 100
 ENDED = 140
+
+
+def send_with_retry(method):
+    @wraps(method)
+    def _impl(self, *args, **kwargs):
+        try:
+            method(self, *args, **kwargs)
+        except (IOError, TaurusNetworkError):
+            self.log.debug("Error sending data: %s", traceback.format_exc())
+            self.log.warning("Failed to send data, will retry in %s sec...", self.timeout)
+            try:
+                time.sleep(self.timeout)
+                method(self, *args, **kwargs)
+                self.log.info("Succeeded with retry")
+            except NETWORK_PROBLEMS:
+                self.log.error("Fatal error sending data: %s", traceback.format_exc())
+                self.log.warning("Will skip failed data and continue running")
+
+    return _impl
+
+
+def get_with_retry(method):
+    @wraps(method)
+    def _impl(self, *args, **kwargs):
+        while True:
+            try:
+                return method(self, *args, **kwargs)
+            except NETWORK_PROBLEMS:
+                self.log.debug("Error making request: %s", traceback.format_exc())
+                self.log.warning("Failed to make request, will retry in %s sec...", self.user.timeout)
+                time.sleep(self.user.timeout)
+
+    return _impl
 
 
 class BZAObject(dict):
@@ -482,6 +524,7 @@ class Master(BZAObject):
         res = self._request(url, data, method='PATCH')
         self.update(res['result'])
 
+    @get_with_retry
     def get_status(self):
         sess = self._request(self.address + '/api/v4/masters/%s/status' % self['id'])
         return sess['result']
@@ -591,6 +634,7 @@ class Session(BZAObject):
         data = {"signature": self.data_signature, "testId": self['testId'], "sessionId": self['id']}
         self._request(url, data)
 
+    @send_with_retry
     def send_kpi_data(self, data, is_check_response=True, submit_target=None):
         """
         Sends online data
@@ -625,6 +669,7 @@ class Session(BZAObject):
             self.notify_monitoring_file(file_name)
             self.monitoring_upload_notified = True
 
+    @send_with_retry
     def upload_file(self, filename, contents=None):
         """
         Upload single artifact

--- a/bzt/modules/blazemeter/blazemeter_reporter.py
+++ b/bzt/modules/blazemeter/blazemeter_reporter.py
@@ -36,7 +36,6 @@ from bzt.utils import b, humanize_bytes, iteritems, open_browser, BetterDict, to
 from bzt.modules.aggregator import AggregatorListener, DataPoint, KPISet, ResultsProvider, ConsolidatingAggregator
 from bzt.modules.monitoring import Monitoring, MonitoringListener
 from bzt.modules.blazemeter.project_finder import ProjectFinder
-from bzt.modules.blazemeter.net_utils import send_with_retry
 from bzt.modules.blazemeter.const import NOTE_SIZE_LIMIT
 
 
@@ -351,7 +350,6 @@ class BlazeMeterUploader(Reporter, AggregatorListener, MonitoringListener, Singl
                 self.__send_monitoring()
         return super(BlazeMeterUploader, self).check()
 
-    @send_with_retry
     def __send_data(self, data, do_check=True, is_final=False):
         """
         :type data: list[bzt.modules.aggregator.DataPoint]
@@ -363,7 +361,6 @@ class BlazeMeterUploader(Reporter, AggregatorListener, MonitoringListener, Singl
             self.__extend_reported_data(data)
         serialized = self._dpoint_serializer.get_kpi_body(data, is_final)
 
-        # todo: send_with_retry only following (don't serialize many times):
         self._session.send_kpi_data(serialized, do_check)
 
     @staticmethod
@@ -396,7 +393,6 @@ class BlazeMeterUploader(Reporter, AggregatorListener, MonitoringListener, Singl
         if self.send_monitoring:
             self.monitoring_buffer.record_data(data)
 
-    @send_with_retry
     def __send_monitoring(self):
         engine_id = self.engine.config.get('modules').get('shellexec').get('env').get('TAURUS_INDEX_ALL', '')
         if not engine_id:

--- a/bzt/modules/blazemeter/cloud_provisioning.py
+++ b/bzt/modules/blazemeter/cloud_provisioning.py
@@ -42,7 +42,6 @@ from bzt.modules.services import Unpacker
 from bzt.requests_model import has_variable_pattern
 from bzt.utils import iteritems, open_browser, BetterDict, ExceptionalDownloader, ProgressBarContext
 from bzt.utils import to_json, dehumanize_time, get_full_path, get_files_recursive, replace_in_config
-from bzt.modules.blazemeter.net_utils import get_with_retry
 from bzt.modules.blazemeter.blazemeter_reporter import BlazeMeterUploader
 from bzt.modules.blazemeter.cloud_test import FUNC_API_TEST_TYPE, FUNC_GUI_TEST_TYPE, TAURUS_TEST_TYPE
 from bzt.modules.blazemeter.project_finder import ProjectFinder
@@ -472,7 +471,6 @@ class CloudProvisioning(MasterProvisioning, WidgetProvider):
         self.widget.update()
         return super(CloudProvisioning, self).check()
 
-    @get_with_retry
     def _check_master_status(self):
         return self.router.get_master_status()
 


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Would be great to avoid data extending/serialization several times.
For that purpose repeating network logic of is moved from BM reporter closer to bza interface.

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
