### PR TITLE
US792009: safari: fix recognizing of Blazemeter run 

### DIFF
--- a/bzt/modules/_apiritif/generator.py
+++ b/bzt/modules/_apiritif/generator.py
@@ -1040,7 +1040,7 @@ from selenium.webdriver.common.keys import Keys
             browser = self.capabilities.get("browserName", "").lower()
             if browser in ["microsoftedge", "edge"]:
                 browser = 'edge'
-            elif browser == 'safari' and 'blazemeter' in self.remote_address:
+            elif browser == 'safari' and 'api/v4/grid/wd/hub' in self.remote_address:
                 browser = 'MiniBrowser'  # use MiniBrowser instead of safari as a remote browser in Blazemeter
         if browser == 'firefox':
             options = self._get_firefox_options()
@@ -1108,12 +1108,10 @@ from selenium.webdriver.common.keys import Keys
         return edge_options + self._get_headless_setup()
 
     def _get_webkitgtk_options(self):
-        webkitgtk_options = [
+        return [
             ast.Assign(
                 targets=[ast.Name(id="options")],
                 value=ast_call(func=ast_attr("webdriver.WebKitGTKOptions")))]
-
-        return webkitgtk_options + self._get_headless_setup()
 
     def _get_firefox_profile(self):
         capabilities = sorted(self.capabilities.keys())

--- a/tests/resources/selenium/capabilities_options_for_remote_safari.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_safari.py
@@ -34,7 +34,8 @@ class TestRemoteSc(unittest.TestCase):
         options.add_argument('one')
         options.add_argument('two')
         options.set_capability('browserName', 'safari')
-        self.driver = webdriver.Remote(command_executor='http://addr-of-remote-server.blazemeter.com', options=options)
+        self.driver = webdriver.Remote(command_executor='http://addr-of-remote-server.com/api/v4/grid/wd/hub',
+                                       options=options)
         self.driver.implicitly_wait(timeout)
         add_flow_markers()
         apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows={},

--- a/tests/resources/selenium/capabilities_options_for_remote_safari_s3.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_safari_s3.py
@@ -31,7 +31,7 @@ class TestLocScRemote(unittest.TestCase):
         options = webdriver.WebKitGTKOptions()
         options.add_argument('one')
         options.add_argument('two')
-        self.driver = webdriver.Remote(command_executor='http://user:key@remote_web_driver_host.blazemeter:port/wd/hub',
+        self.driver = webdriver.Remote(command_executor='http://user:key@remote_web_driver:port/api/v4/grid/wd/hub',
                                        desired_capabilities={'browserName': 'safari', 'cap1': 'val1', 'cap2': 'val2'},
                                        options=options)
         self.driver.implicitly_wait(timeout)

--- a/tests/unit/modules/_selenium/test_selenium_builder.py
+++ b/tests/unit/modules/_selenium/test_selenium_builder.py
@@ -2717,7 +2717,7 @@ class TestSelenium4Only(SeleniumTestCase):
         self.configure({
             "execution": [{
                 "executor": "selenium",
-                "remote": "http://addr-of-remote-server.blazemeter.com",
+                "remote": "http://addr-of-remote-server.com/api/v4/grid/wd/hub",
                 "scenario": "remote_sc"}],
             "scenarios": {
                 "remote_sc": {
@@ -3005,7 +3005,7 @@ class TestSelenium3Only(SeleniumTestCase):
                 "scenario": "loc_sc_remote"}],
             "scenarios": {
                 "loc_sc_remote": {
-                    "remote": "http://user:key@remote_web_driver_host.blazemeter:port/wd/hub",
+                    "remote": "http://user:key@remote_web_driver:port/api/v4/grid/wd/hub",
                     "capabilities": {
                         "browserName": "safari",
                         "cap1": "val1",


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
