### PR TITLE
Update types of passfail validation messages in cloud

### DIFF
--- a/bzt/bza.py
+++ b/bzt/bza.py
@@ -498,7 +498,7 @@ class Test(BZAObject):
                     self.log.warning(f"Passfail Warning: {warning_msg}")
                 validated = True
         if not validated:
-            self.log.error(f"Passfail error: Unable to validate by {url}.")
+            self.log.debug(f"Passfail error: Unable to validate by {url}.")
         return validated
 
 

--- a/bzt/modules/blazemeter/cloud_provisioning.py
+++ b/bzt/modules/blazemeter/cloud_provisioning.py
@@ -223,13 +223,12 @@ class CloudProvisioning(MasterProvisioning, WidgetProvider):
         validate_passfail = any(reporter.get('module') == 'passfail' for reporter in reporting)
         if validate_passfail:
             if self.router._test.started_passfail_validation():
+                self.log.info("Please keep in mind that validation can take time.")
                 timeout = 100
                 for i in range(timeout):
                     if self.router._test.get_passfail_validation():
                         return
-                    self.log.warning(f"Unsuccessful Passfail validation attempt [{i + 1}]. Retrying...")
-                    if not i % 10:
-                        self.log.warning("Please keep in mind that validation can take time.")
+                    self.log.debug(f"Unsuccessful Passfail validation attempt [{i + 1}]. Retrying...")
                     sleep(1)
                 self.log.error("Unable get Passfail validation!")
             else:

--- a/site/dat/docs/changes/fix-passfail-cloud-warning-messages.change
+++ b/site/dat/docs/changes/fix-passfail-cloud-warning-messages.change
@@ -1,0 +1,1 @@
+Update types of passfail validation messages in cloud

--- a/tests/unit/modules/test_cloudProvisioning.py
+++ b/tests/unit/modules/test_cloudProvisioning.py
@@ -1597,8 +1597,10 @@ class TestCloudProvisioning(BZTestCase):
         self.obj.check()
 
         warnings = self.log_recorder.warn_buff.getvalue()
+        info = self.log_recorder.info_buff.getvalue()
         self.assertIn("Passfail Warning: passfail warning", warnings)
         self.assertIn("Passfail Warning: passfail file warning", warnings)
+        self.assertIn("Please keep in mind that validation can take time.", info)
 
     def test_nonstandard_env(self):
         self.obj.user.address = "https://some-bzm-link.com"


### PR DESCRIPTION
* logic
* test
* changefile

For bug DE512712.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
