### PR TITLE
Drop astunparse dependency for 3.9+

### DIFF
--- a/bzt/modules/_apiritif/generator.py
+++ b/bzt/modules/_apiritif/generator.py
@@ -18,6 +18,7 @@ import ast
 import math
 import re
 import string
+import sys
 from collections import OrderedDict
 from urllib import parse
 
@@ -1223,8 +1224,11 @@ from selenium.webdriver.common.keys import Keys
         stmts.append(self._gen_classdef())
 
         stmts = self._gen_imports() + stmts  # todo: order is important (with classdef) because of self.appium setup
-
-        return ast.Module(body=stmts)
+        if sys.version_info >= (3, 8):
+            # 3.8 AST has new type_ignores field
+            return ast.Module(body=stmts, type_ignores=[])
+        else:
+            return ast.Module(body=stmts, **kwargs)
 
     def _gen_imports(self):
         imports = [
@@ -1941,6 +1945,7 @@ from selenium.webdriver.common.keys import Keys
     def save(self, filename):
         with open(filename, 'wt', encoding='utf8') as fds:
             fds.write("# coding=utf-8\n")
+            ast.fix_missing_locations(self.tree)
             fds.write(unparse_ast(self.tree))
 
     def _gen_logging(self):

--- a/bzt/modules/_apiritif/generator.py
+++ b/bzt/modules/_apiritif/generator.py
@@ -21,14 +21,13 @@ import string
 from collections import OrderedDict
 from urllib import parse
 
-import astunparse
 import selenium
 
 from bzt import TaurusConfigError, TaurusInternalException
 from bzt.engine import Scenario
 from bzt.requests_model import HTTPRequest, HierarchicRequestParser, TransactionBlock, \
     SetVariables, IncludeScenarioBlock
-from bzt.utils import iteritems, dehumanize_time, ensure_is_dict, is_selenium_4
+from bzt.utils import iteritems, dehumanize_time, ensure_is_dict, is_selenium_4, unparse_ast
 from .ast_helpers import ast_attr, ast_call, gen_empty_line_stmt, gen_store, gen_subscript, gen_try_except, gen_raise
 from .jmeter_functions import JMeterExprCompiler
 
@@ -1942,7 +1941,7 @@ from selenium.webdriver.common.keys import Keys
     def save(self, filename):
         with open(filename, 'wt', encoding='utf8') as fds:
             fds.write("# coding=utf-8\n")
-            fds.write(astunparse.unparse(self.tree))
+            fds.write(unparse_ast(self.tree))
 
     def _gen_logging(self):
         set_log = ast.Assign(

--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -16,6 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import ast
 import codecs
 import copy
 import csv
@@ -1705,6 +1706,13 @@ class PythonGenerator(object):
 
     def gen_new_line(self, indent=0):
         return self.gen_statement("", indent=indent)
+
+
+if sys.version_info >= (3, 9):
+    unparse_ast = ast.unparse
+else:
+    import astunparse
+    unparse_ast = astunparse.unparse
 
 
 def str_representer(dumper, data):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 apiritif>=0.9.8
-astunparse>=1.6.0
+astunparse>=1.6.0; python_version < '3.9'
 colorama; sys_platform == 'win32'
 colorlog
 cssselect

--- a/tests/unit/cases.py
+++ b/tests/unit/cases.py
@@ -1,7 +1,6 @@
 import logging
 import difflib
 import ast
-import astunparse
 import sys
 from io import StringIO
 from logging import Handler
@@ -9,7 +8,7 @@ from unittest.case import TestCase
 
 from bzt.engine import ScenarioExecutor, EXEC
 from bzt.engine import SelfDiagnosable
-from bzt.utils import get_full_path
+from bzt.utils import get_full_path, unparse_ast
 from tests.unit import ROOT_LOGGER, EngineEmul
 from tests.unit.mocks import DummyOut
 
@@ -105,8 +104,8 @@ class BZTestCase(TestCase):
             exp_lines = [x.replace(key, subs[key]).rstrip() for x in exp_lines]
 
         if python_files:
-            act_lines = astunparse.unparse(ast.parse('\n'.join(act_lines))).split('\n')
-            exp_lines = astunparse.unparse(ast.parse('\n'.join(exp_lines))).split('\n')
+            act_lines = unparse_ast(ast.parse('\n'.join(act_lines))).split('\n')
+            exp_lines = unparse_ast(ast.parse('\n'.join(exp_lines))).split('\n')
 
         diff = list(difflib.unified_diff(exp_lines, act_lines))
 

--- a/tests/unit/modules/_selenium/test_selenium_builder.py
+++ b/tests/unit/modules/_selenium/test_selenium_builder.py
@@ -1,11 +1,11 @@
 # coding=utf-8
 
 import ast
-import astunparse
 import os
 
 import bzt.utils
 from bzt import TaurusConfigError
+from bzt.utils import unparse_ast
 from bzt.modules._apiritif.generator import is_selenium_4
 from tests.unit import RESOURCES_DIR
 from tests.unit.modules._selenium import SeleniumTestCase
@@ -1114,7 +1114,7 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
         ]
 
         for idx in range(len(target_lines)):
-            target_lines[idx] = astunparse.unparse(ast.parse(target_lines[idx]))
+            target_lines[idx] = unparse_ast(ast.parse(target_lines[idx]))
             self.assertIn(TestSeleniumScriptGeneration.clear_spaces(target_lines[idx]),
                           TestSeleniumScriptGeneration.clear_spaces(content),
                           msg="\n\n%s. %s" % (idx, target_lines[idx]))
@@ -1152,7 +1152,7 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
             "self.driver.find_element(target[0],target[1])).perform()"
         ]
         for idx in range(len(target_lines)):
-            target_lines[idx] = astunparse.unparse(ast.parse(target_lines[idx]))
+            target_lines[idx] = unparse_ast(ast.parse(target_lines[idx]))
             self.assertIn(TestSeleniumScriptGeneration.clear_spaces(target_lines[idx]),
                           TestSeleniumScriptGeneration.clear_spaces(content),
                           msg="\n\n%s. %s" % (idx, target_lines[idx]))
@@ -1967,7 +1967,7 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
             "wait_for('notclickable', [{'id':'myId'}], 10.0)"
         ]
         for idx in range(len(target_lines)):
-            target_lines[idx] = astunparse.unparse(ast.parse(target_lines[idx]))
+            target_lines[idx] = unparse_ast(ast.parse(target_lines[idx]))
             self.assertIn(TestSeleniumScriptGeneration.clear_spaces(target_lines[idx]),
                           TestSeleniumScriptGeneration.clear_spaces(content),
                           msg="\n\n%s. %s" % (idx, target_lines[idx]))


### PR DESCRIPTION
With Python 3.9, the standard library AST module now comes bundled with an AST unparser (which is what the `astunparse` based on), the [`ast.unparse`](https://docs.python.org/3/library/ast.html#ast.unparse). This would allow taurus to drop the hard requirement on it. I've moved the unparser to the `utils`, since and now it is under a conditional import. 
 
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
