### PR TITLE
Handle HTTP 500 errors in update check

### DIFF
--- a/bzt/engine/engine.py
+++ b/bzt/engine/engine.py
@@ -731,6 +731,11 @@ class Engine(object):
             self.log.warning("Failed to check for updates")
             return
 
+        if response.status_code == 500:
+            self.log.debug("Checking for updates returned HTTP 500: %s", traceback.format_exc())
+            self.log.warning("Checking for updates returned HTTP 500.")
+            return
+         
         data = response.json()
         latest = data.get('latest')
         needs_upgrade = data.get('needsUpgrade')


### PR DESCRIPTION
There was no checking of a proper response before attempting to decode JSON. When the server returns an HTTP 500, we get an error when attempting to decode a non-existent JSON response. Now, we first check that the response is not HTTP 500.
