### PR TITLE
[WIP]remove duration assertion from jmx

### DIFF
--- a/bzt/jmx/tools.py
+++ b/bzt/jmx/tools.py
@@ -476,14 +476,7 @@ class JMeterScenarioBuilder(JMX):
         children.extend(self._get_timer(request))
 
         self.__add_assertions(children, request)
-
-        timeout = ProtocolHandler.safe_time(request.priority_option('timeout'))
-        if timeout is not None:
-            children.append(JMX._get_dur_assertion(timeout))
-            children.append(etree.Element("hashTree"))
-
         self.__add_extractors(children, request)
-
         self.__add_jsr_elements(children, request)
 
         return [sampler, children]


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
