### PR TITLE
catch ProxyError while trying to install webdrivers

### DIFF
--- a/bzt/modules/_selenium.py
+++ b/bzt/modules/_selenium.py
@@ -21,9 +21,9 @@ from abc import abstractmethod
 from webdriver_manager.chrome import ChromeDriverManager
 from webdriver_manager.firefox import GeckoDriverManager
 from urwid import Text, Pile
-from requests.exceptions import ConnectionError
+from requests.exceptions import ConnectionError, ProxyError
 
-from bzt import TaurusConfigError, ToolError
+from bzt import TaurusConfigError
 from bzt.modules import ReportableExecutor
 from bzt.modules.console import PrioritizedWidget
 from bzt.utils import get_files_recursive, get_full_path, RequiredTool, is_windows
@@ -270,7 +270,7 @@ class ChromeDriver(RequiredTool):
                                          self.webdriver_manager.driver.get_os_type(),
                                          f'{self.webdriver_manager.driver.get_version()}',
                                          filename)
-            except (ValueError, ConnectionError) as err:
+            except (ValueError, ConnectionError, ProxyError) as err:
                 tool_path = os.path.join(base_dir, 'drivers/chromedriver', filename)
                 self.log.warning(err)
         super().__init__(tool_path=tool_path, installable=False, mandatory=False, **kwargs)
@@ -302,7 +302,7 @@ class GeckoDriver(RequiredTool):
                                          self.webdriver_manager.driver.get_os_type(),
                                          f'{self.webdriver_manager.driver.get_version()}',
                                          filename)
-            except (ValueError, ConnectionError) as err:
+            except (ValueError, ConnectionError, ProxyError) as err:
                 tool_path = os.path.join(base_dir, 'drivers/geckodriver', filename)
                 self.log.warning(err)
         super().__init__(tool_path=tool_path, installable=False, mandatory=False, **kwargs)


### PR DESCRIPTION
Add ProxyError to set of errors which can cause during installing webdrivers.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
