### PR TITLE
DE522215: fix 'headless' for selenium4

### DIFF
--- a/bzt/modules/_apiritif/generator.py
+++ b/bzt/modules/_apiritif/generator.py
@@ -1020,10 +1020,10 @@ from selenium.webdriver.common.keys import Keys
     def _get_headless_setup(self):
         if self.scenario.get("headless", False):
             self.log.info("Headless mode works only with Selenium 3.8.0+, be sure to have it installed")
-            return [ast.Expr(
-                ast_call(func=ast_attr("options.set_headless")))]
-        else:
-            return []
+            if self.selenium_version.startswith("4"):
+                return [ast.Assign(targets=[ast_attr("options.headless")], value=ast_attr("True"))]
+            return [ast.Expr(ast_call(func=ast_attr("options.set_headless")))]
+        return []
 
     def _get_options(self, browser):
         if browser == 'remote':

--- a/bzt/modules/_apiritif/generator.py
+++ b/bzt/modules/_apiritif/generator.py
@@ -1021,9 +1021,12 @@ from selenium.webdriver.common.keys import Keys
         if self.scenario.get("headless", False):
             self.log.info("Headless mode works only with Selenium 3.8.0+, be sure to have it installed")
             if self.selenium_version.startswith("4"):
-                return [ast.Assign(targets=[ast_attr("options.headless")], value=ast_attr("True"))]
-            return [ast.Expr(ast_call(func=ast_attr("options.set_headless")))]
-        return []
+                return [ast.Assign(
+                    targets=[ast_attr("options.headless")], value=ast_attr("True"))]
+            return [ast.Expr(
+                ast_call(func=ast_attr("options.set_headless")))]
+        else:
+            return []
 
     def _get_options(self, browser):
         if browser == 'remote':

--- a/site/dat/docs/changes/fix-headless-for-selenium-4.change
+++ b/site/dat/docs/changes/fix-headless-for-selenium-4.change
@@ -1,0 +1,1 @@
+Update 'options.headless = True' for selenium 4.

--- a/tests/unit/modules/_selenium/test_selenium_builder.py
+++ b/tests/unit/modules/_selenium/test_selenium_builder.py
@@ -2451,7 +2451,7 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
 
         self.obj_prepare()
         exp_file = RESOURCES_DIR + "selenium/generated_from_requests_shadow.py"
-        str_to_replace = (self.obj.xengine.artifacts_dir + os.path.sep).replace('\\', '\\\\')
+        str_to_replace = (self.obj.engine.artifacts_dir + os.path.sep).replace('\\', '\\\\')
         self.assertFilesEqual(exp_file, self.obj.script, str_to_replace, "/somewhere/", python_files=True)
 
 

--- a/tests/unit/modules/_selenium/test_selenium_builder.py
+++ b/tests/unit/modules/_selenium/test_selenium_builder.py
@@ -2451,7 +2451,7 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
 
         self.obj_prepare()
         exp_file = RESOURCES_DIR + "selenium/generated_from_requests_shadow.py"
-        str_to_replace = (self.obj.engine.artifacts_dir + os.path.sep).replace('\\', '\\\\')
+        str_to_replace = (self.obj.xengine.artifacts_dir + os.path.sep).replace('\\', '\\\\')
         self.assertFilesEqual(exp_file, self.obj.script, str_to_replace, "/somewhere/", python_files=True)
 
 
@@ -2540,3 +2540,20 @@ class TestIsSelenium4(SeleniumTestCase):
         ]
         for idx in range(len(target_lines)):
             self.assertIn(target_lines[idx], content, msg="\n\n%s. %s" % (idx, target_lines[idx]))
+
+    def test_headless_chrome_selenium_4(self):
+        self.configure({
+            "execution": [{
+                "executor": "selenium",
+                "scenario": "loc_sc"}],
+            "scenarios": {
+                "loc_sc": {
+                    "browser": "Firefox",
+                    "headless": True,
+                    "requests": ["http://blazedemo.com/"]
+                }}})
+
+        self.obj_prepare()
+        with open(self.obj.script) as generated:
+            gen_contents = generated.read()
+        self.assertIn("options.headless = True", gen_contents)

--- a/tests/unit/modules/_selenium/test_selenium_builder.py
+++ b/tests/unit/modules/_selenium/test_selenium_builder.py
@@ -2548,7 +2548,7 @@ class TestIsSelenium4(SeleniumTestCase):
                 "scenario": "loc_sc"}],
             "scenarios": {
                 "loc_sc": {
-                    "browser": "Firefox",
+                    "browser": "Chrome",
                     "headless": True,
                     "requests": ["http://blazedemo.com/"]
                 }}})


### PR DESCRIPTION
Fix for migration defect from selenium 3 to selenium 4: set 'options.headless = True' in test_requests.py in case if selenium 4 is used for launching the test.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
