### PR TITLE
webdriver: don't fail the test if driver couldn't be downloaded

### DIFF
--- a/bzt/modules/_selenium.py
+++ b/bzt/modules/_selenium.py
@@ -25,8 +25,7 @@ from bzt import TaurusConfigError
 from bzt.modules import ReportableExecutor
 from bzt.modules.console import PrioritizedWidget
 from bzt.modules.services import PythonTool
-from bzt.utils import get_files_recursive, get_full_path, RequiredTool, is_windows, is_mac, platform_bitness, unzip, \
-    untar
+from bzt.utils import get_files_recursive, get_full_path, RequiredTool, is_windows, is_mac, unzip, untar
 
 
 class AbstractSeleniumExecutor(ReportableExecutor):

--- a/bzt/modules/_selenium.py
+++ b/bzt/modules/_selenium.py
@@ -308,8 +308,11 @@ class WebDriver(RequiredTool):
         shutil.copy2(driver_path, self.dest)
 
     def _install_by_link(self):
-        self._get_download_link()
-        self._download_and_save()
+        try:
+            self._get_download_link()
+            self._download_and_save()
+        except BaseException as exc:
+            self.log.warning(f"{self.tool_name} wasn't downloaded. Reason: {type(exc).__name__}, {exc}")
 
     def _get_download_link(self):
         pass

--- a/bzt/modules/_selenium.py
+++ b/bzt/modules/_selenium.py
@@ -345,7 +345,8 @@ class GeckoDriver(WebDriver):
         self.download_link = self.download_link.format(version=self.version, arch=arch, ext=ext)
 
     def install(self):
-        os.makedirs(self.get_dir())
+        if not os.path.exists(self.get_dir()):
+            os.makedirs(self.get_dir())
 
         dist = self._download(use_link=True)
         if self.download_link.endswith('.zip'):

--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -1284,7 +1284,7 @@ class RequiredTool(object):
         self.mirror_manager = None
         self.mandatory = mandatory
         self.installable = installable
-        self.version = str(version) if version is not None else self.VERSION
+        self.version = str(version) if version else self.VERSION
         self.tool_name = self.__class__.__name__
 
         # for browsermobproxy compatability, remove it later

