### PR TITLE
US759134 support 300 labels per engine

### DIFF
--- a/bzt/modules/aggregator.py
+++ b/bzt/modules/aggregator.py
@@ -786,7 +786,7 @@ class ConsolidatingAggregator(Aggregator, ResultsProvider):
     def __init__(self):
         Aggregator.__init__(self, is_functional=False)
         ResultsProvider.__init__(self)
-        self.generalize_labels = 500
+        self.generalize_labels = 900
         self.ignored_labels = ["ignore"]
         self.underlings = []
         self.buffer = {}

--- a/site/dat/docs/Reporting.md
+++ b/site/dat/docs/Reporting.md
@@ -124,7 +124,7 @@ The `consolidator` has several settings:
 ```yaml
 modules:
   consolidator:
-    generalize-labels: 500    # support up to this number of labels
+    generalize-labels: 900    # support up to this number of labels
     ignore-labels: # sample labels starting with prefixes from this list 
       - ignore     # will be ignored by results reader (eg ignore_myrequest)
       
@@ -151,7 +151,7 @@ modules:
 
 To handle a lot of test data correctly and efficiently, Taurus performs a few tricks when calculates statistics.
 
-For example, the number of requests/labels Taurus can handle is capped by `generalize-labels` option (100 by default).
+For example, the number of requests/labels Taurus can handle is capped by `generalize-labels` option (300 by default).
 Similar labels can be folded into a single one. For example, if the number of labels is high,
 `http://blazedemo.com/?foo=bar` and `http://blazedemo.com/?foo=baz` will be folded together and treated as two requests with the same label. This label merging only happens when you have more than 1/4 of `generalize-labels` utilized.
 

--- a/site/dat/docs/changes/update-default-handled-labels-count-to-300.change
+++ b/site/dat/docs/changes/update-default-handled-labels-count-to-300.change
@@ -1,0 +1,1 @@
+update default handled labels count to 300


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
