### PR TITLE
Fix python 3.9 install issue with fuzzyset

### DIFF
--- a/bzt/modules/aggregator.py
+++ b/bzt/modules/aggregator.py
@@ -23,7 +23,7 @@ import time
 from abc import abstractmethod
 from collections import Counter
 
-import fuzzyset2 as fuzzyset
+import fuzzyset
 from hdrpy import HdrHistogram, RecordedIterator
 from yaml import SafeDumper
 from yaml.representer import SafeRepresenter

--- a/bzt/modules/aggregator.py
+++ b/bzt/modules/aggregator.py
@@ -23,7 +23,7 @@ import time
 from abc import abstractmethod
 from collections import Counter
 
-import fuzzyset
+import fuzzyset2 as fuzzyset
 from hdrpy import HdrHistogram, RecordedIterator
 from yaml import SafeDumper
 from yaml.representer import SafeRepresenter

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ colorama; sys_platform == 'win32'
 colorlog
 cssselect
 Cython; python_version >= '3.9'
-fuzzyset2==0.1.1
+fuzzyset2
 hdrpy>=0.3.3
 lxml>=4.6.2
 progressbar33

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ colorama; sys_platform == 'win32'
 colorlog
 cssselect
 Cython; python_version >= '3.9'
-fuzzyset==0.0.19
+fuzzyset2==0.1.1
 hdrpy>=0.3.3
 lxml>=4.6.2
 progressbar33

--- a/site/dat/docs/changes/fix-dep-fuzzyset-python39.change
+++ b/site/dat/docs/changes/fix-dep-fuzzyset-python39.change
@@ -1,0 +1,1 @@
+- fix fuzzyset dependency build to fail on python 3.9


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).
fuzzyset is deprecated in favor of https://pypi.org/project/fuzzyset2/
Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
