### PR TITLE
Update Molotov executor and reader

### DIFF
--- a/bzt/modules/_molotov.py
+++ b/bzt/modules/_molotov.py
@@ -15,7 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import os
 import shutil
 from math import ceil
 
@@ -37,12 +36,15 @@ class MolotovExecutor(ScenarioExecutor):
         self.stderr = None
         self.molotov = None
         self.scenario = None
+        self.script = None
         self.launch_cmdline = None
         self.user_tool_path = None
 
     def prepare(self):
         super(MolotovExecutor, self).prepare()
         self.install_required_tools()
+
+        self.script = self.get_script_path()
         self.stdout = open(self.engine.create_artifact("molotov", ".out"), 'w')
         self.stderr = open(self.engine.create_artifact("molotov", ".err"), 'w')
 
@@ -69,21 +71,15 @@ class MolotovExecutor(ScenarioExecutor):
 
         if load.concurrency:
             cmdline += ['--workers', str(load.concurrency)]
-        else:
-            cmdline += ['--workers', "1"]
 
         if 'processes' in self.execution:
             cmdline += ['--processes', str(self.execution['processes'])]
 
-        duration = 0
         if load.ramp_up:
-            ramp_up = int(ceil(dehumanize_time(load.hold)))
-            duration += ramp_up
-            cmdline += ['--ramp-up', str(ramp_up)]
+            cmdline += ['--ramp-up', str(int(ceil(load.ramp_up)))]
+
         if load.hold:
-            hold = int(ceil(dehumanize_time(load.hold)))
-            duration += hold
-        cmdline += ['--duration', str(duration)]
+            cmdline += ['--duration', str(int(ceil(load.hold)))]
 
         think_time = self.get_scenario().get("think-time", None)
         if think_time:
@@ -151,6 +147,7 @@ class MolotovReportReader(ResultsReader):
             self.read_records += 1
             if row.get("type") == "workers":
                 self._concurrency = row.get("value", self._concurrency)
+
             elif row.get("type") == "scenario_success":
                 label = unicode_decode(row["name"])
                 tstmp = int(float(row["ts"]))
@@ -160,6 +157,7 @@ class MolotovReportReader(ResultsReader):
                 cnn = ltc = byte_count = 0
                 trname = ''
                 yield tstmp, label, self._concurrency, rtm, cnn, ltc, rcd, error, trname, byte_count
+
             elif row.get("type") == "scenario_failure":
                 label = unicode_decode(row["name"])
                 tstmp = int(float(row["ts"]))
@@ -168,17 +166,4 @@ class MolotovReportReader(ResultsReader):
                 error = row["errorMessage"]
                 cnn = ltc = byte_count = 0
                 trname = ''
-                yield tstmp, label, self._concurrency, rtm, cnn, ltc, rcd, error, trname, byte_count
-            elif row.get("type") == "request":
-                label = unicode_decode(row["label"])
-                tstmp = int(float(row["ts"]))
-                rtm = float(row["elapsed"])
-                rcd = row["responseCode"]
-                error = None
-                if int(rcd) >= 400:
-                    error = row["responseMessage"]
-                cnn = 0
-                ltc = 0
-                trname = ''
-                byte_count = 0
                 yield tstmp, label, self._concurrency, rtm, cnn, ltc, rcd, error, trname, byte_count

--- a/bzt/modules/_molotov.py
+++ b/bzt/modules/_molotov.py
@@ -78,8 +78,7 @@ class MolotovExecutor(ScenarioExecutor):
         if load.ramp_up:
             cmdline += ['--ramp-up', str(int(ceil(load.ramp_up)))]
 
-        if load.hold:
-            cmdline += ['--duration', str(int(ceil(load.hold)))]
+        cmdline += ['--duration', str(int(ceil(load.hold)))]
 
         think_time = self.get_scenario().get("think-time", None)
         if think_time:

