### PR TITLE
Support JMeter iterations value as a property

### DIFF
--- a/bzt/jmx/threadgroups.py
+++ b/bzt/jmx/threadgroups.py
@@ -60,7 +60,11 @@ class AbstractThreadGroup(object):
         try:
             return int(raw_val)
         except (ValueError, TypeError):
-            return raw_val
+            if isinstance(self, ThreadGroup):
+                return raw_val if raw_val else default
+            msg = "Parsing {param} '{val}' in group '{gtype}' failed, choose {default}"
+            self.log.warning(msg.format(param=name, val=raw_val, gtype=self.gtype, default=default))
+            return default
 
     def get_on_error(self):
         selector = ".//stringProp[@name='ThreadGroup.on_sample_error']"

--- a/bzt/jmx/threadgroups.py
+++ b/bzt/jmx/threadgroups.py
@@ -57,14 +57,12 @@ class AbstractThreadGroup(object):
         if raw:
             return raw_val
 
-        try:
-            return int(raw_val)
-        except (ValueError, TypeError):
-            if isinstance(self, ThreadGroup):
-                return raw_val if raw_val else default
-            msg = "Parsing {param} '{val}' in group '{gtype}' failed, choose {default}"
-            self.log.warning(msg.format(param=name, val=raw_val, gtype=self.gtype, default=default))
-            return default
+        if raw_val:
+            if raw_val.isdigit() or raw_val[1:].isdigit():  # positive or negative number
+                return int(raw_val)
+            else:
+                return raw_val
+        return default
 
     def get_on_error(self):
         selector = ".//stringProp[@name='ThreadGroup.on_sample_error']"

--- a/bzt/jmx/threadgroups.py
+++ b/bzt/jmx/threadgroups.py
@@ -60,9 +60,7 @@ class AbstractThreadGroup(object):
         try:
             return int(raw_val)
         except (ValueError, TypeError):
-            msg = "Parsing {param} '{val}' in group '{gtype}' failed, choose {default}"
-            self.log.warning(msg.format(param=name, val=raw_val, gtype=self.gtype, default=default))
-            return default
+            return raw_val
 
     def get_on_error(self):
         selector = ".//stringProp[@name='ThreadGroup.on_sample_error']"

--- a/site/dat/docs/changes/fix-jmeter-iterations-as-property.change
+++ b/site/dat/docs/changes/fix-jmeter-iterations-as-property.change
@@ -1,0 +1,1 @@
+When JMeter iterations value is a property, use it

--- a/tests/resources/jmeter/jmx/iterations-property.jmx
+++ b/tests/resources/jmeter/jmx/iterations-property.jmx
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.2.1">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath"></stringProp>
+    </TestPlan>
+    <hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="TG" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">${__P(LoopCount,5)}</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">${__P(NumberOfThreads,2)}</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="HTTP Request" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain"></stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">https://blazedemo.com/</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout"></stringProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+        <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/tests/unit/modules/jmeter/test_JMX.py
+++ b/tests/unit/modules/jmeter/test_JMX.py
@@ -407,7 +407,7 @@ class TestMQTTSamplers(BZTestCase):
         self.assertEqual(config['topic'], sample.find(".//stringProp[@name='mqtt.topic_name']").text)
         self.assertEqual("specified elapsed time (ms)",
                          sample.find(".//stringProp[@name='mqtt.sample_condition']").text)
-        self.assertEqual(str(config['time']*1000),
+        self.assertEqual(str(config['time'] * 1000),
                          sample.find(".//stringProp[@name='mqtt.sample_condition_value']").text)
         self.assertIn('jsr223', request.config)
         jsr223 = request.config.get('jsr223')[0]

--- a/tests/unit/modules/jmeter/test_JMX.py
+++ b/tests/unit/modules/jmeter/test_JMX.py
@@ -316,16 +316,14 @@ class TestLoadSettingsProcessor(BZTestCase):
                        jmx_file=RESOURCES_DIR + 'jmeter/jmx/iterations-property.jmx',
                        settings={'force-ctg': False})
         self.sniff_log(self.obj.log)
