### PR TITLE
fix jmeter timeout generation

### DIFF
--- a/bzt/jmx/base.py
+++ b/bzt/jmx/base.py
@@ -906,18 +906,6 @@ class JMX(object):
         return cfg
 
     @staticmethod
-    def _get_dur_assertion(timeout):
-        """
-
-        :type timeout: int
-        :return:
-        """
-        element = etree.Element("DurationAssertion", guiclass="DurationAssertionGui",
-                                testclass="DurationAssertion", testname="Timeout Check")
-        element.append(JMX._string_prop("DurationAssertion.duration", timeout))
-        return element
-
-    @staticmethod
     def get_constant_timer(delay):
         timer_type = "ConstantTimer"
         element = etree.Element(timer_type, guiclass="%sGui" % timer_type, testclass=timer_type, testname="Think-Time")

--- a/bzt/jmx/base.py
+++ b/bzt/jmx/base.py
@@ -372,7 +372,7 @@ class JMX(object):
         proxy.append(JMX._bool_prop("HTTPSampler.follow_redirects", follow_redirects))
         proxy.append(JMX._bool_prop("HTTPSampler.auto_redirects", False))
 
-        if timeout is not None:
+        if timeout:
             proxy.append(JMX._string_prop("HTTPSampler.connect_timeout", timeout))
             proxy.append(JMX._string_prop("HTTPSampler.response_timeout", timeout))
 

--- a/bzt/jmx/http.py
+++ b/bzt/jmx/http.py
@@ -35,7 +35,7 @@ class HTTPProtocolHandler(ProtocolHandler):
 
         content_encoding = scenario.get("content-encoding", None)
 
