### PR TITLE
Update default version of JMeter to 5.4.2 (CVE-2021-44228 & CVE-2021-45046)

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1375,7 +1375,7 @@ class JMeter(RequiredTool):
     PLUGINS_MANAGER = 'https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-manager/{version}/jmeter-plugins-manager-{version}.jar'
     COMMAND_RUNNER_VERSION = "2.2"
     COMMAND_RUNNER = 'https://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/{version}/cmdrunner-{version}.jar'
-    VERSION = "5.4.1"
+    VERSION = "5.4.2"
 
     def __init__(self, config=None, props=None, **kwargs):
         settings = config or {}

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -11,7 +11,7 @@ modules:
   jmeter:
     path: ~/.bzt/jmeter-taurus/bin/jmeter
     download-link: https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-{version}.zip
-    version: 5.4.1  # minimal supported version of JMeter is 5.0
+    version: 5.4.2  # minimal supported version of JMeter is 5.0
     force-ctg: true   # true by default
     detect-plugins: true
     fix-log4j: true

--- a/site/dat/docs/changes/fix-update-jmeter-version.change
+++ b/site/dat/docs/changes/fix-update-jmeter-version.change
@@ -1,0 +1,1 @@
+update default version of jmeter to 5.4.2 (CVE-2021-44228 & CVE-2021-45046)


### PR DESCRIPTION
Update default version of JMeter to 5.4.2 (CVE-2021-44228 & CVE-2021-45046)
- https://blogs.apache.org/security/entry/cve-2021-44228
- https://qainsights.com/log4j-vulnerability-important-note-to-performance-engineers/

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [X] Description of PR explains the context of change
- [X] Unit tests cover the change, no broken tests
- [X] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [X] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
