### PR TITLE
DE525766 Fixed usage of variables in Store eval action

### DIFF
--- a/bzt/modules/_apiritif/generator.py
+++ b/bzt/modules/_apiritif/generator.py
@@ -485,10 +485,11 @@ from selenium.webdriver.common.keys import Keys
                 func=ast_attr("self.assertTrue"),
                 args=[self._gen_eval_js_expression(name), ast.Str(name, kind="")]))
         elif atype == 'store' and tag == 'eval':
+            escaped_value = self._escape_js_blocks(value)
             elements.append(
                 gen_store(
                     self._gen_expr(name.strip()),
-                    value=self._gen_eval_js_expression(value))
+                    value=self._gen_eval_js_expression(escaped_value))
             )
         else:
             target = None

--- a/site/dat/docs/changes/fix-store-eval-variables.change
+++ b/site/dat/docs/changes/fix-store-eval-variables.change
@@ -1,0 +1,1 @@
+Fixed usage of variables in Store eval action

--- a/tests/resources/selenium/generated_from_requests_v2.py
+++ b/tests/resources/selenium/generated_from_requests_v2.py
@@ -93,7 +93,7 @@ class TestLocSc(unittest.TestCase):
                 var_loc_as[1]).get_attribute('innerText')
             self.assertTrue(self.driver.execute_script('return 10 === 2*5;'), '10 === 2*5')
 
-            self.vars['var_eval'] = self.driver.execute_script('return 0 == false;')
+            self.vars['var_eval'] = self.driver.execute_script('return myFunction();\nfunction myFunction(){{\n btnNameVar="{}";\n return "support";\n}};'.format(self.vars['btnName1']))
 
             var_loc_keys = get_locator([{'xpath': '/wrong/one'}, {'xpath': '/html/body/div[3]/form/div/input'}])
             self.driver.find_element(

--- a/tests/unit/modules/_selenium/test_selenium_builder.py
+++ b/tests/unit/modules/_selenium/test_selenium_builder.py
@@ -1446,7 +1446,8 @@ class TestSeleniumScriptGeneration(ExecutorTestCase):
                                     {
                                         "type": "storeEval",
                                         "param": "var_eval",
-                                        "value": "0 == false"
+                                        "value": "myFunction();\nfunction myFunction(){\n "
+                                                 "btnNameVar=\"${btnName1}\";\n return \"support\";\n}"
                                     },
                                     {
                                         "type": "click",


### PR DESCRIPTION
Added replacement of single {} to double so that variables may be used for storeEval action as well.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
