### PR TITLE
Fix no concurrency in Molotov

### DIFF
--- a/bzt/modules/_molotov.py
+++ b/bzt/modules/_molotov.py
@@ -67,8 +67,10 @@ class MolotovExecutor(ScenarioExecutor):
 
         cmdline = [self.molotov.tool_path]
 
-        if load.concurrency is not None:
+        if load.concurrency is not None and load.concurrency:
             cmdline += ['--workers', str(load.concurrency)]
+        else:
+            cmdline += ['--workers', "1"]
 
         if 'processes' in self.execution:
             cmdline += ['--processes', str(self.execution['processes'])]

--- a/bzt/modules/_molotov.py
+++ b/bzt/modules/_molotov.py
@@ -67,7 +67,7 @@ class MolotovExecutor(ScenarioExecutor):
 
         cmdline = [self.molotov.tool_path]
 
-        if load.concurrency is not None and load.concurrency:
+        if load.concurrency:
             cmdline += ['--workers', str(load.concurrency)]
         else:
             cmdline += ['--workers', "1"]

--- a/site/dat/docs/changes/fix-no-concurrency-for-molotov.change
+++ b/site/dat/docs/changes/fix-no-concurrency-for-molotov.change
@@ -1,0 +1,1 @@
+Use  for Molotov concurrency equals 1 for no concurrency in yaml


### PR DESCRIPTION
Use for Molotov concurrency equals 1 for no concurrency in yaml.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