-        self.assertEqual(LoadSettingsProcessor.TG, self.obj.tg)  # because keep-iterations is True
+
+        self.assertEqual(LoadSettingsProcessor.TG, self.obj.tg)
         self.obj.modify(self.jmx)
 
         res_values = {}
         for group in self.get_groupset():
             res_values[group.get_testname()] = {'conc': group.get_concurrency(), 'iter': group.get_iterations()}
-
         self.assertEqual(res_values, {'TG': {'conc': 2, 'iter': '${__P(LoopCount,5)}'}})
-        msg = "Parsing loops \'${__P(LoopCount,5)}\' in group \'ThreadGroup\' failed, choose None"
-        self.assertNotIn(msg, self.log_recorder.warn_buff.getvalue())
 
     def test_TG_iterations_from_load(self):
         """ThreadGroup:  concurrency, ramp-up, iterations"""

--- a/tests/unit/modules/jmeter/test_JMX.py
+++ b/tests/unit/modules/jmeter/test_JMX.py
@@ -311,6 +311,17 @@ class TestLoadSettingsProcessor(BZTestCase):
             self.assertEqual(group.gtype, "ThreadGroup")
             self.assertEqual("-1", group.element.find(".//*[@name='LoopController.loops']").text)
 
+    def test_TG_iterations_property(self):
+        self.configure(jmx_file=RESOURCES_DIR + 'jmeter/jmx/iterations-property.jmx', settings={'force-ctg': False})
+        self.assertEqual(LoadSettingsProcessor.TG, self.obj.tg)  # because keep-iterations is True
+        self.obj.modify(self.jmx)
+
+        res_values = {}
+        for group in self.get_groupset():
+            res_values[group.get_testname()] = {'conc': group.get_concurrency(), 'iter': group.get_iterations()}
+
+        self.assertEqual(res_values, {'TG': {'conc': 2, 'iter': '${__P(LoopCount,5)}'}})
+
     def test_TG_iterations_from_load(self):
         """ThreadGroup:  concurrency, ramp-up, iterations"""
         self.configure(load={'concurrency': 76, 'ramp-up': 4, 'iterations': 5},

--- a/tests/unit/modules/jmeter/test_JMX.py
+++ b/tests/unit/modules/jmeter/test_JMX.py
@@ -312,7 +312,9 @@ class TestLoadSettingsProcessor(BZTestCase):
             self.assertEqual("-1", group.element.find(".//*[@name='LoopController.loops']").text)
 
     def test_TG_iterations_property(self):
-        self.configure(jmx_file=RESOURCES_DIR + 'jmeter/jmx/iterations-property.jmx', settings={'force-ctg': False})
+        self.configure(load={'hold-for': 1},
+                       jmx_file=RESOURCES_DIR + 'jmeter/jmx/iterations-property.jmx',
+                       settings={'force-ctg': False})
         self.sniff_log(self.obj.log)
         self.assertEqual(LoadSettingsProcessor.TG, self.obj.tg)  # because keep-iterations is True
         self.obj.modify(self.jmx)

--- a/tests/unit/modules/jmeter/test_JMX.py
+++ b/tests/unit/modules/jmeter/test_JMX.py
@@ -313,6 +313,7 @@ class TestLoadSettingsProcessor(BZTestCase):
 
     def test_TG_iterations_property(self):
         self.configure(jmx_file=RESOURCES_DIR + 'jmeter/jmx/iterations-property.jmx', settings={'force-ctg': False})
+        self.sniff_log(self.obj.log)
         self.assertEqual(LoadSettingsProcessor.TG, self.obj.tg)  # because keep-iterations is True
         self.obj.modify(self.jmx)
 
@@ -321,6 +322,8 @@ class TestLoadSettingsProcessor(BZTestCase):
             res_values[group.get_testname()] = {'conc': group.get_concurrency(), 'iter': group.get_iterations()}
 
         self.assertEqual(res_values, {'TG': {'conc': 2, 'iter': '${__P(LoopCount,5)}'}})
+        msg = "Parsing loops \'${__P(LoopCount,5)}\' in group \'ThreadGroup\' failed, choose None"
+        self.assertNotIn(msg, self.log_recorder.warn_buff.getvalue())
 
     def test_TG_iterations_from_load(self):
         """ThreadGroup:  concurrency, ramp-up, iterations"""


### PR DESCRIPTION
Use JMeter property as interations value when not ctg.

Bug DE514864.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
