### PR TITLE
Multiply concurrency and iteration values for K6

### DIFF
--- a/bzt/modules/k6.py
+++ b/bzt/modules/k6.py
@@ -57,7 +57,8 @@ class K6Executor(ScenarioExecutor):
             cmdline += ['--duration', str(int(load.hold)) + "s"]
 
         if load.iterations:
-            cmdline += ['--iterations', str(load.iterations)]
+            iterations = load.iterations * load.concurrency if load.concurrency else load.iterations
+            cmdline += ['--iterations', str(iterations)]
 
         user_cmd = self.settings.get("cmdline")
         if user_cmd:

--- a/site/dat/docs/changes/fix-k6-iterations-value.change
+++ b/site/dat/docs/changes/fix-k6-iterations-value.change
@@ -1,0 +1,1 @@
+multiply concurrency and iteration values for K6

--- a/tests/unit/modules/test_k6.py
+++ b/tests/unit/modules/test_k6.py
@@ -92,6 +92,17 @@ class TestK6Executor(ExecutorTestCase):
         })
         self.assertIn("--iterations 100", self.CMD_LINE)
 
+    def test_iterations_multiplied(self):
+        self.simple_run({
+            "execution": {
+                "iterations": "10",
+                "concurrency": "10",
+                "scenario": {"script": K6_SCRIPT},
+                "executor": "k6"
+            },
+        })
+        self.assertIn("--iterations 100", self.CMD_LINE)
+
 
 class TestK6Reader(BZTestCase):
     def test_read(self):


### PR DESCRIPTION
By default, K6 divides iteration value by concurrency value. 

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
