### PR TITLE
fix

### DIFF
--- a/tests/unit/modules/test_services.py
+++ b/tests/unit/modules/test_services.py
@@ -17,20 +17,15 @@ from tests.unit.mocks import ModuleMock, BZMock
 
 class TestPipInstaller(BZTestCase):
     def setUp(self):
-        self.obj = PipInstaller()
         super(TestPipInstaller, self).setUp()
-
-    def tearDown(self):
-        super(TestPipInstaller, self).tearDown()
+        self.obj = PipInstaller()
+        self.obj.engine = EngineEmul()
 
     def test_install(self):
         self.sniff_log(self.obj.log)
         self.obj.parameters['packages'] = ['test-package']
         self.obj.versions['test-package'] = "0.0.0"
         self.obj.pip_cmd = [join(RESOURCES_DIR, "python-pip", 'python-pip' + EXE_SUFFIX)]
-        engine = EngineEmul()
-        engine.config.merge({'services': {'pip-installer': []}})
-        self.obj.engine = engine
 
         self.obj.prepare()
         self.assertTrue(os.path.exists(self.obj.engine.temp_pythonpath))


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
