### PR TITLE
Run bzt in Docker with Python 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,7 @@ RUN bash ./setup_12.x \
      apt-transport-https openjdk-11-jdk xvfb siege apache2-utils firefox ruby nodejs locales
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
 
-RUN $PIP_INSTALL numpy
-RUN $APT_INSTALL tsung
+RUN $PIP_INSTALL numpy && $APT_INSTALL tsung
 
 # set en_US.UTF-8 as default locale
 RUN locale-gen "en_US.UTF-8" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,12 @@ WORKDIR /tmp
 # add node repo and call 'apt-get update'
 RUN bash ./setup_12.x \
    && $APT_INSTALL \
-     python3-pip unzip build-essential python3-dev software-properties-common \
-     apt-transport-https openjdk-11-jdk xvfb siege tsung apache2-utils firefox ruby nodejs locales
+     python3-pip unzip build-essential python3.9-dev software-properties-common \
+     apt-transport-https openjdk-11-jdk xvfb siege apache2-utils firefox ruby nodejs locales
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
+
+RUN $PIP_INSTALL numpy
+RUN $APT_INSTALL tsung
 
 # set en_US.UTF-8 as default locale
 RUN locale-gen "en_US.UTF-8" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,18 +14,21 @@ COPY dist/bzt*whl /tmp
 WORKDIR /tmp
 # add node repo and call 'apt-get update'
 RUN bash ./setup_12.x \
-   && $APT_INSTALL \
-     python3-pip unzip build-essential python3.9-dev software-properties-common \
-     apt-transport-https openjdk-11-jdk xvfb siege apache2-utils firefox ruby nodejs locales
+   && $APT_INSTALL python3-pip python3.9-dev
+
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
 
-RUN $PIP_INSTALL numpy && $APT_INSTALL tsung
+# numpy & chardet must be installed before the same apt packages
+RUN $PIP_INSTALL setuptools wheel numpy chardet
+
+RUN $APT_UPDATE && $APT_INSTALL \
+    unzip build-essential software-properties-common apt-transport-https \
+    openjdk-11-jdk xvfb siege apache2-utils firefox ruby nodejs locales tsung
 
 # set en_US.UTF-8 as default locale
 RUN locale-gen "en_US.UTF-8" \
    && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 
-RUN $PIP_INSTALL setuptools wheel
 RUN gem install rspec rake selenium-webdriver
 
 # Get Google Chrome

--- a/site/dat/docs/changes/feat-support-py39-in-docker.change
+++ b/site/dat/docs/changes/feat-support-py39-in-docker.change
@@ -1,0 +1,1 @@
+Run bzt in Docker with Python 3.9


### PR DESCRIPTION
Problem:
Conflict of chardet and numpy versions happened due to different logic of python package installation of pip & dpkg. 
The second one doesn't provide any checks for already installed packages.
It's related to following apt packages: python3-chardet & python3-numpy.
Solution:
According to this mentioned packages must be installed explicitly with pip before of dpkg alternatives.
New versions are installed into /usr/lib/python3.9/dist-packages (instead of /usr/lib/python3/dist-packages) and thus they mask correspond apt packages (obsolete ones) on the level of sys.path namespace.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
