### PR TITLE
don't overlap user's yaml config with .bzt-rc

### DIFF
--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -168,7 +168,8 @@ class CLI(object):
         if self.options.no_system_configs is None:
             self.options.no_system_configs = False
 
-        if not self.options.no_system_configs:
+        load_hidden_configs = not self.options.no_system_configs
+        if load_hidden_configs:
             bzt_rc = os.path.expanduser(os.path.join('~', ".bzt-rc"))
             if os.path.exists(bzt_rc):
                 self.log.debug("Using personal config: %s" % bzt_rc)
@@ -177,7 +178,7 @@ class CLI(object):
                 self.log.info("No personal config found, creating one at %s", bzt_rc)
                 shutil.copy(os.path.join(RESOURCES_DIR, 'base-bzt-rc.yml'), bzt_rc)
 
-            configs += [bzt_rc]
+            configs.insert(0, bzt_rc)
 
         self.log.info("Starting with configs: %s", configs)
         merged_config = self.engine.configure(configs, not self.options.no_system_configs)


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
