### PR TITLE
Avoid error in engine when exception during JMeter installation

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -94,7 +94,7 @@ class JMeterExecutor(ScenarioExecutor):
     def __init__(self):
         super(JMeterExecutor, self).__init__()
         self.original_jmx = None
-        self.modified_jmx = None
+        self.modified_jmx = ""
         self.jmeter_log = None
         self.properties = BetterDict()
         self.properties_file = None
@@ -390,8 +390,7 @@ class JMeterExecutor(ScenarioExecutor):
             self.log.debug("JMeter worked for %s seconds", self.end_time - self.start_time)
 
     def post_process(self):
-        if self.modified_jmx:
-            self.engine.existing_artifact(self.modified_jmx, True)
+        self.engine.existing_artifact(self.modified_jmx, True)
         super(JMeterExecutor, self).post_process()
 
     def has_results(self):

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -390,7 +390,8 @@ class JMeterExecutor(ScenarioExecutor):
             self.log.debug("JMeter worked for %s seconds", self.end_time - self.start_time)
 
     def post_process(self):
-        self.engine.existing_artifact(self.modified_jmx, True)
+        if self.modified_jmx:
+            self.engine.existing_artifact(self.modified_jmx, True)
         super(JMeterExecutor, self).post_process()
 
     def has_results(self):

--- a/site/dat/docs/changes/fix-jmeter-postprocess-file-error.change
+++ b/site/dat/docs/changes/fix-jmeter-postprocess-file-error.change
@@ -1,0 +1,1 @@
+Avoid error in engine when empty 'modified_jmx' due to exception in prepare

--- a/tests/unit/modules/jmeter/test_JMeterExecutor.py
+++ b/tests/unit/modules/jmeter/test_JMeterExecutor.py
@@ -225,6 +225,17 @@ class TestJMeterExecutor(ExecutorTestCase):
             if self.obj.jmeter_log and os.path.exists(self.obj.jmeter_log):
                 self.obj.log.debug("%s", open(self.obj.jmeter_log).read())
 
+    def test_no_modified_jmx(self):
+        def mocked_install_required_tools():
+            raise BaseException
+
+        self.configure(json.loads(open(RESOURCES_DIR + "json/get-post.json").read()))
+        self.obj.install_required_tools = mocked_install_required_tools
+        try:
+            self.obj.prepare()  # does not initialize modified_jmx
+        except BaseException:
+            self.obj.post_process()  # fails is modified_jmx is None and not str
+
     def test_issue_no_iterations(self):
         self.configure({"execution": {
             "concurrency": 10,


### PR DESCRIPTION
Avoid error in engine in post_process when empty 'modified_jmx' due to exception in prepare

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
