### PR TITLE
Generate error message when K6 doesn't log any

### DIFF
--- a/site/dat/docs/changes/fix-k6-no-error-message-when-404.change
+++ b/site/dat/docs/changes/fix-k6-no-error-message-when-404.change
@@ -1,0 +1,1 @@
+Generate error message when K6 doesn't log any


### PR DESCRIPTION
When there is an error but no error message in K6 log, the message is generated with the response code being like this: "Response code X".

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
