### PR TITLE
fix import of ArgOptions for selenium4

### DIFF
--- a/bzt/modules/_apiritif/generator.py
+++ b/bzt/modules/_apiritif/generator.py
@@ -113,7 +113,6 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.common.options import ArgOptions
 """
 
     BY_TAGS = ("byName", "byID", "byCSS", "byXPath", "byLinkText", "byElement", "byShadow")
@@ -1301,6 +1300,14 @@ from selenium.webdriver.common.options import ArgOptions
                 source = "selenium"
 
             imports.append(ast.parse(self.IMPORTS % source).body)
+            if self.selenium_version.startswith("4"):
+                imports.append(
+                    ast.ImportFrom(
+                        module="selenium.webdriver.common.options",
+                        names=[ast.alias(name="ArgOptions", asname=None)],
+                        level=0
+                    )
+                )
             self.selenium_extras.add("get_locator")
             self.selenium_extras.add("waiter")
             extra_names = [ast.alias(name=name, asname=None) for name in self.selenium_extras]

--- a/tests/resources/selenium/external_logging.py
+++ b/tests/resources/selenium/external_logging.py
@@ -19,7 +19,6 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import waiter, action_end, get_locator, action_start
 
 class TestSample(unittest.TestCase):

--- a/tests/resources/selenium/generated_from_requests.py
+++ b/tests/resources/selenium/generated_from_requests.py
@@ -19,7 +19,6 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import dialogs_answer_on_next_prompt, open_window, dialogs_get_next_prompt, switch_frame, dialogs_get_next_alert, dialogs_get_next_confirm, dialogs_answer_on_next_alert, close_window, waiter, wait_for, dialogs_answer_on_next_confirm, dialogs_replace, get_locator, switch_window
 reader_1 = apiritif.CSVReaderPerThread('first.csv', loop=True)
 reader_2 = apiritif.CSVReaderPerThread('second.csv', loop=False)

--- a/tests/resources/selenium/generated_from_requests_appium_browser.py
+++ b/tests/resources/selenium/generated_from_requests_appium_browser.py
@@ -19,7 +19,6 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import waiter, get_locator, wait_for
 
 class TestLocScAppium(unittest.TestCase):

--- a/tests/resources/selenium/generated_from_requests_flow_markers.py
+++ b/tests/resources/selenium/generated_from_requests_flow_markers.py
@@ -19,7 +19,6 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import waiter, add_flow_markers, get_locator, wait_for
 
 class TestLocSc(unittest.TestCase):

--- a/tests/resources/selenium/generated_from_requests_foreach.py
+++ b/tests/resources/selenium/generated_from_requests_foreach.py
@@ -19,7 +19,6 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import waiter, get_locator, get_elements
 
 class TestLocSc(unittest.TestCase):

--- a/tests/resources/selenium/generated_from_requests_if_then_else.py
+++ b/tests/resources/selenium/generated_from_requests_if_then_else.py
@@ -19,7 +19,6 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import waiter, get_locator
 
 class TestLocSc(unittest.TestCase):

--- a/tests/resources/selenium/generated_from_requests_loop_variables.py
+++ b/tests/resources/selenium/generated_from_requests_loop_variables.py
@@ -19,7 +19,6 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import waiter, get_locator, get_loop_range
 
 class TestLocSc(unittest.TestCase):

--- a/tests/resources/selenium/generated_from_requests_remote.py
+++ b/tests/resources/selenium/generated_from_requests_remote.py
@@ -19,7 +19,6 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import waiter, add_flow_markers, get_locator, wait_for
 
 class TestLocScRemote(unittest.TestCase):

--- a/tests/resources/selenium/generated_from_requests_shadow.py
+++ b/tests/resources/selenium/generated_from_requests_shadow.py
@@ -19,7 +19,6 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import waiter, get_locator, find_element_by_shadow
 
 class TestLocSc(unittest.TestCase):

--- a/tests/resources/selenium/generated_from_requests_v2.py
+++ b/tests/resources/selenium/generated_from_requests_v2.py
@@ -19,7 +19,6 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import dialogs_answer_on_next_prompt, open_window, dialogs_get_next_prompt, switch_frame, dialogs_answer_on_next_alert, dialogs_get_next_alert, dialogs_get_next_confirm, close_window, waiter, wait_for, dialogs_answer_on_next_confirm, dialogs_replace, get_locator, switch_window
 
 class TestLocSc(unittest.TestCase):

--- a/tests/resources/selenium/test_nfc.py
+++ b/tests/resources/selenium/test_nfc.py
@@ -19,7 +19,6 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import waiter, get_locator
 
 class TestSc1(unittest.TestCase):


### PR DESCRIPTION
fix import of ArgOptions for selenium4

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
