### PR TITLE
Use .bzt instead of artifacts for -install-tools with python tools

### DIFF
--- a/bzt/modules/_apiritif/executor.py
+++ b/bzt/modules/_apiritif/executor.py
@@ -153,6 +153,10 @@ class ApiritifNoseExecutor(SubprocessedExecutor):
 
     def install_required_tools(self):
         self.apiritif = self._get_tool(Apiritif, engine=self.engine, version=self.settings.get("version", None))
+
+        if not self.parameters.get("temp", True):
+            self.apiritif.installer.settings['temp'] = False
+
         if not self.apiritif.check_if_installed():
             self.apiritif.install()
 

--- a/bzt/modules/_locustio.py
+++ b/bzt/modules/_locustio.py
@@ -73,11 +73,7 @@ class LocustIOExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInsta
             self.engine.aggregator.add_underling(self.reader)
 
     def install_required_tools(self):
-        self.locust = self._get_tool(Locust, engine=self.engine, version=self.settings.get("version", None))
-
-        if not self.parameters.get("temp", True):
-            self.locust.installer.settings['temp'] = False
-
+        self.locust = self._get_tool(Locust, engine=self.engine, settings=self.settings)
         if not self.locust.check_if_installed():
             self.locust.install()
 
@@ -173,6 +169,7 @@ class LocustIOExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInsta
 
     def post_process(self):
         self.locust.post_process()
+        super(LocustIOExecutor, self).post_process()
 
     def has_results(self):
         master_results = self.is_master and self.reader.cumulative
@@ -203,8 +200,10 @@ class LocustIOExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInsta
 
 
 class Locust(PythonTool):
-    def __init__(self, engine, version, **kwargs):
-        super(Locust, self).__init__(packages=["locust"], version=version, engine=engine, **kwargs)
+    def __init__(self, engine, settings, **kwargs):
+        version = settings.get("version", None)
+        temp = settings.get("temp", True)
+        super(Locust, self).__init__(packages=["locust"], temp_flag=temp, version=version, engine=engine, **kwargs)
 
 
 class WorkersReader(ResultsProvider):

--- a/bzt/modules/_locustio.py
+++ b/bzt/modules/_locustio.py
@@ -74,6 +74,10 @@ class LocustIOExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInsta
 
     def install_required_tools(self):
         self.locust = self._get_tool(Locust, engine=self.engine, version=self.settings.get("version", None))
+
+        if not self.parameters.get("temp", True):
+            self.locust.installer.settings['temp'] = False
+
         if not self.locust.check_if_installed():
             self.locust.install()
 