--- a/bzt/utils.py
+++ b/bzt/utils.py
@@ -1274,24 +1274,21 @@ class RequiredTool(object):
     Abstract required tool
     """
     VERSION = None
+    DOWNLOAD_LINK = None
 
     def __init__(self, log=None, tool_path="", download_link="", http_client=None,
                  env=None, version=None, installable=True, mandatory=True):
         self.http_client = http_client
         self.tool_path = os.path.expanduser(tool_path)
-        self.download_link = download_link
+        self.download_link = download_link or self.DOWNLOAD_LINK
         self.mirror_manager = None
         self.mandatory = mandatory
-
-        self.version = self.VERSION
-        if version is not None:
-            self.version = str(version)
-
         self.installable = installable
-
+        self.version = str(version) if version is not None else self.VERSION
         self.tool_name = self.__class__.__name__
 
         # for browsermobproxy compatability, remove it later
+        # todo: check it! (as well as others 'remove it later')
         if not isinstance(log, logging.Logger):
             log = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,3 @@ requests>=2.18.1
 urwid
 terminaltables>=3.1.0
 molotov
-webdriver-manager

--- a/site/dat/docs/Selenium.md
+++ b/site/dat/docs/Selenium.md
@@ -115,9 +115,9 @@ Selenium executor supports building test script from the `requests` option of `s
 
 ## Automatic Installation of Web Driver
 
-By default, Taurus will download the appropriate ChromeDriver and GeckoDriver using webdriver-manager and put them in PATH when running tests.
+By default, Taurus will download newest ChromeDriver and GeckoDriver and put them in PATH when running tests.
 
-You can also use already downloaded drivers by the following options:
+You can also order specific version or use already downloaded drivers by the following options:
 ```yaml
 execution:
 - executor: selenium
@@ -132,9 +132,10 @@ scenarios:
 modules:
   selenium:
     chromedriver:
-      path: /full/path/to/driver
+      version: 97.0.4692.36   # desirable driver version
+
     geckodriver:
-      path: /full/path/to/driver
+      path: /full/path/to/driver  # path to existed driver
 ```
 
 ## Using Virtual Display on Linux

--- a/site/dat/docs/Selenium.md
+++ b/site/dat/docs/Selenium.md
@@ -115,30 +115,6 @@ Selenium executor supports building test script from the `requests` option of `s
 
 ## Automatic Installation of Web Driver
 
-By default, Taurus will download ChromeDriver and GeckoDriver and put them in PATH when running tests.
-
-You can configure this behaviour with the following options:
-```yaml
-execution:
-- executor: selenium
-  iterations: 1
-  scenario: simple
-  
-scenarios:
-  simple:
-    requests:
-    - http://blazedemo.com/
-
-modules:
-  selenium:
-    chromedriver:
-      version: 2.30
-      download-link: https://chromedriver.storage.googleapis.com/{version}/chromedriver_{arch}.zip
-    geckodriver:
-      version: 0.17.0
-      download-link: https://github.com/mozilla/geckodriver/releases/download/v{version}/geckodriver-v{version}-{arch}.{ext}
-```
-
 By default, Taurus will download the appropriate ChromeDriver and GeckoDriver using webdriver-manager and put them in PATH when running tests.
 
 You can also use already downloaded drivers by the following options:

--- a/tests/unit/modules/_selenium/__init__.py
+++ b/tests/unit/modules/_selenium/__init__.py
@@ -82,7 +82,7 @@ class MockDriver(RequiredTool):
         return True
 
     @staticmethod
-    def get_driver_dir():
+    def get_dir():
         return ""
 
     def install(self):

--- a/tests/unit/modules/_selenium/__init__.py
+++ b/tests/unit/modules/_selenium/__init__.py
@@ -29,11 +29,6 @@ class SeleniumTestCase(ExecutorTestCase):
         self.virtual_display = VirtualDisplay()
         self.virtual_display.engine = self.engine
         self.virtual_display.startup()
-
-        self.tmp_chromedriver = bzt.modules._selenium.ChromeDriver
-        self.tmp_geckodriver = bzt.modules._selenium.GeckoDriver
-        bzt.modules._selenium.ChromeDriver = MockDriver
-        bzt.modules._selenium.GeckoDriver = MockDriver
         self.obj.settings = self.engine.config.get("modules").get("selenium")
 
     def tearDown(self):
@@ -45,8 +40,6 @@ class SeleniumTestCase(ExecutorTestCase):
                 self.obj.runner.stderr.close()
         bzt.modules._selenium.Selenium = self.tmp_selenium
         bzt.modules._apiritif.executor.Selenium = self.tmp_selenium_apiritif
-        bzt.modules._selenium.ChromeDriver = self.tmp_chromedriver
-        bzt.modules._selenium.GeckoDriver = self.tmp_geckodriver
         super(SeleniumTestCase, self).tearDown()
 
 
@@ -68,22 +61,4 @@ class MockPythonTool(RequiredTool):
         return self.version
 
     def post_process(self):
-        pass
-
-
-class MockDriver(RequiredTool):
-    tool_name = "MockDriver"
-    tool_path = ""
-
-    def __init__(self, **kwargs):
-        pass
-
-    def check_if_installed(self):
-        return True
-
-    @staticmethod
-    def get_dir():
-        return ""
-
-    def install(self):
         pass

--- a/tests/unit/modules/_selenium/test_java.py
+++ b/tests/unit/modules/_selenium/test_java.py
@@ -134,7 +134,7 @@ class TestJUnitTester(BZTestCase):
         selenium.engine = engine_obj
         selenium.install_required_tools()
         for driver in selenium.webdrivers:
-            selenium.env.add_path({"PATH": driver.get_driver_dir()})
+            selenium.env.add_path({"PATH": driver.get_dir()})
 
         self.obj = JUnitTester()
         self.obj.env = selenium.env
@@ -266,7 +266,7 @@ class TestSeleniumJUnitTester(SeleniumTestCase):
         super(SeleniumExecutor, self.obj).prepare()
         self.obj.install_required_tools()
         for driver in self.obj.webdrivers:
-            self.obj.env.add_path({"PATH": driver.get_driver_dir()})
+            self.obj.env.add_path({"PATH": driver.get_dir()})
         self.obj.create_runner()
         self.obj.runner.install_required_tools = lambda: None
         self.obj.runner._compile_scripts = lambda: None
@@ -475,7 +475,7 @@ class TestSeleniumTestNGRunner(SeleniumTestCase):
         super(SeleniumExecutor, self.obj).prepare()
         self.obj.install_required_tools()
         for driver in self.obj.webdrivers:
-            self.obj.env.add_path({"PATH": driver.get_driver_dir()})
+            self.obj.env.add_path({"PATH": driver.get_dir()})
         self.obj.create_runner()
         self.obj.runner.install_required_tools = lambda: None
         self.obj.runner._compile_scripts = lambda: None

--- a/tests/unit/modules/_selenium/test_python_executors.py
+++ b/tests/unit/modules/_selenium/test_python_executors.py
@@ -9,13 +9,12 @@ from unittest import skipIf
 import bzt
 from bzt.engine import EXEC
 from bzt.modules import ConsolidatingAggregator
-from bzt.modules._selenium import GeckoDriver
 from bzt.modules.functional import FuncSamplesReader, LoadSamplesReader, FunctionalAggregator
 from bzt.modules._apiritif import ApiritifNoseExecutor
 from bzt.modules._pytest import PyTestExecutor
 from bzt.modules.robot import RobotExecutor
 from tests.unit import RESOURCES_DIR, ExecutorTestCase
-from tests.unit.modules._selenium import SeleniumTestCase, MockPythonTool, MockDriver
+from tests.unit.modules._selenium import SeleniumTestCase, MockPythonTool
 from bzt.utils import EXE_SUFFIX, is_windows
 
 
@@ -314,17 +313,6 @@ class TestPyTestExecutor(ExecutorTestCase):
     EXECUTOR = PyTestExecutor
     CMD_LINE = None
 
-    def setUp(self):
-        super().setUp()
-        self.tmp_chromedriver = bzt.modules._selenium.ChromeDriver
-        bzt.modules._selenium.ChromeDriver = MockDriver
-        self.tmp_geckodriver = bzt.modules._selenium.GeckoDriver
-        bzt.modules._selenium.GeckoDriver = MockDriver
-
-    def tearDown(self):
-        bzt.modules._selenium.ChromeDriver = self.tmp_chromedriver
-        bzt.modules._selenium.GeckoDriver = self.tmp_geckodriver
-
     def start_subprocess(self, args, **kwargs):
         self.CMD_LINE = args
 
@@ -387,11 +375,6 @@ class TestPyTestExecutor(ExecutorTestCase):
             }
         })
         self.obj_prepare()
-        driver = self.obj._get_tool(MockDriver, tool_path=self.obj.settings.get('geckodriver').get('path'))
-        if not driver.check_if_installed():
-            driver.install()
-        self.obj.env.add_path({"PATH": driver.get_dir()})
-
         self.obj.engine.start_subprocess = self.start_subprocess
         self.obj.startup()
         self.obj.post_process()
@@ -404,11 +387,6 @@ class TestPyTestExecutor(ExecutorTestCase):
             }
         })
         self.obj_prepare()
-        driver = self.obj._get_tool(MockDriver, tool_path=self.obj.settings.get('geckodriver').get('path'))
-        if not driver.check_if_installed():
-            driver.install()
-        self.obj.env.add_path({"PATH": driver.get_dir()})
-
         self.obj.engine.start_subprocess = self.start_subprocess
         self.obj.startup()
         self.obj.post_process()

--- a/tests/unit/modules/_selenium/test_python_executors.py
+++ b/tests/unit/modules/_selenium/test_python_executors.py
@@ -390,7 +390,7 @@ class TestPyTestExecutor(ExecutorTestCase):
         driver = self.obj._get_tool(MockDriver, tool_path=self.obj.settings.get('geckodriver').get('path'))
         if not driver.check_if_installed():
             driver.install()
-        self.obj.env.add_path({"PATH": driver.get_driver_dir()})
+        self.obj.env.add_path({"PATH": driver.get_dir()})
 
         self.obj.engine.start_subprocess = self.start_subprocess
         self.obj.startup()
@@ -407,7 +407,7 @@ class TestPyTestExecutor(ExecutorTestCase):
         driver = self.obj._get_tool(MockDriver, tool_path=self.obj.settings.get('geckodriver').get('path'))
         if not driver.check_if_installed():
             driver.install()
-        self.obj.env.add_path({"PATH": driver.get_driver_dir()})
+        self.obj.env.add_path({"PATH": driver.get_dir()})
 
         self.obj.engine.start_subprocess = self.start_subprocess
         self.obj.startup()

--- a/tests/unit/modules/_selenium/test_selenium_executor.py
+++ b/tests/unit/modules/_selenium/test_selenium_executor.py
@@ -430,35 +430,3 @@ class TestReportReader(BZTestCase):
         self.assertEqual(items[2].status, "PASSED")
         self.assertEqual(items[4].test_case, 'SkippedTest')
         self.assertEqual(items[4].status, "SKIPPED")
-
-
-class MockWebDriverManager:
-    def __init__(self, **kwargs):
-        pass
-
-    def install(self):
-        return os.path.join(RESOURCES_DIR, "selenium/mockdriver")
-
-
-class TestWebrdivers(BZTestCase):
-    def test_webdriver_manager(self):
-        self.sniff_log(self.log)
-        tmp_chromedriver = bzt.modules._selenium.ChromeDriver.MANAGER
-        tmp_geckodriver = bzt.modules._selenium.GeckoDriver.MANAGER
-
-        try:
-            bzt.modules._selenium.ChromeDriver.MANAGER = MockWebDriverManager
-            bzt.modules._selenium.GeckoDriver.MANAGER = MockWebDriverManager
-
-            chromedriver = ChromeDriver()
-            chromedriver.install()
-
-            geckodriver = GeckoDriver()
-            geckodriver.install()
-
-        finally:
-            bzt.modules._selenium.ChromeDriver.MANAGER = tmp_chromedriver
-            bzt.modules._selenium.GeckoDriver.MANAGER = tmp_geckodriver
-
-        self.assertIn("Will install ChromeDriver into", self.log_recorder.info_buff.getvalue())
-        self.assertIn("Will install GeckoDriver into", self.log_recorder.info_buff.getvalue())

--- a/tests/unit/modules/_selenium/test_selenium_executor.py
+++ b/tests/unit/modules/_selenium/test_selenium_executor.py
@@ -197,7 +197,7 @@ class TestSeleniumStuff(SeleniumTestCase):
         super(SeleniumExecutor, self.obj).prepare()
         self.obj.install_required_tools()
         for driver in self.obj.webdrivers:
-            self.obj.env.add_path({"PATH": driver.get_driver_dir()})
+            self.obj.env.add_path({"PATH": driver.get_dir()})
         self.obj.create_runner()
         self.obj.runner._check_tools = lambda *args: None
         self.obj.runner._compile_scripts = lambda: None

--- a/tests/unit/modules/_selenium/test_selenium_executor.py
+++ b/tests/unit/modules/_selenium/test_selenium_executor.py
@@ -11,7 +11,7 @@ from bzt.engine import EXEC
 from bzt.modules._apiritif import ApiritifNoseExecutor
 from bzt.modules.functional import LoadSamplesReader, FuncSamplesReader
 from bzt.modules.provisioning import Local
-from bzt.modules._selenium import SeleniumExecutor, ChromeDriver, GeckoDriver
+from bzt.modules._selenium import SeleniumExecutor
 from bzt.utils import LDJSONReader, FileReader
 from tests.unit import BZTestCase, RESOURCES_DIR, ROOT_LOGGER, EngineEmul
 from tests.unit.mocks import DummyListener

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -11,7 +11,7 @@ from bzt.engine import Configuration, EXEC
 from bzt.modules._selenium import SeleniumExecutor
 from bzt.utils import BetterDict, is_windows, get_full_path, get_uniq_name, communicate
 from tests.unit import local_paths_config, RESOURCES_DIR, BZTestCase, ExecutorTestCase, TEST_DIR, EngineEmul
-from tests.unit.modules._selenium import MockDriver, MockPythonTool
+from tests.unit.modules._selenium import MockPythonTool
 
 
 class MockClient(object):
@@ -27,10 +27,6 @@ class TestEngine(BZTestCase):
         super(TestEngine, self).setUp()
         self.obj = EngineEmul()
         self.paths = local_paths_config()
-        self.tmp_chromedriver = bzt.modules._selenium.ChromeDriver
-        bzt.modules._selenium.ChromeDriver = MockDriver
-        self.tmp_geckodriver = bzt.modules._selenium.GeckoDriver
-        bzt.modules._selenium.GeckoDriver = MockDriver
         self.tmp_selenium = bzt.modules._selenium.Selenium
         bzt.modules._selenium.Selenium = MockPythonTool
         self.tmp_apiritif_selenium = bzt.modules._apiritif.executor.Selenium
@@ -38,8 +34,6 @@ class TestEngine(BZTestCase):
 
     def tearDown(self):
         super(TestEngine, self).tearDown()
-        bzt.modules._selenium.ChromeDriver = self.tmp_chromedriver
-        bzt.modules._selenium.GeckoDriver = self.tmp_geckodriver
         bzt.modules._selenium.Selenium = self.tmp_selenium
         bzt.modules._apiritif.executor.Selenium = self.tmp_apiritif_selenium
 


### PR DESCRIPTION
Don't fail the test if webdriver couldn't be downloaded.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [x] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
