### PR TITLE
Update Robot return code check

### DIFF
--- a/bzt/modules/robot.py
+++ b/bzt/modules/robot.py
@@ -23,7 +23,7 @@ from bzt import TaurusConfigError
 from bzt.engine import HavingInstallableTools
 from bzt.modules import SubprocessedExecutor
 from bzt.modules.services import PythonTool
-from bzt.utils import RequiredTool
+from bzt.utils import RequiredTool, CALL_PROBLEMS
 from bzt.utils import get_full_path, RESOURCES_DIR
 
 
@@ -117,6 +117,18 @@ class RobotExecutor(SubprocessedExecutor, HavingInstallableTools):
 class Robot(PythonTool):
     def __init__(self, engine, version, **kwargs):
         super(Robot, self).__init__(packages=["robotframework", "apiritif"], version=version, engine=engine, **kwargs)
+
+    def check_if_installed(self):
+        self.log.debug(f"Checking {self.tool_name}.")
+        try:
+            _, _ = self.call([sys.executable, "-m", self.tool_name.lower(), "--version"])
+        except CALL_PROBLEMS as exc:
+            if exc.returncode == 251:
+                self.log.debug(f"{self.tool_name} output: {exc.stdout}")
+                return True
+
+            self.log.debug(f"{self.tool_name} check failed: {exc}")
+            return False
 
 
 class TaurusRobotRunner(RequiredTool):

--- a/site/dat/docs/changes/fix-robot-installation-check.change
+++ b/site/dat/docs/changes/fix-robot-installation-check.change
@@ -1,0 +1,1 @@
+Update Robot return code check


### PR DESCRIPTION
Robot returns nonzero code 251 while version check.

Robot return codes: http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#return-codes.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
