### PR TITLE
DE527242: revert apiritif to 1.0.0

### DIFF
--- a/bzt/modules/_apiritif/executor.py
+++ b/bzt/modules/_apiritif/executor.py
@@ -268,7 +268,7 @@ class ApiritifTester(ApiritifNoseExecutor):
 
 
 class Apiritif(PythonTool):
-    VERSION = "1.1.2"
+    VERSION = "1.0.0"
     PACKAGES = ["apiritif"]
 
 

--- a/site/dat/docs/changes/revert-apiritif.change
+++ b/site/dat/docs/changes/revert-apiritif.change
@@ -1,0 +1,1 @@
+Revert apiritif to 1.0.0 due to StopIteration issue

--- a/tests/ci/requirements.txt
+++ b/tests/ci/requirements.txt
@@ -1,4 +1,4 @@
-apiritif>=1.1.2
+apiritif==1.0.0
 http-here
 nose2
 codecov


### PR DESCRIPTION
Revert apiritif to 1.0.0 due to StopIteration issue while running GUI Functional test with csv file. 

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
