### PR TITLE
Locust wrapper bug fix

### DIFF
--- a/bzt/resources/locustio-taurus-wrapper.py
+++ b/bzt/resources/locustio-taurus-wrapper.py
@@ -116,14 +116,16 @@ class LocustStarter(object):
             self.writer.writeheader()
             events.request.add_listener(self.__on_request_success)
             events.request.add_listener(self.__on_request_failure)
-
-        elif not os.getenv("WORKERS_LDJSON"):   # master of distributed mode
+        elif os.getenv("WORKERS_LDJSON"):   # master of distributed mode
+            fname = os.getenv("WORKERS_LDJSON")
+            self.fhd = open(fname, 'wt')
+            self.writer = None
+        else:
             raise ValueError("Please specify JTL or WORKERS_LDJSON environment variable")
 
         main.main()
 
-        if self.fhd:
-            self.fhd.close()
+        self.fhd.close()
 
 
 if __name__ == '__main__':

--- a/site/dat/docs/changes/fix-locust-wrapper-bug.change
+++ b/site/dat/docs/changes/fix-locust-wrapper-bug.change
@@ -1,0 +1,1 @@
+Locust wrapper bug fix


### PR DESCRIPTION
Locust in distributed mode fails because WORKERS_LDJSON file is not created.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
