### PR TITLE
Revert commit 3e72208c2f308eab60051230b096c54b2732aac2

### DIFF
--- a/bzt/modules/aggregator.py
+++ b/bzt/modules/aggregator.py
@@ -627,23 +627,15 @@ class ResultsReader(ResultsProvider):
             self.track_percentiles = perc_levels
 
     @staticmethod
-    def get_mixed_label(label, kpis=None, rc=None):
+    def get_label(label, kpis):
         # it is used for generation of extended label.
         # each label data is splitted according to sample state (success/error/assert)
-
-        if rc:  # rc of error (from errors.jtl)
-            if rc == '200':
-                group = SAMPLE_STATES[1]    # jmeter error (assertion, etc.)
-            else:
-                group = SAMPLE_STATES[2]    # http error
+        if kpis[5] is None:
+            group = SAMPLE_STATES[0]   # no errors
+        elif kpis[5] == 'OK':
+            group = SAMPLE_STATES[1]   # jmeter error - assert, timeout, etc.
         else:
-            if kpis[4] == '200':
-                if kpis[5] is None:
-                    group = SAMPLE_STATES[0]    # successed sample
-                else:
-                    group = SAMPLE_STATES[1]  # jmeter error
-            else:
-                group = SAMPLE_STATES[2]  # http error
+            group = SAMPLE_STATES[2]   # other errors, usually RC != 200
 
         return '-'.join((label, str(group)))
 
@@ -716,7 +708,7 @@ class ResultsReader(ResultsProvider):
 
     def __add_sample(self, current, label, kpis):
         if self.redundant_aggregation:
-            label = self.get_mixed_label(label, kpis=kpis)
+            label = self.get_label(label, kpis)
 
         if label not in current:
             current[label] = KPISet(self.track_percentiles, self.__get_rtimes_max(label))

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -835,8 +835,7 @@ class JTLReader(ResultsReader):
         self.csvreader = IncrementalCSVReader(self.log, filename)
         self.read_records = 0
         if errors_filename:
-            self.errors_reader = JTLErrorsReader(
-                errors_filename, parent_logger, err_msg_separator, self.get_mixed_label)
+            self.errors_reader = JTLErrorsReader(errors_filename, parent_logger, err_msg_separator)
         else:
             self.errors_reader = None
 
@@ -882,7 +881,8 @@ class JTLReader(ResultsReader):
 
     def _calculate_datapoints(self, final_pass=False):
         for point in super(JTLReader, self)._calculate_datapoints(final_pass):
-            if self.errors_reader:
+            if self.errors_reader and not self.redundant_aggregation:
+                self.errors_reader.read_file()
                 err_details = self.errors_reader.get_data(point[DataPoint.TIMESTAMP])  # get only for labels we have
                 for label in err_details:
                     if label in point[DataPoint.CURRENT]:
@@ -891,9 +891,6 @@ class JTLReader(ResultsReader):
                         self.log.warning("Had error data but no KPISet %s: %s", label, err_details[label])
 
                 for label, label_data in iteritems(point[DataPoint.CURRENT]):
-                    if self.redundant_aggregation:
-                        continue
-
                     if label in err_details:
                         pass
                     elif label_data[KPISet.ERRORS]:
@@ -1182,7 +1179,7 @@ class JTLErrorsReader(object):
     """
     url_xpath = GenericTranslator().css_to_xpath("java\\.net\\.URL")
 
-    def __init__(self, filename, parent_logger, err_msg_separator=None, label_converter=None):
+    def __init__(self, filename, parent_logger, err_msg_separator=None):
         # http://stackoverflow.com/questions/9809469/python-sax-to-lxml-for-80gb-xml/9814580#9814580
         super(JTLErrorsReader, self).__init__()
         self.log = parent_logger.getChild(self.__class__.__name__)
@@ -1191,7 +1188,6 @@ class JTLErrorsReader(object):
         self.buffer = BetterDict()
         self.failed_processing = False
         self.err_msg_separator = err_msg_separator
-        self.label_converter = label_converter
 
     def read_file(self, final_pass=False):
         """
@@ -1278,8 +1274,6 @@ class JTLErrorsReader(object):
 
         err_item = KPISet.error_item_skel(f_msg, f_rc, 1, f_type, url_counts, f_tag)
         buf = self.buffer.get(t_stamp, force_set=True)
-        if self.label_converter:
-            label = self.label_converter(label, rc=f_rc)
         KPISet.inc_list(buf.get(label, [], force_set=True), ("msg", f_msg), err_item)
         KPISet.inc_list(buf.get('', [], force_set=True), ("msg", f_msg), err_item)
 

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -9,11 +9,13 @@ from random import random
 
 import requests
 
+from bzt.engine import Engine, Configuration, Singletone, Service
+from bzt.engine import Provisioning, Reporter, ScenarioExecutor
 from bzt.modules import TransactionListener
-from bzt.modules.aggregator import DataPoint, KPISet, ResultsReader, AggregatorListener, ConsolidatingAggregator
+from bzt.modules.aggregator import DataPoint, KPISet
+from bzt.modules.aggregator import ResultsReader, AggregatorListener
 from bzt.modules.functional import FunctionalResultsReader, FunctionalAggregatorListener
 from bzt.utils import b, load_class, to_json, get_full_path, get_uniq_name, FileReader, is_windows, temp_file
-from bzt.engine import Engine, Configuration, Singletone, Service, Provisioning, Reporter, ScenarioExecutor
 
 from tests.unit.base import TEST_DIR, ROOT_LOGGER, BUILD_DIR
 
