### PR TITLE
Update jmeter default version to 5.4.1

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1375,7 +1375,7 @@ class JMeter(RequiredTool):
     PLUGINS_MANAGER = 'https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-manager/{version}/jmeter-plugins-manager-{version}.jar'
     COMMAND_RUNNER_VERSION = "2.2"
     COMMAND_RUNNER = 'https://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/{version}/cmdrunner-{version}.jar'
-    VERSION = "5.2.1"
+    VERSION = "5.4.1"
 
     def __init__(self, config=None, props=None, **kwargs):
         settings = config or {}

--- a/site/dat/docs/changes/fix-update-jmeter-version.change
+++ b/site/dat/docs/changes/fix-update-jmeter-version.change
@@ -1,0 +1,1 @@
+Update default version of jmeter tool to 5.4.1


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [X] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [X] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
