### PR TITLE
Store value as parameter name in Apiritif

### DIFF
--- a/bzt/modules/_apiritif/ast_helpers.py
+++ b/bzt/modules/_apiritif/ast_helpers.py
@@ -60,5 +60,5 @@ def gen_store(name, value):
     return ast.Assign(
         targets=[ast.Subscript(
             value=ast_attr("self.vars"),
-            slice=ast.Str(name, kind=""))],
+            slice=name)],
         value=value)

--- a/bzt/modules/_apiritif/generator.py
+++ b/bzt/modules/_apiritif/generator.py
@@ -466,11 +466,11 @@ from selenium.webdriver.common.keys import Keys
                     args=[ast_attr("self.driver.title"), self._gen_expr(name)]))
             else:
                 elements.append(gen_store(
-                    name=name.strip(),
+                    name=self._gen_expr(name.strip()),
                     value=self._gen_expr(ast_attr("self.driver.title"))))
         elif atype == 'store' and tag == 'string':
             elements.append(gen_store(
-                name=name.strip(),
+                name=self._gen_expr(name.strip()),
                 value=self._gen_expr(value.strip())))
         elif atype == 'assert' and tag == 'eval':
             elements.append(ast_call(
@@ -479,7 +479,7 @@ from selenium.webdriver.common.keys import Keys
         elif atype == 'store' and tag == 'eval':
             elements.append(
                 gen_store(
-                    name=name.strip(),
+                    self._gen_expr(name.strip()),
                     value=self._gen_eval_js_expression(value))
             )
         else:
@@ -515,7 +515,7 @@ from selenium.webdriver.common.keys import Keys
                                         "strip")))]))
                 elif atype.startswith('store'):
                     elements.append(gen_store(
-                        name=name.strip(),
+                        self._gen_expr(name.strip()),
                         value=self._gen_expr(locator_attr)))
 
         return elements

--- a/site/dat/docs/changes/feat-apiritif-store-value-as-param.change
+++ b/site/dat/docs/changes/feat-apiritif-store-value-as-param.change
@@ -1,0 +1,1 @@
+Store value as parameter name


### PR DESCRIPTION
Possibility to use stored value as a name for another parameter.

Bug DE513219.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
