### PR TITLE
Avoid dialogs_replace when not needed

### DIFF
--- a/site/dat/docs/changes/fix-avoid-dialogs-replace.change
+++ b/site/dat/docs/changes/fix-avoid-dialogs-replace.change
@@ -1,0 +1,1 @@
+Avoid unnecessary call to dialogs_replace method when there are no actions that rely on it (i.e. assertdialog and answerdialog)

--- a/tests/resources/selenium/external_logging.py
+++ b/tests/resources/selenium/external_logging.py
@@ -9,7 +9,6 @@ from time import time, sleep
 
 import apiritif
 import traceback
-
 import os
 import re
 from selenium import webdriver
@@ -20,7 +19,7 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import action_start, dialogs_replace, waiter, get_locator, action_end
+from bzt.resources.selenium_extras import waiter, action_end, get_locator, action_start
 
 class TestSample(unittest.TestCase):
 
@@ -46,13 +45,11 @@ class TestSample(unittest.TestCase):
         action_end({'param': {}, 'type': 'new_session'})
 
 
-
     def _1_Test(self):
         with apiritif.smart_transaction('Test'):
             action_start({'param': 'http://blazedemo.com/', 'selectors': [], 'tag': '', 'type': 'go', 'value': None})
             self.driver.get('http://blazedemo.com/')
 
-            dialogs_replace()
             waiter()
             action_end({'param': 'http://blazedemo.com/', 'selectors': [], 'tag': '', 'type': 'go', 'value': None})
             action_start({'param': 'leaving blazedemo', 'selectors': [], 'tag': '', 'type': 'log', 'value': None})

--- a/tests/resources/selenium/generated_from_requests_appium_browser.py
+++ b/tests/resources/selenium/generated_from_requests_appium_browser.py
@@ -19,7 +19,7 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import dialogs_replace, get_locator, wait_for, waiter
+from bzt.resources.selenium_extras import waiter, get_locator, wait_for
 
 class TestLocScAppium(unittest.TestCase):
 
@@ -44,7 +44,6 @@ class TestLocScAppium(unittest.TestCase):
     def _1_(self):
         with apiritif.smart_transaction('/'):
             self.driver.get('http://blazedemo.com/')
-            dialogs_replace()
             wait_for('present', [{'xpath': "//input[@type='submit']"}], 3.5)
             self.assertEqual(self.driver.title, 'BlazeDemo')
             body = self.driver.page_source

--- a/tests/resources/selenium/generated_from_requests_flow_markers.py
+++ b/tests/resources/selenium/generated_from_requests_flow_markers.py
@@ -19,7 +19,7 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import wait_for, waiter, dialogs_replace, get_locator, add_flow_markers
+from bzt.resources.selenium_extras import waiter, add_flow_markers, get_locator, wait_for
 
 class TestLocSc(unittest.TestCase):
 
@@ -44,7 +44,6 @@ class TestLocSc(unittest.TestCase):
     def _1_(self):
         with apiritif.smart_transaction('/'):
             self.driver.get('http://blazedemo.com/')
-            dialogs_replace()
             wait_for('present', [{'xpath': "//input[@type='submit']"}], 3.5)
             self.assertEqual(self.driver.title, 'BlazeDemo')
             body = self.driver.page_source

--- a/tests/resources/selenium/generated_from_requests_if_then_else.py
+++ b/tests/resources/selenium/generated_from_requests_if_then_else.py
@@ -19,7 +19,7 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import waiter, get_locator, dialogs_replace
+from bzt.resources.selenium_extras import waiter, get_locator
 
 class TestLocSc(unittest.TestCase):
 
@@ -43,7 +43,6 @@ class TestLocSc(unittest.TestCase):
         with apiritif.smart_transaction('Conditions test'):
             self.driver.get('http://blazedemo.com')
 
-            dialogs_replace()
             waiter()
 
             test = self.driver.execute_script('return document.getElementsByName("fromPort")[0].length > 0;')

--- a/tests/resources/selenium/generated_from_requests_remote.py
+++ b/tests/resources/selenium/generated_from_requests_remote.py
@@ -19,7 +19,7 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import add_flow_markers, waiter, wait_for, dialogs_replace, get_locator
+from bzt.resources.selenium_extras import waiter, add_flow_markers, get_locator, wait_for
 
 class TestLocScRemote(unittest.TestCase):
 
@@ -44,7 +44,6 @@ class TestLocScRemote(unittest.TestCase):
     def _1_(self):
         with apiritif.smart_transaction('/'):
             self.driver.get('http://blazedemo.com/')
-            dialogs_replace()
             wait_for('present', [{'xpath': "//input[@type='submit']"}], 3.5)
             self.assertEqual(self.driver.title, 'BlazeDemo')
             body = self.driver.page_source


### PR DESCRIPTION
* Avoid unnecessary call to dialogs_replace method when there are no actions that rely on it (i.e. assertdialog and answerdialog)

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
