### PR TITLE
Allow for custom controllers by extending blocks parsing logic

### DIFF
--- a/bzt/jmx/parallel.py
+++ b/bzt/jmx/parallel.py
@@ -1,0 +1,56 @@
+from lxml import etree
+
+from bzt import TaurusConfigError
+from bzt.jmx.base import JMX
+from bzt.jmx.tools import RequestCompiler
+from bzt.requests_model import HierarchicRequestParser, Request
+
+
+class ParallelBlock(Request):
+    NAME = "parallel"
+
+    def __init__(self, do_clause, config):
+        super(ParallelBlock, self).__init__(config)
+        self.do_clause = do_clause
+
+    def __repr__(self):
+        do_clause = [repr(req) for req in self.do_clause]
+        return "ParallelBlock(do=%s)" % do_clause
+
+
+class ParallelRequestCompiler(RequestCompiler):
+    def __init__(self, jmx_builder):
+        super().__init__(jmx_builder)
+
+    def compile_parallel_block(self, block):
+        parallel_controller = self._get_parallel_controller()
+        parallel_children = etree.Element("hashTree")
+        for compiled in self.jmx_builder.compile_requests(block.do_clause):
+            for element in compiled:
+                parallel_children.append(element)
+
+        return [parallel_controller, parallel_children]
+
+    def _get_parallel_controller(self):
+        controller = etree.Element("com.blazemeter.jmeter.controller.ParallelSampler",
+                                   testname="Parallel Controller",
+                                   testclass="com.blazemeter.jmeter.controller.ParallelSampler",
+                                   guiclass="com.blazemeter.jmeter.controller.ParallelControllerGui")
+        controller.append(JMX.int_prop("MAX_THREAD_NUMBER", 6))
+        controller.append(JMX._bool_prop("PARENT_SAMPLE", False))
+        controller.append(JMX._bool_prop("LIMIT_MAX_THREAD_NUMBER", False))
+        return controller
+
+    def visit_parallelblock(self, block):
+        return self.compile_parallel_block(block)
+
+
+class ProtocolRequestParser(HierarchicRequestParser):
+    def _parse_request(self, req):
+        if 'parallel' in req:
+            do_clauses = req.get("do", TaurusConfigError("'do' clause is mandatory for 'parallel' blocks"))
+            do_requests = self._parse_requests(do_clauses)
+            return ParallelBlock(do_requests, req)
+
+        else:
+            return super()._parse_request(req)

--- a/bzt/jmx/tools.py
+++ b/bzt/jmx/tools.py
@@ -264,7 +264,7 @@ class JMeterScenarioBuilder(JMX):
 
         self.default_block_handler = self.executor.settings.get('default_block_handler', 'http')
         self.blocks_handler = {}
-        for block_name, block_classes in iteritems(self.executor.settings.get("block_handler", None)):
+        for block_name, block_classes in iteritems(self.executor.settings.get("block_handler", {})):
             self.blocks_handler[block_name] = {}
             cls_obj = load_class(block_classes['request-compiler'])
             request_compiler_instance = cls_obj(self)

--- a/bzt/jmx/tools.py
+++ b/bzt/jmx/tools.py
@@ -258,8 +258,8 @@ class JMeterScenarioBuilder(JMX):
         self.protocol_handlers = {}
         for protocol, cls_name in iteritems(self.executor.settings.get("protocol-handlers")):
             cls_obj = load_class(cls_name)
-            request_compiler_instance = cls_obj(self.system_props, self.engine)
-            self.protocol_handlers[protocol] = request_compiler_instance
+            instance = cls_obj(self.system_props, self.engine)
+            self.protocol_handlers[protocol] = instance
         self.FIELD_KEYSTORE_CONFIG = 'keystore-config'
 
         self.default_block_handler = self.executor.settings.get('default_block_handler', 'http')

--- a/bzt/jmx/tools.py
+++ b/bzt/jmx/tools.py
@@ -30,7 +30,7 @@ from bzt.utils import iteritems, numeric_types
 from bzt.utils import BetterDict, dehumanize_time, ensure_is_dict, load_class, guess_delimiter
 
 
-class RequestCompiler(RequestVisitor):  # TODO Apply logic similar to protocol handler
+class RequestCompiler(RequestVisitor):
     def __init__(self, jmx_builder):
         super(RequestCompiler, self).__init__()
         self.jmx_builder = jmx_builder
@@ -262,7 +262,6 @@ class JMeterScenarioBuilder(JMX):
             self.protocol_handlers[protocol] = request_compiler_instance
         self.FIELD_KEYSTORE_CONFIG = 'keystore-config'
 
-        # TODO look into eliminating structure replication. Maybe particular method to initialize extendable modules?
         self.default_block_handler = self.executor.settings.get('default_block_handler', 'http')
         self.blocks_handler = {}
         for block_name, block_classes in iteritems(self.executor.settings.get("block_handler", None)):

--- a/site/dat/docs/changes/feat-jmeter-extensible-custom-controllers-.change
+++ b/site/dat/docs/changes/feat-jmeter-extensible-custom-controllers-.change
@@ -1,0 +1,1 @@
+Add the ability to define custom controllers by overwriting two classes, similar to the way protocols are extended.

--- a/tests/unit/modules/jmeter/test_JMeterExecutor.py
+++ b/tests/unit/modules/jmeter/test_JMeterExecutor.py
@@ -3162,3 +3162,31 @@ class TestJMeterExecutor(ExecutorTestCase):
         self.assertTrue("RTEConnectionConfig.protocol" in xml_tree)
         self.assertTrue("RTEConnectionConfig.terminalType" in xml_tree)
         self.assertTrue("RTEConnectionConfig.connectTimeout" in xml_tree)
+
+    def test_full_extended_block_handlers(self):
+        self.obj.settings.merge({
+            'block_handler': {
+                'parallel': {
+                    "request-compiler": "bzt.jmx.parallel.ParallelRequestCompiler",
+                    "hierarchic-request-parser": "bzt.jmx.parallel.ProtocolRequestParser"
+                }}})
+
+        self.configure({"execution": {
+            "scenario": {
+                "block_handler": "parallel",
+                "requests": [{
+                    "parallel": "",
+                    "do": [{"url": "http://localhost",
+                           "extract-regexp": {
+                               "varname": {
+                                   "regexp": "???",
+                                   "scope": "variable",
+                                   "from-variable": "RESULT"}
+                           }}]
+                }]}
+            }
+        })
+        self.obj.prepare()
+        xml_tree = open(self.obj.modified_jmx, "rb").read().decode("utf-8")
+        self.assertTrue(".server" in xml_tree)
+        self.assertTrue("com.blazemeter.jmeter.controller.ParallelSampler" in xml_tree)


### PR DESCRIPTION
Hey Taurus team,
These changes will allow users to define their own `HierarchicRequestParser` and `RequestCompiler` in the same way that protocols are able to be extended. This is required for a few jmeter plugins, such as parallel controllers. I have provided the implementation of parallel controller along with this PR. 

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