-        timeout = scenario.get("timeout", None)
+        timeout = scenario.get("timeout", "30s")
         timeout = self.safe_time(timeout)
         elements = [JMX._get_http_defaults(default_address, timeout, retrieve_resources,
                                            concurrent_pool_size, content_encoding, resources_regex),
@@ -43,8 +43,6 @@ class HTTPProtocolHandler(ProtocolHandler):
         return elements
 
     def get_sampler_pair(self, request):
-        timeout = self.safe_time(request.priority_option('timeout'))
-
         # convert body to string
         if isinstance(request.body, (dict, list, numeric_types)):
             if request.get_header('content-type') == 'application/json' or isinstance(request.body, numeric_types):
@@ -63,6 +61,10 @@ class HTTPProtocolHandler(ProtocolHandler):
         # method can be put, post, or even variable
         if has_file_for_body and request.method != "GET":
             files = [{"path": body_file}]
+
+        timeout = self.safe_time(request.config.get("timeout"))
+        if not timeout:
+            timeout = ""  # timeless request forbidden (timeout = 0)
 
         http = JMX._get_http_request(request.url, request.label, request.method, timeout, request.body,
                                      request.priority_option('keepalive', default=True),

--- a/bzt/jmx/http.py
+++ b/bzt/jmx/http.py
@@ -63,8 +63,6 @@ class HTTPProtocolHandler(ProtocolHandler):
             files = [{"path": body_file}]
 
         timeout = self.safe_time(request.config.get("timeout"))
-        if not timeout:
-            timeout = ""  # timeless request forbidden (timeout = 0)
 
         http = JMX._get_http_request(request.url, request.label, request.method, timeout, request.body,
                                      request.priority_option('keepalive', default=True),

--- a/bzt/jmx/tools.py
+++ b/bzt/jmx/tools.py
@@ -476,14 +476,7 @@ class JMeterScenarioBuilder(JMX):
         children.extend(self._get_timer(request))
 
         self.__add_assertions(children, request)
-
-        timeout = ProtocolHandler.safe_time(request.priority_option('timeout'))
-        if timeout is not None:
-            children.append(JMX._get_dur_assertion(timeout))
-            children.append(etree.Element("hashTree"))
-
         self.__add_extractors(children, request)
-
         self.__add_jsr_elements(children, request)
 
         return [sampler, children]

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -215,7 +215,7 @@ scenarios:
     headers: # global headers
       header-name: header-value
     think-time: 1s500ms  # global delay between each request
-    timeout: 500ms  #  timeout for connecting, receiving results
+    timeout: 500ms  #  timeout for connecting, receiving results, default value is 30s
     default-address: "https://www.blazedemo.com:8080"  # http request defaults scheme, domain, port
     keepalive: true  # true by default, applied on all requests in scenario
     retrieve-resources: true  # true by default, retrieves all embedded resources from HTML pages
@@ -241,8 +241,6 @@ scenarios:
       random-order: false
 ```
 See more info about data-sources [here](DataSources.md).
-
-Note that `timeout` also sets duration assertion that will mark response failed if response time was more than timeout.
 
 If you want to use JMeter properties in `default-address`, you'll have to specify mandatory scheme and separate address/port. Like this: `default-address: https://${\__P(hostname)}:${\__P(port)}`.
 

--- a/tests/unit/modules/jmeter/test_JMeterExecutor.py
+++ b/tests/unit/modules/jmeter/test_JMeterExecutor.py
@@ -2911,17 +2911,17 @@ class TestJMeterExecutor(ExecutorTestCase):
 
         ct_id = "stringProp[@name='HTTPSampler.connect_timeout']"
         rt_id = "stringProp[@name='HTTPSampler.response_timeout']"
-        default_timeouts = [xml_tree.find(f".//{default_element}/{element}").text for element in (ct_id, rt_id)]
+        default_timeouts = [xml_tree.find(f".//{default_element}/{element}") for element in (ct_id, rt_id)]
 
         http_samplers = [f"HTTPSamplerProxy[@testname='http://request{num}.com']" for num in [1, 2]]
-        request1_timeouts = [xml_tree.find(f".//{http_samplers[0]}/{element}").text for element in (ct_id, rt_id)]
-        request2_timeouts = [xml_tree.find(f".//{http_samplers[1]}/{element}").text for element in (ct_id, rt_id)]
+        request1_timeouts = [xml_tree.find(f".//{http_samplers[0]}/{element}") for element in (ct_id, rt_id)]
+        request2_timeouts = [xml_tree.find(f".//{http_samplers[1]}/{element}") for element in (ct_id, rt_id)]
 
         duration_assertion_timeouts = xml_tree.findall(f".//stringProp[@name='DurationAssertion.duration']")
 
-        self.assertEqual(["1", "1"], default_timeouts)
+        self.assertEqual(["1", "1"], [t.text for t in default_timeouts])
         self.assertEqual([None, None], request1_timeouts)
-        self.assertEqual(["2", "2"], request2_timeouts)
+        self.assertEqual(["2", "2"], [t.text for t in request2_timeouts])
         self.assertEqual(0, len(duration_assertion_timeouts))
 
     def test_timeouts_default(self):
@@ -2940,15 +2940,15 @@ class TestJMeterExecutor(ExecutorTestCase):
 
         ct_id = "stringProp[@name='HTTPSampler.connect_timeout']"
         rt_id = "stringProp[@name='HTTPSampler.response_timeout']"
-        default_timeouts = [xml_tree.find(f".//{default_element}/{element}").text for element in (ct_id, rt_id)]
+        default_timeouts = [xml_tree.find(f".//{default_element}/{element}") for element in (ct_id, rt_id)]
 
         http_samplers = [f"HTTPSamplerProxy[@testname='http://request{num}.com']" for num in [1, 2]]
-        request1_timeouts = [xml_tree.find(f".//{http_samplers[0]}/{element}").text for element in (ct_id, rt_id)]
-        request2_timeouts = [xml_tree.find(f".//{http_samplers[1]}/{element}").text for element in (ct_id, rt_id)]
+        request1_timeouts = [xml_tree.find(f".//{http_samplers[0]}/{element}") for element in (ct_id, rt_id)]
+        request2_timeouts = [xml_tree.find(f".//{http_samplers[1]}/{element}") for element in (ct_id, rt_id)]
 
-        self.assertEqual(["30000", "30000"], default_timeouts)
+        self.assertEqual(["30000", "30000"], [t.text for t in default_timeouts])
         self.assertEqual([None, None], request1_timeouts)
-        self.assertEqual(["2", "2"], request2_timeouts)
+        self.assertEqual(["2", "2"], [t.text for t in request2_timeouts])
 
     def test_diagnostics(self):
         self.configure({

--- a/tests/unit/modules/jmeter/test_JMeterExecutor.py
+++ b/tests/unit/modules/jmeter/test_JMeterExecutor.py
@@ -588,7 +588,7 @@ class TestJMeterExecutor(ExecutorTestCase):
         xml_tree = etree.fromstring(open(self.obj.modified_jmx, "rb").read())
         sampler_element = xml_tree.findall(".//HTTPSamplerProxy[@testname='With body params']")
         arguments_element_prop = sampler_element[0][0]
-        self.assertEqual(11, len(sampler_element[0].getchildren()))
+        self.assertEqual(9, len(sampler_element[0].getchildren()))
         self.assertEqual(1, len(arguments_element_prop.getchildren()))
         self.assertEqual(2, len(arguments_element_prop[0].getchildren()))
         self.assertEqual(1, len(arguments_element_prop[0].findall(".//elementProp[@name='param1']")))

--- a/tests/unit/modules/jmeter/test_JMeterExecutor.py
+++ b/tests/unit/modules/jmeter/test_JMeterExecutor.py
@@ -2917,10 +2917,10 @@ class TestJMeterExecutor(ExecutorTestCase):
         request1_timeouts = [xml_tree.find(f".//{http_samplers[0]}/{element}").text for element in (ct_id, rt_id)]
         request2_timeouts = [xml_tree.find(f".//{http_samplers[1]}/{element}").text for element in (ct_id, rt_id)]
 
-        duration_assertion_timeouts = [xml_tree.findall(f".//stringProp[@name='DurationAssertion.duration']")]
+        duration_assertion_timeouts = xml_tree.findall(f".//stringProp[@name='DurationAssertion.duration']")
 
         self.assertEqual(["1", "1"], default_timeouts)
-        self.assertEqual(["", ""], request1_timeouts)
+        self.assertEqual([None, None], request1_timeouts)
         self.assertEqual(["2", "2"], request2_timeouts)
         self.assertEqual(0, len(duration_assertion_timeouts))
 
@@ -2947,7 +2947,7 @@ class TestJMeterExecutor(ExecutorTestCase):
         request2_timeouts = [xml_tree.find(f".//{http_samplers[1]}/{element}").text for element in (ct_id, rt_id)]
 
         self.assertEqual(["30000", "30000"], default_timeouts)
-        self.assertEqual(["", ""], request1_timeouts)
+        self.assertEqual([None, None], request1_timeouts)
         self.assertEqual(["2", "2"], request2_timeouts)
 
     def test_diagnostics(self):


### PR DESCRIPTION
Remove unnecessary duration assertion (request timeout must be enough)
Remove timeout inheritance (from scenario to request), let jmeter to manage them by itself
Set scenario timeout to 30s by default

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
