### PR TITLE
Rollback the latest assertion changes because of cloud bug

### DIFF
--- a/bzt/modules/aggregator.py
+++ b/bzt/modules/aggregator.py
@@ -794,7 +794,7 @@ class ConsolidatingAggregator(Aggregator, ResultsProvider):
 
     :type underlings: list[bzt.modules.aggregator.ResultsProvider]
     """
-    OVERALL_STATE = "all_transactions_aggregated"
+    OVERALL_LABEL = ""
 
     # TODO: switch to underling-count-based completeness criteria
     def __init__(self):
@@ -816,7 +816,7 @@ class ConsolidatingAggregator(Aggregator, ResultsProvider):
         return data
 
     def __extend_reported_data(self, kpi_sets):
-        def add_kpi_set_to_state(destination, _state=self.OVERALL_STATE):
+        def add_kpi_set_to_state(destination, _state):
             # add kpi_set to data[<label>][<_state>] value
             if _state not in destination:
                 destination[_state] = copy.deepcopy(kpi_set)  # avoid merging kpis for first sample
@@ -824,9 +824,10 @@ class ConsolidatingAggregator(Aggregator, ResultsProvider):
                 destination[_state].merge_kpis(kpi_set)  # deepcopy inside
                 destination[_state].recalculate()
 
+        overall_label = self.settings.get('overall-label', self.OVERALL_LABEL)
         data = kpi_sets['current']
-        overall_label = ''
-        mixed_labels = set(data.keys()) - {overall_label}
+        del data['']  # remove prev overall
+        mixed_labels = list(data.keys())  # take mixed_labels only (list of keys will be changed)
         data[overall_label] = dict()
         for key in mixed_labels:
             sep = key.rindex('-')
@@ -835,8 +836,8 @@ class ConsolidatingAggregator(Aggregator, ResultsProvider):
             if original_label not in data:
                 data[original_label] = dict()
 
-            add_kpi_set_to_state(data[overall_label])
-            add_kpi_set_to_state(data[original_label])
+            add_kpi_set_to_state(data[overall_label], overall_label)
+            add_kpi_set_to_state(data[original_label], overall_label)
             add_kpi_set_to_state(data[overall_label], state)
             add_kpi_set_to_state(data[original_label], state)
 

--- a/site/dat/docs/changes/fix-rollback-assertion-changes.change
+++ b/site/dat/docs/changes/fix-rollback-assertion-changes.change
@@ -1,0 +1,1 @@
+Rollback the latest changes because of cloud bug

--- a/tests/unit/modules/test_consolidatingAggregator.py
+++ b/tests/unit/modules/test_consolidatingAggregator.py
@@ -189,7 +189,7 @@ class TestConsolidatingAggregator(BZTestCase):
         self.obj.post_process()
 
         self.assertEqual(4, len(watcher.results))
-        allowed_states = set(SAMPLE_STATES + AGGREGATED_STATES + (ConsolidatingAggregator.OVERALL_STATE,))
+        allowed_states = set(SAMPLE_STATES + AGGREGATED_STATES + (ConsolidatingAggregator.OVERALL_LABEL,))
         for dp in watcher.results:
             written_kpis = dp['current']
             for label in written_kpis:


### PR DESCRIPTION
The number of assertions per label is incorrect, but the total number is fine.

Bug DE520333.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