--- a/bzt/modules/_locustio.py
+++ b/bzt/modules/_locustio.py
@@ -201,9 +201,7 @@ class LocustIOExecutor(ScenarioExecutor, WidgetProvider, FileLister, HavingInsta
 
 class Locust(PythonTool):
     def __init__(self, engine, settings, **kwargs):
-        version = settings.get("version", None)
-        temp = settings.get("temp", True)
-        super(Locust, self).__init__(packages=["locust"], temp_flag=temp, version=version, engine=engine, **kwargs)
+        super(Locust, self).__init__(packages=["locust"], engine=engine, settings=settings, **kwargs)
 
 
 class WorkersReader(ResultsProvider):

--- a/bzt/modules/_molotov.py
+++ b/bzt/modules/_molotov.py
@@ -52,6 +52,10 @@ class MolotovExecutor(ScenarioExecutor, FileLister, WidgetProvider, HavingInstal
     def install_required_tools(self):
         self.molotov = self._get_tool(Molotov, engine=self.engine, version=self.settings.get("version", None),
                                       path=self.settings.get('path', None))
+
+        if not self.parameters.get("temp", True):
+            self.molotov.installer.settings['temp'] = False
+
         if not self.molotov.check_if_installed():
             self.molotov.install()
 

--- a/bzt/modules/_molotov.py
+++ b/bzt/modules/_molotov.py
@@ -50,12 +50,8 @@ class MolotovExecutor(ScenarioExecutor, FileLister, WidgetProvider, HavingInstal
             self.engine.aggregator.add_underling(self.reader)
 
     def install_required_tools(self):
-        self.molotov = self._get_tool(Molotov, engine=self.engine, version=self.settings.get("version", None),
+        self.molotov = self._get_tool(Molotov, engine=self.engine, settings=self.settings,
                                       path=self.settings.get('path', None))
-
-        if not self.parameters.get("temp", True):
-            self.molotov.installer.settings['temp'] = False
-
         if not self.molotov.check_if_installed():
             self.molotov.install()
 
@@ -118,6 +114,7 @@ class MolotovExecutor(ScenarioExecutor, FileLister, WidgetProvider, HavingInstal
 
     def post_process(self):
         self.molotov.post_process()
+        super(MolotovExecutor, self).post_process()
 
     def get_error_diagnostics(self):
         diagnostics = []
@@ -138,8 +135,8 @@ class MolotovExecutor(ScenarioExecutor, FileLister, WidgetProvider, HavingInstal
 
 
 class Molotov(PythonTool):
-    def __init__(self, engine, version, path, **kwargs):
-        super(Molotov, self).__init__(packages=["molotov"], version=version, engine=engine, **kwargs)
+    def __init__(self, engine, settings, path, **kwargs):
+        super(Molotov, self).__init__(packages=["molotov"], engine=engine, settings=settings, **kwargs)
         self.tool_path = os.path.join(self.tool_path, "bin", self.tool_name.lower())
         self.user_tool_path = path
 

--- a/bzt/modules/_pytest.py
+++ b/bzt/modules/_pytest.py
@@ -60,9 +60,7 @@ class PyTestExecutor(SubprocessedExecutor, HavingInstallableTools):
         """
         we need installed nose plugin
         """
-        self.pytest = self._get_tool(PyTest, engine=self.engine, version=self.settings.get("version", None))
-        if not self.parameters.get("temp", True):
-            self.pytest.installer.settings['temp'] = False
+        self.pytest = self._get_tool(PyTest, engine=self.engine, settings=self.settings)
         self._check_tools([self.pytest, self._get_tool(TaurusPytestRunner, tool_path=self.runner_path)])
 
     def startup(self):
@@ -93,8 +91,8 @@ class PyTestExecutor(SubprocessedExecutor, HavingInstallableTools):
         return super(PyTestExecutor, self).check()
 
     def post_process(self):
-        super(PyTestExecutor, self).post_process()
         self.pytest.post_process()
+        super(PyTestExecutor, self).post_process()
         self.__log_lines()
 
     def __log_lines(self):
@@ -108,9 +106,9 @@ class PyTestExecutor(SubprocessedExecutor, HavingInstallableTools):
 
 
 class PyTest(PythonTool):
-    def __init__(self, engine, version, **kwargs):
+    def __init__(self, engine, settings, **kwargs):
         super(PyTest, self).__init__(packages=["pytest", "pytest-xdist", "apiritif"],
-                                     version=version, engine=engine, **kwargs)
+                                     engine=engine, settings=settings, **kwargs)
 
 
 class TaurusPytestRunner(RequiredTool):

--- a/bzt/modules/_pytest.py
+++ b/bzt/modules/_pytest.py
@@ -61,6 +61,8 @@ class PyTestExecutor(SubprocessedExecutor, HavingInstallableTools):
         we need installed nose plugin
         """
         self.pytest = self._get_tool(PyTest, engine=self.engine, version=self.settings.get("version", None))
+        if not self.parameters.get("temp", True):
+            self.pytest.installer.settings['temp'] = False
         self._check_tools([self.pytest, self._get_tool(TaurusPytestRunner, tool_path=self.runner_path)])
 
     def startup(self):

--- a/bzt/modules/robot.py
+++ b/bzt/modules/robot.py
@@ -79,6 +79,8 @@ class RobotExecutor(SubprocessedExecutor, HavingInstallableTools):
 
     def install_required_tools(self):
         self.robot = self._get_tool(Robot, engine=self.engine, version=self.settings.get("version", None))
+        if not self.parameters.get("temp", True):
+            self.robot.installer.settings['temp'] = False
         self._check_tools([self.robot, self._get_tool(TaurusRobotRunner, tool_path=self.runner_path)])
 
     def startup(self):

--- a/bzt/modules/robot.py
+++ b/bzt/modules/robot.py
@@ -78,9 +78,7 @@ class RobotExecutor(SubprocessedExecutor, HavingInstallableTools):
                 raise TaurusConfigError("`tags` is not a string or text")
 
     def install_required_tools(self):
-        self.robot = self._get_tool(Robot, engine=self.engine, version=self.settings.get("version", None))
-        if not self.parameters.get("temp", True):
-            self.robot.installer.settings['temp'] = False
+        self.robot = self._get_tool(Robot, engine=self.engine, settings=self.settings)
         self._check_tools([self.robot, self._get_tool(TaurusRobotRunner, tool_path=self.runner_path)])
 
     def startup(self):
@@ -114,11 +112,12 @@ class RobotExecutor(SubprocessedExecutor, HavingInstallableTools):
 
     def post_process(self):
         self.robot.post_process()
+        super(RobotExecutor, self).post_process()
 
 
 class Robot(PythonTool):
-    def __init__(self, engine, version, **kwargs):
-        super(Robot, self).__init__(packages=["robotframework", "apiritif"], version=version, engine=engine, **kwargs)
+    def __init__(self, engine, settings, **kwargs):
+        super(Robot, self).__init__(packages=["robotframework", "apiritif"], engine=engine, settings=settings, **kwargs)
 
 
 class TaurusRobotRunner(RequiredTool):

--- a/bzt/modules/services.py
+++ b/bzt/modules/services.py
@@ -204,6 +204,9 @@ class InstallChecker(Service, Singletone):
         problems = []
         include_set = self._parse_module_filter(self.settings.get("include", []))
         exclude_set = self._parse_module_filter(self.settings.get("exclude", []))
+
+        modules = ["locust", "pytest", "molotov", "robot", "apiritif"]
+
         for mod_name in modules:
             if include_set and mod_name not in include_set:
                 continue
@@ -232,6 +235,7 @@ class InstallChecker(Service, Singletone):
             return
 
         self.log.info("Checking installation needs for: %s", mod_name)
+        mod.parameters["temp"] = False
         mod.install_required_tools()
         self.log.info("Module is fine: %s", mod_name)
 

--- a/bzt/modules/services.py
+++ b/bzt/modules/services.py
@@ -204,7 +204,6 @@ class InstallChecker(Service, Singletone):
         problems = []
         include_set = self._parse_module_filter(self.settings.get("include", []))
         exclude_set = self._parse_module_filter(self.settings.get("exclude", []))
-
         for mod_name in modules:
             if include_set and mod_name not in include_set:
                 continue

--- a/bzt/modules/services.py
+++ b/bzt/modules/services.py
@@ -134,10 +134,12 @@ class PipInstaller(Service):
 
 
 class PythonTool(RequiredTool):
-    def __init__(self, packages, temp_flag, version, engine, **kwargs):
+    def __init__(self, packages, engine, settings, **kwargs):
         tool_path = engine.temp_pythonpath
         super(PythonTool, self).__init__(tool_path=tool_path, **kwargs)
 
+        temp_flag = settings.get("temp", True)
+        version = settings.get("version", None)
         self.installer = PipInstaller(engine, packages=packages, temp_flag=temp_flag)
         if version:
             self.installer.versions[packages[0]] = version

--- a/bzt/modules/services.py
+++ b/bzt/modules/services.py
@@ -44,6 +44,7 @@ class PipInstaller(Service):
     def __init__(self, engine, packages=None, temp_flag=True):
         super(PipInstaller, self).__init__()
         self.packages = packages or []
+        self.has_installed_packages = False
         self.versions = BetterDict()
         self.engine = engine
         self.temp = temp_flag
@@ -52,7 +53,11 @@ class PipInstaller(Service):
         self.pip_cmd = [self.interpreter, "-m", "pip"]
 
     def _install(self, packages):
-        if not packages:
+        if packages:
+
+            # workaround for PythonTool, remove after expanding check logic from prepare() to PythonTool
+            self.has_installed_packages = True
+
             self.log.debug("Nothing to install")
             return
         cmdline = self.pip_cmd + ["install", "-t", self.target_dir]
@@ -127,7 +132,8 @@ class PipInstaller(Service):
         self._install(self.packages)
 
     def post_process(self):
-        if self.packages and self.temp and not is_windows() and os.path.exists(self.target_dir):    # might be forbidden on win as tool still work
+        # might be forbidden on win as tool still work
+        if self.has_installed_packages and self.temp and not is_windows():
             self.log.debug("remove packages: %s" % self.packages)
 
             shutil.rmtree(self.target_dir)  # it removes all content of directory in reality, not only self.packages

--- a/bzt/modules/services.py
+++ b/bzt/modules/services.py
@@ -53,13 +53,11 @@ class PipInstaller(Service):
         self.pip_cmd = [self.interpreter, "-m", "pip"]
 
     def _install(self, packages):
-        if packages:
-
-            # workaround for PythonTool, remove after expanding check logic from prepare() to PythonTool
-            self.has_installed_packages = True
-
+        if not packages:
             self.log.debug("Nothing to install")
             return
+        # workaround for PythonTool, remove after expanding check logic from prepare() to PythonTool
+        self.has_installed_packages = True
         cmdline = self.pip_cmd + ["install", "-t", self.target_dir]
         for package in packages:
             version = self.versions.get(package, None)
@@ -96,10 +94,10 @@ class PipInstaller(Service):
         return missed
 
     def _uninstall(self, packages):
-        pass     # todo:
+        pass  # todo:
 
     def _reload(self, packages):
-        pass     # todo:
+        pass  # todo:
 
     def prepare(self):
         """
@@ -123,7 +121,7 @@ class PipInstaller(Service):
         if not os.path.exists(self.target_dir):
             os.makedirs(get_full_path(self.target_dir), exist_ok=True)
 
-        if self._missed(["pip"]):   # extend to windows (bzt-pip)
+        if self._missed(["pip"]):  # extend to windows (bzt-pip)
             raise TaurusInternalException("pip module not found for interpreter %s" % self.interpreter)
         self.packages = self._missed(self.packages)
         if not self.packages:
@@ -455,7 +453,7 @@ class VirtualDisplay(Service, Singletone):
             self.log.info(msg, (width, height), self.virtual_display.new_display_var)
             VirtualDisplay.SHARED_VIRTUAL_DISPLAY = self.virtual_display
 
-            self.engine.shared_env.set({'DISPLAY': os.environ['DISPLAY']})   # backward compatibility
+            self.engine.shared_env.set({'DISPLAY': os.environ['DISPLAY']})  # backward compatibility
 
     def free_virtual_display(self):
         if self.virtual_display and self.virtual_display.is_alive():

--- a/bzt/modules/services.py
+++ b/bzt/modules/services.py
@@ -205,8 +205,6 @@ class InstallChecker(Service, Singletone):
         include_set = self._parse_module_filter(self.settings.get("include", []))
         exclude_set = self._parse_module_filter(self.settings.get("exclude", []))
 
-        modules = ["locust", "pytest", "molotov", "robot", "apiritif"]
-
         for mod_name in modules:
             if include_set and mod_name not in include_set:
                 continue

--- a/site/dat/docs/changes/fix-install-tools-check-directory.change
+++ b/site/dat/docs/changes/fix-install-tools-check-directory.change
@@ -1,0 +1,1 @@
+Use .bzt instead of artifacts for -install-tools

--- a/tests/unit/modules/test_services.py
+++ b/tests/unit/modules/test_services.py
@@ -19,8 +19,7 @@ class TestPipInstaller(BZTestCase):
     def setUp(self):
         engine = EngineEmul()
         engine.config.merge({'services': {'pip-installer': []}})
-        self.obj = PipInstaller()
-        self.obj.engine = engine
+        self.obj = PipInstaller(engine)
         super(TestPipInstaller, self).setUp()
 
     def tearDown(self):
@@ -45,7 +44,7 @@ class TestPipInstaller(BZTestCase):
 class TestPythonTool(BZTestCase):
     def setUp(self):
         self.engine = EngineEmul()
-        self.obj = PythonTool(engine=self.engine, packages=['test-name'], version=None)
+        self.obj = PythonTool(engine=self.engine, packages=['test-name'], settings={})
         super(TestPythonTool, self).setUp()
 
     def tearDown(self):

--- a/tests/unit/modules/test_services.py
+++ b/tests/unit/modules/test_services.py
@@ -3,9 +3,11 @@ import os
 import shutil
 import zipfile
 from os.path import join
+import bzt.utils
 
 from bzt import NormalShutdown, ToolError, TaurusConfigError
 from bzt.engine import Service, Provisioning, EngineModule
+from bzt.modules._locustio import LocustIOExecutor
 from bzt.modules.blazemeter import CloudProvisioning
 from bzt.modules.services import Unpacker, InstallChecker, AndroidEmulatorLoader, AppiumLoader, PipInstaller, PythonTool
 from bzt.utils import get_files_recursive, EXE_SUFFIX, JavaVM, Node, is_windows
@@ -193,6 +195,26 @@ class TestToolInstaller(BZTestCase):
         obj.engine.config.get("modules")["err"] = "hello there"
         obj.settings["include"] = "base,dummy"
         self.assertRaises(NormalShutdown, obj.prepare)
+
+    def test_python_module(self):
+        def mock_exec(*args, **kwargs):
+            return "locust here", ""
+
+        obj = InstallChecker()
+        obj.engine = EngineEmul()
+        obj.engine.config.get("modules")["locust"] = LocustIOExecutor.__module__ + "." + LocustIOExecutor.__name__
+        obj.settings["include"] = "locust"
+
+        old_exec = bzt.utils.exec_and_communicate
+        bzt.utils.exec_and_communicate = mock_exec
+        try:
+            obj.prepare()
+        except NormalShutdown:
+            pass
+        finally:
+            bzt.utils.exec_and_communicate = old_exec
+
+        self.assertFalse(obj.engine.config.get("modules").get('locust').get('temp'))
 
 
 class TestAndroidEmulatorLoader(BZTestCase):


### PR DESCRIPTION
* set constant place for pythontools in -install-tools case (to .bzt). It's important to avoid pythontool installation for every execution (e.g. in docker)
* extract version and temp flag at PythonTool level (not in executor)


Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