@@ -253,18 +255,6 @@ class ModuleMock(ScenarioExecutor, Provisioning, Reporter, Service):
 
     def get_error_diagnostics(self):
         return ['DIAGNOSTICS']
-
-
-class MockListener(Reporter, AggregatorListener):
-    def __init__(self):
-        super(MockListener, self).__init__()
-        self.results = []
-
-    def aggregated_second(self, data):
-        aggregator = self.engine.aggregator
-        if isinstance(aggregator, ConsolidatingAggregator):
-            data = aggregator.converter(data)
-        self.results.append(data)
 
 
 class MockReader(ResultsReader, AggregatorListener):

--- a/tests/unit/modules/test_external.py
+++ b/tests/unit/modules/test_external.py
@@ -1,4 +1,4 @@
-from bzt.modules.aggregator import DataPoint, KPISet, ConsolidatingAggregator, SAMPLE_STATES
+from bzt.modules.aggregator import DataPoint, KPISet, ConsolidatingAggregator
 from bzt.modules.external import ExternalResultsLoader
 from bzt.modules.jmeter import FuncJTLReader, JTLReader
 from bzt.modules.ab import TSVDataReader
@@ -6,7 +6,7 @@ from bzt.modules.gatling import DataLogReader as GatlingLogReader
 from bzt.modules.vegeta import VegetaLogReader
 
 from tests.unit import RESOURCES_DIR, close_reader_file, ExecutorTestCase
-from tests.unit.mocks import MockReader, MockListener
+from tests.unit.mocks import MockReader
 
 
 class TestExternalResultsLoader(ExecutorTestCase):
@@ -74,75 +74,6 @@ class TestExternalResultsLoader(ExecutorTestCase):
         cumulative_kpis = last_dp[DataPoint.CUMULATIVE]['']
         self.assertIn('200', cumulative_kpis[KPISet.RESP_CODES])
         self.assertIn('404', cumulative_kpis[KPISet.RESP_CODES])
-
-    def test_errors_jtl_ext(self):
-        self.configure({
-            "execution": [{
-                "data-file": RESOURCES_DIR + "/jmeter/jtl/simple.kpi.jtl",
-                "errors-file": RESOURCES_DIR + "/jmeter/jtl/simple.error.jtl",
-            }]
-        })
-        self.obj.engine.aggregator.redundant_aggregation = True
-        self.obj.prepare()
-        self.obj.reader.redundant_aggregation = True
-        self.obj.startup()
-        self.obj.check()
-        self.obj.shutdown()
-        self.obj.post_process()
-        self.obj.engine.aggregator.post_process()
-        results = self.results_listener.results
-        self.assertGreater(len(results), 0)
-        last_dp = results[-1]
-        cumulative_kpis = last_dp[DataPoint.CUMULATIVE]['']
-        self.assertIn('200', cumulative_kpis[KPISet.RESP_CODES])
-        self.assertIn('404', cumulative_kpis[KPISet.RESP_CODES])
-        pass
-
-    def test_extend_data_and_assertion(self):
-        # check aggregated results for error details in the corresponding state record:
-        #   'current': {
-        #     <label>:
-        #       {'jmeter_errors': {..
-        #           'errors': [{'msg':..., 'tag':..., ...}, ...]..}, # there must be real jmeter errors and nothing more
-        #        'http_errors': {..}, 'success': {..}, ...}}, <other_labels>...}
-        self.configure({
-            "execution": [{
-                "data-file": RESOURCES_DIR + "/jmeter/jtl/kpi-pair1.jtl",
-                "errors-file": RESOURCES_DIR + "/jmeter/jtl/error-pair1.jtl",
-            }]
-        })
-        self.engine.aggregator.settings['extend-aggregation'] = True
-        watcher = MockListener()
-        watcher.engine = self.obj.engine
-
-        self.engine.aggregator.prepare()
-        self.obj.prepare()
-        self.engine.aggregator.add_listener(watcher)
-        self.engine.aggregator.startup()
-        self.obj.startup()
-
-        while not self.obj.check():
-            self.engine.aggregator.check()
-
-        self.obj.shutdown()
-        self.engine.aggregator.shutdown()
-        self.obj.post_process()
-        self.obj.engine.aggregator.post_process()
-
-        dp = watcher.results[0]['current']
-
-        success_label = 'Response Code 200'
-        self.assertEqual([], dp[success_label][SAMPLE_STATES[0]][KPISet.ERRORS])
-
-        jmeter_error_label = 'Invalid Assert (No results for path)'
-        sample_jmeter_error = ('No results for path: $[\'error\']', 'JSON Path Assertion - No results for path')
-        jmeter_errors_err = [(e['msg'], e['tag']) for e in dp[jmeter_error_label][SAMPLE_STATES[1]][KPISet.ERRORS]]
-        self.assertEqual({sample_jmeter_error}, set(jmeter_errors_err))
-
-        http_error_label = 'Response Code 400'
-        sample_http_error = ('Bad Request', None)
-        http_errors_err = [(e['msg'], e['tag']) for e in dp[http_error_label][SAMPLE_STATES[2]][KPISet.ERRORS]]
-        self.assertEqual({sample_http_error}, set(http_errors_err))
 
     def test_errors_jtl2(self):
         self.configure({


### PR DESCRIPTION
The number of assertions per label is incorrect, but the total number is fine.

Bug DE520333.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
