### PR TITLE
Update capabilities and docs

### DIFF
--- a/site/dat/docs/Apiritif.md
+++ b/site/dat/docs/Apiritif.md
@@ -1027,6 +1027,8 @@ Note: The capabilities are a way in which the remote service filters and selects
   - acceptInsecureCerts
   - platformName — commonly used for mobile devices
 
+Full capabilities list is [here](https://www.selenium.dev/documentation/webdriver/capabilities/). 
+
 Note: Currently it is possible to perform basic tests in mobile browsers using the available actions commands, in the future more commands related to mobile will be incorporated to allow a better interactivity.
 
 ### Sample Remote Webdriver scenario:

--- a/site/dat/docs/Apiritif.md
+++ b/site/dat/docs/Apiritif.md
@@ -1027,7 +1027,7 @@ Note: The capabilities are a way in which the remote service filters and selects
   - acceptInsecureCerts
   - platformName — commonly used for mobile devices
 
-Full capabilities list is [here](https://www.selenium.dev/documentation/webdriver/capabilities/). 
+Full capabilities list is [here](https://www.selenium.dev/documentation/webdriver/capabilities/).
 
 Note: Currently it is possible to perform basic tests in mobile browsers using the available actions commands, in the future more commands related to mobile will be incorporated to allow a better interactivity.
 

--- a/site/dat/docs/Apiritif.md
+++ b/site/dat/docs/Apiritif.md
@@ -94,7 +94,7 @@ In `selenium` mode follow request features are supported:
 
   - `browser` for the following browser types: Chrome, Firefox, Ie, Opera, Android-Chrome, iOS-Safari, Remote
   - `remote` for local webdriver, local remote webdriver or [remote webdriver](#Remote-WebDriver)
-  - `capabilities` of local and [remote webdriver](#Remote-WebDriver): `browser`, `version`, `javascript`, `platform`, `os\_version`, `selenium`, `device`, `app`
+  - `capabilities` of local and [remote webdriver](#Remote-WebDriver)
   - `request` only for GET method
       - `action` keyword for Selenium actions
       - `assert` (requested page source inspected use the new assertTitle, assertTextBy or assertValueBy* for item level)
@@ -1022,11 +1022,10 @@ Note: The capabilities are a way in which the remote service filters and selects
 
 ### Commonly used capabilities
 
-  - browser
-  - version
-  - platform
-  - device # ID of the device (Mobile browser)
-  - os_version # commonly used only for mobile
+  - browserName
+  - browserVersion
+  - acceptInsecureCerts
+  - platformName — commonly used for mobile devices
 
 Note: Currently it is possible to perform basic tests in mobile browsers using the available actions commands, in the future more commands related to mobile will be incorporated to allow a better interactivity.
 
@@ -1037,8 +1036,8 @@ scenarios:
     browser: Remote
     remote: http://user:key@remote_web_driver_host:port/wd/hub
     capabilities:
-      browser: firefox  # Depends on the capabilities of the remote selenium server
-      version: "54.0"
+      browserName: firefox  # Depends on the capabilities of the remote selenium server
+      browserVersion: "95.0"
     requests:
     - url: http://demo.blazemeter.com  # url to open, only get method is supported
       actions:  # holds list of actions to perform
@@ -1053,8 +1052,8 @@ scenarios:
   request_example:
     remote: http://user:key@remote_web_driver_host:port/wd/hub
     capabilities:
-      browser: firefox  # Depends on the capabilities of the remote selenium server
-      version: "54.0"
+      browserName: firefox  # Depends on the capabilities of the remote selenium server
+      browserVersion: "95.0"
     requests:
     - url: http://demo.blazemeter.com  # url to open, only get method is supported
       actions:  # holds list of actions to perform

--- a/site/dat/docs/changes/fix-review-browser-capabilities.change
+++ b/site/dat/docs/changes/fix-review-browser-capabilities.change
@@ -1,0 +1,1 @@
+Update capabilities info in docs

--- a/site/dat/docs/changes/fix-review-browser-capabilities.change
+++ b/site/dat/docs/changes/fix-review-browser-capabilities.change
@@ -1,1 +1,1 @@
-Update capabilities info in docs
+Upgrade deprecated parameter and update capabilities info in docs

--- a/site/dat/docs/changes/fix-review-browser-capabilities.change
+++ b/site/dat/docs/changes/fix-review-browser-capabilities.change
@@ -1,1 +1,1 @@
-Upgrade deprecated parameter and update capabilities info in docs
+Remove deprecated parameter and update capabilities info in docs

--- a/tests/resources/selenium/generated_from_requests_appium_browser.py
+++ b/tests/resources/selenium/generated_from_requests_appium_browser.py
@@ -19,7 +19,8 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import waiter, get_locator, wait_for
+from bzt.resources.selenium_extras import wait_for, get_locator, waiter
+
 
 class TestLocScAppium(unittest.TestCase):
 
@@ -27,20 +28,18 @@ class TestLocScAppium(unittest.TestCase):
         self.vars = {}
 
         timeout = 3.5
-        self.driver = None
         options = webdriver.ChromeOptions()
         options.add_argument('--no-sandbox')
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--disable-gpu')
         options.set_capability('unhandledPromptBehavior', 'ignore')
-        self.driver = webdriver.Remote(command_executor='http://localhost:4723/wd/hub',
-                                       desired_capabilities={'browserName': 'chrome', 'deviceName': '',
-                                                             'platformName': 'android'},
-                                       options=options)
+        options.set_capability('browserName', 'chrome')
+        options.set_capability('deviceName', '')
+        options.set_capability('platformName', 'android')
+        self.driver = webdriver.Remote(command_executor='http://localhost:4723/wd/hub', options=options)
         self.driver.implicitly_wait(timeout)
         apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows={},
                                        scenario_name='loc_sc_appium')
-
 
     def _1_(self):
         with apiritif.smart_transaction('/'):

--- a/tests/resources/selenium/generated_from_requests_remote.py
+++ b/tests/resources/selenium/generated_from_requests_remote.py
@@ -19,7 +19,8 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import waiter, add_flow_markers, get_locator, wait_for
+from bzt.resources.selenium_extras import get_locator, add_flow_markers, wait_for, waiter
+
 
 class TestLocScRemote(unittest.TestCase):
 
@@ -27,19 +28,21 @@ class TestLocScRemote(unittest.TestCase):
         self.vars = {}
 
         timeout = 3.5
-        self.driver = None
         options = webdriver.FirefoxOptions()
+        options.set_capability('app', '')
+        options.set_capability('browserName', 'firefox')
+        options.set_capability('deviceName', '')
+        options.set_capability('javascriptEnabled', 'True')
+        options.set_capability('platformName', 'linux')
+        options.set_capability('platformVersion', '')
+        options.set_capability('seleniumVersion', '')
+        options.set_capability('version', '54.0')
         self.driver = webdriver.Remote(command_executor='http://user:key@remote_web_driver_host:port/wd/hub',
-                                       desired_capabilities={'app': '', 'browserName': 'firefox', 'deviceName': '',
-                                                             'javascriptEnabled': 'True', 'platformName': 'linux',
-                                                             'platformVersion': '', 'seleniumVersion': '',
-                                                             'version': '54.0'},
                                        options=options)
         self.driver.implicitly_wait(timeout)
         add_flow_markers()
         apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows={},
                                        scenario_name='loc_sc_remote')
-
 
     def _1_(self):
         with apiritif.smart_transaction('/'):

--- a/tests/unit/modules/_selenium/test_selenium_builder.py
+++ b/tests/unit/modules/_selenium/test_selenium_builder.py
@@ -738,7 +738,7 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
 
         self.assertNotIn("options.set_headless()", gen_contents)
 
-    def test_capabilities_type(self):
+    def test_capabilities_update(self):
         self.configure({
             "execution": [{
                 "executor": "selenium",
@@ -757,10 +757,11 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
             content = fds.read()
 
         target_lines = [
-            "'proxy': {'key': 'val'}",
-            "'string_cap': 'string_val'"
+            "options.set_capability('proxy', {'key': 'val'})",
+            "options.set_capability('string_cap', 'string_val')"
         ]
-        wrong_line = "'proxy': \"{'key': 'val'}\""
+
+        wrong_line = "desired_capabilities={'proxy': {'key': 'val'}, 'string_cap': 'string_val'}"
 
         for line in target_lines:
             self.assertIn(line, content)
@@ -801,12 +802,12 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
             content = fds.read()
 
         target_lines = [
-            "'name1': 'settings'",
-            "'name2': 'execution'",
-            "'name3': 'scenario'",
-            "'name4': 'execution'",
-            "'name5': 'execution'",
-            "'name6': 'scenario'"]
+            "options.set_capability('name1', 'settings')",
+            "options.set_capability('name2', 'execution')",
+            "options.set_capability('name3', 'scenario')",
+            "options.set_capability('name4', 'execution')",
+            "options.set_capability('name5', 'execution')",
+            "options.set_capability('name6', 'scenario')"]
 
         for line in target_lines:
             self.assertIn(line, content)
@@ -870,7 +871,7 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
         with open(self.obj.script) as script:
             content = script.read()
 
-        sample = "desired_capabilities={'browserName': '%s'}" % browser_name
+        sample = "options.set_capability('browserName', '%s')" % browser_name
         self.assertIn(sample, content)
 
     def test_build_script_appium_browser(self):
@@ -919,7 +920,7 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
             "scenarios": {
                 "remote_sc": {  # no 'browser' element
                     "capabilities": {
-                        "browserName": "chrome"},  # must be faced in desired_capabilities
+                        "browserName": "chrome"},  # must be set among other capabilities
                     "timeout": "3.5s",
                     "requests": [{
                         "url": "http://blazedemo.com",
@@ -931,7 +932,7 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
         with open(self.obj.script) as fds:
             content = fds.read()
 
-        target = "'browserName': 'chrome'"
+        target = "options.set_capability('browserName', 'chrome')"
         self.assertIn(target, content)
 
     def test_build_script_remote_browser(self):
@@ -944,7 +945,7 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
             "scenarios": {
                 "remote_sc": {
                     "capabilities": {
-                        "browserName": "chrome"},  # must be faced in desired_capabilities
+                        "browserName": "chrome"},  # must be set among other capabilities
                     "timeout": "3.5s",
                     "requests": [{
                         "url": "http://blazedemo.com",
@@ -956,7 +957,7 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
         with open(self.obj.script) as fds:
             content = fds.read()
 
-        target = "'browserName': 'chrome'"
+        target = "options.set_capability('browserName', 'chrome')"
         self.assertIn(target, content)
 
     def test_build_script_remote_Firefox_browser(self):
@@ -968,7 +969,7 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
                 "scenario": "remote_sc"}],
             "scenarios": {
                 "remote_sc": {
-                    "browser": "Firefox",  # must be faced in desired_capabilities (in lower case)
+                    "browser": "Firefox",  # must be set among other capabilities
                     "timeout": "3.5s",
                     "requests": [{
                         "url": "http://blazedemo.com",
@@ -980,7 +981,7 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
         with open(self.obj.script) as fds:
             content = fds.read()
 
-        target = "'browserName': 'firefox'"
+        target = "options.set_capability('browserName', 'firefox')"
         self.assertIn(target, content)
 
     def test_build_script_remote_Edge_browser(self):
@@ -992,7 +993,7 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
                 "scenario": "remote_sc"}],
             "scenarios": {
                 "remote_sc": {
-                    "browser": "MicrosoftEdge",  # must be faced in desired_capabilities (in camel case)
+                    "browser": "MicrosoftEdge",  # must be set among other capabilities (in camel case)
                     "timeout": "3.5s",
                     "requests": [{
                         "url": "http://blazedemo.com",
@@ -1004,7 +1005,7 @@ class TestSeleniumScriptGeneration(SeleniumTestCase):
         with open(self.obj.script) as fds:
             content = fds.read()
 
-        target = "'browserName': 'MicrosoftEdge'"
+        target = "options.set_capability('browserName', 'MicrosoftEdge')"
         self.assertIn(target, content)
 
     def test_build_script_flow_markers(self):


### PR DESCRIPTION
Remove deprecated 'desired_capabilities' parameter. Update capabilities docs.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [x] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
