### PR TITLE
take max concurrency during a second

### DIFF
--- a/bzt/modules/aggregator.py
+++ b/bzt/modules/aggregator.py
@@ -282,7 +282,9 @@ class KPISet(dict):
             # TODO: throughput if interval is not 1s
 
     def add_concurrency(self, cnc, sid):
-        self._concurrencies[sid] = cnc
+        # sid: source id, e.g. node id for jmeter distributed mode
+        if self._concurrencies.get(sid, 0) < cnc:   # take max value of concurrency during the second.
+            self._concurrencies[sid] = cnc
 
     @staticmethod
     def inc_list(values, selector, value):

--- a/site/dat/docs/changes/fix-max-concurrency.change
+++ b/site/dat/docs/changes/fix-max-concurrency.change
@@ -1,0 +1,1 @@
+take max concurrency during a second

--- a/tests/unit/modules/test_aggregator.py
+++ b/tests/unit/modules/test_aggregator.py
@@ -66,6 +66,17 @@ class TestResultsReader(BZTestCase):
         for kpis in (failed['current'], failed['cumulative']):
             self.assertEqual(1, kpis['b']['fail'])
 
+    def test_max_concurrency(self):
+        mock = MockReader()
+        # data format: t_stamp, label, conc, r_time, con_time, latency, r_code, error, trname, byte_count
+        mock.data.append((1, "a", 1, 1, 1, 1, 200, None, '', 0))
+        mock.data.append((1, "b", 3, 2, 2, 2, 200, None, '', 0))
+        mock.data.append((1, "c", 2, 4, 4, 4, 200, None, '', 0))
+
+        data_point = list(mock.datapoints(True))[0]
+        self.assertEqual(3, data_point[DataPoint.CURRENT][''][KPISet.CONCURRENCY])
+        self.assertEqual(3, data_point[DataPoint.CUMULATIVE][''][KPISet.CONCURRENCY])
+
     def test_sample_ignores(self):
         mock = MockReader()
         mock.ignored_labels = ["ignore"]


### PR DESCRIPTION
Concurrency can be variate during a second but taken max of them looks reasonable in most cases.
In order to satisfy DE509611


Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