--- a/examples/all-executors.yml
+++ b/examples/all-executors.yml
@@ -218,8 +218,7 @@ execution:
 
 - executor: molotov  # Molotov_test + https://blazedemo.com/
   concurrency: 1
-  hold-for: 10s
-  iterations: 10
+  hold-for: 5s
   scenario:
     script: molotov/blazedemo.py
 

--- a/site/dat/docs/Molotov.md
+++ b/site/dat/docs/Molotov.md
@@ -10,12 +10,12 @@ Usage:
 execution:
 - executor: molotov
   concurrency: 10  # number of Molotov workers
-  iterations: 5  # iteration limit for the test
   ramp-up: 30s
   hold-for: 1m
   scenario:
-    script: loadtest.py  # has to be valid Molotov's script
+    script: loadtest.py  # has to be  a valid Molotov script
 ```
+Please keep in mind, that Molotov does not support `iterations` keyword.
 
 ## Process number
 

--- a/site/dat/docs/changes/fix-no-concurrency-for-molotov.change
+++ b/site/dat/docs/changes/fix-no-concurrency-for-molotov.change
@@ -1,1 +1,0 @@
-Use  for Molotov concurrency equals 1 for no concurrency in yaml

--- a/site/dat/docs/changes/fix-update-molotov-executor-reader.change
+++ b/site/dat/docs/changes/fix-update-molotov-executor-reader.change
@@ -1,0 +1,1 @@
+Update Molotov executor and reader

--- a/tests/resources/molotov/molotov-report.csv
+++ b/tests/resources/molotov/molotov-report.csv
@@ -1,14 +1,20 @@
-{"type": "workers", "ts": 1506336427.9278605, "value": 0}
-{"type": "request", "label": "http://52.57.188.88/", "responseMessage": "OK", "responseCode": "200", "ts": 1506336429.3267288, "elapsed": 0.065}
-{"wid": "worker-0", "name": "scenario_one", "ts": 1506336429.26943, "duration": 0.122, "type": "scenario_success"}
-{"type": "request", "label": "http://52.57.188.88/", "responseMessage": "OK", "responseCode": "200", "ts": 1506336429.4511755, "elapsed": 0.067}
-{"wid": "worker-0", "name": "scenario_one", "ts": 1506336429.3925147, "duration": 0.126, "type": "scenario_success"}
-{"type": "request", "label": "http://52.57.188.88/", "responseMessage": "OK", "responseCode": "200", "ts": 1506336429.6974301, "elapsed": 0.064}
-{"wid": "worker-0", "name": "scenario_one", "ts": 1506336429.6404092, "duration": 0.122, "type": "scenario_success"}
-{"type": "request", "label": "http://52.57.188.88/", "responseMessage": "OK", "responseCode": "200", "ts": 1506336429.9443498, "elapsed": 0.063}
-{"wid": "worker-0", "name": "scenario_one", "ts": 1506336430.1332557, "duration": 0.123, "type": "scenario_success"}
-{"type": "request", "label": "http://52.57.188.88/", "responseMessage": "OK", "responseCode": "200", "ts": 1506336430.2567751, "elapsed": 0.063}
-{"wid": "worker-0", "name": "scenario_one", "ts": 1506336430.2562625, "duration": 0.063, "type": "scenario_success"}
-{"type": "workers", "ts": 1506336430.3888893, "value": 1}
-{"name": "scenario_two", "type": "scenario_failure", "exception": "AssertionError", "wid": "worker-0", "duration": 0.124, "errorMessage": "Yo dude", "ts": 1506336439.5200522}
-{"type": "request", "label": "http://52.57.188.88/not-found", "responseMessage": "Not Found", "responseCode": "404", "ts": 1506336439.6972542, "elapsed": 0.066}
+{"ts": 1645712661.5029047, "type": "workers", "value": 0}
+{"ts": 1645712661.7488089, "type": "request", "label": "https://blazedemo.com/", "elapsed": 0.251, "responseCode": "200", "responseMessage": "OK"}
+{"ts": 1645712661.5035622, "wid": "worker-0", "type": "scenario_success", "name": "scenario_one", "duration": 0.496}
+{"ts": 1645712662.1414242, "type": "request", "label": "https://blazedemo.com/not-found", "elapsed": 0.264, "responseCode": "404", "responseMessage": "Not Found"}
+{"ts": 1645712662.0000732, "wid": "worker-0", "type": "scenario_failure", "name": "scenario_two", "duration": 0.406, "exception": "AssertionError", "errorMessage": ""}
+{"ts": 1645712662.50475, "type": "workers", "value": 1}
+{"ts": 1645712662.6180196, "type": "request", "label": "https://blazedemo.com/", "elapsed": 0.22, "responseCode": "200", "responseMessage": "OK"}
+{"ts": 1645712662.4058871, "wid": "worker-0", "type": "scenario_success", "name": "scenario_one", "duration": 0.433}
+{"ts": 1645712663.0457025, "type": "request", "label": "https://blazedemo.com/not-found", "elapsed": 0.321, "responseCode": "404", "responseMessage": "Not Found"}
+{"ts": 1645712662.8385682, "wid": "worker-0", "type": "scenario_failure", "name": "scenario_two", "duration": 0.529, "exception": "AssertionError", "errorMessage": ""}
+{"ts": 1645712663.5058749, "type": "workers", "value": 1}
+{"ts": 1645712663.510754, "type": "request", "label": "https://blazedemo.com/not-found", "elapsed": 0.249, "responseCode": "404", "responseMessage": "Not Found"}
+{"ts": 1645712663.367201, "wid": "worker-0", "type": "scenario_failure", "name": "scenario_two", "duration": 0.393, "exception": "AssertionError", "errorMessage": ""}
+{"ts": 1645712663.9051208, "type": "request", "label": "https://blazedemo.com/not-found", "elapsed": 0.258, "responseCode": "404", "responseMessage": "Not Found"}
+{"ts": 1645712663.7601733, "wid": "worker-0", "type": "scenario_failure", "name": "scenario_two", "duration": 0.403, "exception": "AssertionError", "errorMessage": ""}
+{"ts": 1645712664.506538, "type": "workers", "value": 1}
+{"ts": 1645712664.305398, "type": "request", "label": "https://blazedemo.com/", "elapsed": 0.241, "responseCode": "200", "responseMessage": "OK"}
+{"ts": 1645712664.1636362, "wid": "worker-0", "type": "scenario_success", "name": "scenario_one", "duration": 0.383}
+{"ts": 1645712664.754881, "type": "request", "label": "https://blazedemo.com/", "elapsed": 0.339, "responseCode": "200", "responseMessage": "OK"}
+{"ts": 1645712664.5464728, "wid": "worker-0", "type": "scenario_success", "name": "scenario_one", "duration": 0.547}

--- a/tests/unit/modules/test_molotov.py
+++ b/tests/unit/modules/test_molotov.py
@@ -1,11 +1,10 @@
 import sys
 import time
-import unittest
 from os.path import join
 
 from bzt.modules.aggregator import DataPoint, KPISet
 from bzt.modules._molotov import MolotovExecutor, MolotovReportReader
-from bzt.utils import EXE_SUFFIX, is_windows
+from bzt.utils import EXE_SUFFIX
 from tests.unit import BZTestCase, ExecutorTestCase, RESOURCES_DIR, close_reader_file, ROOT_LOGGER
 
 TOOL_NAME = 'molotov-mock' + EXE_SUFFIX
@@ -57,7 +56,6 @@ class TestMolotov(ExecutorTestCase):
         self.obj.settings.merge({
             "path": TOOL_PATH})
         self.obj.execution.merge({
-            "iterations": 1,
             "scenario": {
                 "script": LOADTEST_PY}})
         self.obj_prepare()
@@ -73,20 +71,29 @@ class TestMolotov(ExecutorTestCase):
         resources = self.obj.get_resource_files()
         self.assertEqual(resources, [LOADTEST_PY])
 
-    @unittest.skipIf(is_windows(), "disabled on windows")
     def test_full(self):
         self.configure({"execution": {
-            "concurrency": 3,
+            "concurrency": 1,
             "processes": 2,
-            "hold-for": "5s",
-            "iterations": 10,
+            "ramp-up": "3s",
+            "hold-for": "4",
             "scenario": {
                 "script": LOADTEST_PY}}})
         self.obj_prepare()
-        self.obj.engine.start_subprocess = lambda **kwargs: None
+        self.obj.engine.start_subprocess = self.start_subprocess
         self.obj.get_widget()
         self.obj.startup()
         self.obj.post_process()
+
+        target_lines = [
+            '--workers 1',
+            '--processes 2',
+            '--ramp-up 3',
+            '--duration 4',
+            '--use-extension=bzt.resources.molotov_ext'
+        ]
+        for line in target_lines:
+            self.assertTrue(line in self.CMD_LINE)
 
     def test_think_time(self):
         self.obj.settings.merge({
@@ -106,17 +113,6 @@ class TestMolotov(ExecutorTestCase):
         self.obj.post_process()
         self.assertTrue('--delay 5.0' in self.CMD_LINE)
 
-    def test_no_concurrency(self):
-        self.configure({"execution": {
-            "iterations": 5,
-            "scenario": {
-                "script": LOADTEST_PY}}})
-        self.obj_prepare()
-        self.obj.engine.start_subprocess = self.start_subprocess
-        self.obj.startup()
-        self.obj.post_process()
-        self.assertTrue('--workers 1' in self.CMD_LINE)
-
 
 class TestReportReader(BZTestCase):
     def test_read(self):
@@ -124,9 +120,9 @@ class TestReportReader(BZTestCase):
         obj = MolotovReportReader(log_path, ROOT_LOGGER)
         points = list(obj.datapoints(True))
 
-        self.assertEqual(len(points), 3)
+        self.assertEqual(len(points), 4)
 
         for datapoint in points:
             self.assertTrue(datapoint['ts'] > 1500000000)
-        self.assertEqual(points[-1][DataPoint.CUMULATIVE][''][KPISet.SUCCESSES], 10)
-        self.assertEqual(points[-1][DataPoint.CUMULATIVE][''][KPISet.FAILURES], 2)
+        self.assertEqual(points[-1][DataPoint.CUMULATIVE][''][KPISet.SUCCESSES], 4)
+        self.assertEqual(points[-1][DataPoint.CUMULATIVE][''][KPISet.FAILURES], 4)

--- a/tests/unit/modules/test_molotov.py
+++ b/tests/unit/modules/test_molotov.py
@@ -95,6 +95,18 @@ class TestMolotov(ExecutorTestCase):
         for line in target_lines:
             self.assertTrue(line in self.CMD_LINE)
 
+    def test_no_hold_for(self):
+        self.configure({"execution": {
+            "scenario": {
+                "script": LOADTEST_PY}}})
+        self.obj_prepare()
+        self.obj.engine.start_subprocess = self.start_subprocess
+        self.obj.get_widget()
+        self.obj.startup()
+        self.obj.post_process()
+
+        self.assertTrue("--duration 0" in self.CMD_LINE)
+
     def test_think_time(self):
         self.obj.settings.merge({
             "path": TOOL_PATH})


### PR DESCRIPTION
1) hold-for change. Molotov `--duration` equals `hold-for` value, not the sum of `hold-for` and `ramp-up`.
2) duration fix. `duraion` is now always present in Molotov cmdline to stop Molotov eventually.
3) two records in results table. Happened because reader counted both url and test function results, and url results shouldn't be counted.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [x] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
