### PR TITLE
Remove old "unstable snapshot" warnings from docs

### DIFF
--- a/site/dat/docs/ApacheBenchmark.md
+++ b/site/dat/docs/ApacheBenchmark.md
@@ -75,5 +75,5 @@ specific Apache Benchmark options via `cmdline`:
 modules:
   ab:
     path: /home/john/build/apache2/bin/ab
-    cmdline: -e csv-file  # This feature is only available in the unstable snapshot.
+    cmdline: -e csv-file
 ```

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -140,7 +140,7 @@ You can specify special cli options for JMeter, for example:
 ```yaml
 modules:
   jmeter:
-    cmdline: --loglevel DEBUG  # This feature is only available in the unstable snapshot.
+    cmdline: --loglevel DEBUG
 ```
 
 ## Run JMeter in Distributed Mode

--- a/site/dat/docs/K6.md
+++ b/site/dat/docs/K6.md
@@ -31,7 +31,6 @@ export default function () {
 }
 ```
 ## Command-line Settings
-_This feature is only available in the [unstable snapshot](https://gettaurus.org/install/Installation/#Unstable-features)._
 You can specify special cli options for K6, for example:
 ```yaml
 modules:

--- a/site/dat/docs/Molotov.md
+++ b/site/dat/docs/Molotov.md
@@ -60,5 +60,5 @@ Also, you can pass specific `molotov` options via `cmdline`:
 modules:
   molotov:
     path: /home/john/venv/bin/molotov
-    cmdline: --verbose  # This feature is only available in the unstable snapshot.
+    cmdline: --verbose
 ```

--- a/site/dat/docs/Robot.md
+++ b/site/dat/docs/Robot.md
@@ -63,7 +63,7 @@ The `interpreter` option allows providing custom interpreter for your tests. Als
 modules:
   robot:
     interpreter: /usr/bin/python3
-    cmdline: --argumentfile file.txt  # This feature is only available in the unstable snapshot.
+    cmdline: --argumentfile file.txt
 ```
 
 ## Examples

--- a/site/dat/docs/Siege.md
+++ b/site/dat/docs/Siege.md
@@ -83,5 +83,5 @@ pass specific Siege via `cmdline`:
 modules:
   siege:
     path: /home/user/sources/siege/bin/siege
-    cmdline: --file=file.txt  # This feature is only available in the unstable snapshot.
+    cmdline: --file=file.txt
 ```

--- a/site/dat/docs/Tsung.md
+++ b/site/dat/docs/Tsung.md
@@ -118,7 +118,7 @@ to point Taurus to the `tsung` executable. Also, you can pass specific Tsung opt
 modules:
   tsung:
     path: /usr/local/bin/tsung
-    cmdline: -n  # This feature is only available in the unstable snapshot.
+    cmdline: -n
 ```
 
 ## Tsung Concurrency Stats

--- a/site/dat/docs/Vegeta.md
+++ b/site/dat/docs/Vegeta.md
@@ -10,7 +10,7 @@ Vegeta does not have so-called "virtual users", but it is very handy because it 
 
 In Taurus, `Vegeta` executor allows to run the load for given duration with specified request rate (throughput) using either existing Vegeta scripts or YAML representation of the HTTP requests.
 
-Vegeta can be auto-installed on Linux and macOS. For Windows manual installation is necessary. _This feature is only available in the [unstable snapshot](https://gettaurus.org/install/Installation/#Unstable-features)._
+Vegeta can be auto-installed on Linux and macOS. For Windows manual installation is necessary.
 
 In order to launch Vegeta executor, you can use yaml config like in the examples below.
 
@@ -52,7 +52,6 @@ scenarios:
 ```
 
 ## Command-line Settings
-_This feature is only available in the [unstable snapshot](https://gettaurus.org/install/Installation/#Unstable-features)._
 You can specify special cli options for Vegeta, for example:
 ```yaml
 modules:

--- a/site/dat/docs/changes/fix-remove-unstable-warnings.change
+++ b/site/dat/docs/changes/fix-remove-unstable-warnings.change
@@ -1,0 +1,1 @@
+Remove old "unstable snapshot" warnings from docs


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [x] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
