### PR TITLE
Fixed unwanted escaping of JS blocks

### DIFF
--- a/site/dat/docs/changes/fix-script-eval-escape.change
+++ b/site/dat/docs/changes/fix-script-eval-escape.change
@@ -1,0 +1,1 @@
+fixed unwanted escaping of JS blocks

--- a/tests/resources/selenium/generated_from_requests.py
+++ b/tests/resources/selenium/generated_from_requests.py
@@ -157,6 +157,8 @@ class TestLocSc(unittest.TestCase):
                 var_loc_keys[1]).submit()
             self.driver.execute_script("alert('This is Sparta');")
             waiter()
+            self.driver.execute_script("{{alert('This is {}');}}".format(self.vars['red_pill']))
+            waiter()
 
             for i in range(10):
                 if ((i % 2) == 0):

--- a/tests/resources/selenium/generated_from_requests_v2.py
+++ b/tests/resources/selenium/generated_from_requests_v2.py
@@ -29,7 +29,7 @@ class TestLocSc(unittest.TestCase):
         self.driver = None
         action_start({'param': {}, 'type': 'new_session', 'value': None})
         try:
-            self.vars = {'my_xpath_locator': '/html/body/div[3]', 'name': 'Name', 'red_pill': 'take_it,'}
+            self.vars = {'my_xpath_locator': '/html/body/div[3]', 'name': 'Name', 'pos': 100, 'red_pill': 'take_it,'}
 
             timeout = 3.5
             options = webdriver.FirefoxOptions()
@@ -134,7 +134,6 @@ class TestLocSc(unittest.TestCase):
             action_start({'param': 'var_assert', 'selectors': [], 'tag': 'eval', 'type': 'assert', 'value': 'myFunction();\nfunction myFunction(){{\n btnNameVar="{}";\n return "support";\n}}'.format(self.vars['btnName1'])})
             self.assertTrue(self.driver.execute_script('return var_assert;'), 'var_assert')
             action_end({'param': 'var_assert', 'selectors': [], 'tag': 'eval', 'type': 'assert', 'value': 'myFunction();\nfunction myFunction(){{\n btnNameVar="{}";\n return "support";\n}}'.format(self.vars['btnName1'])})
-
             action_start({'param': 'var_eval', 'selectors': [], 'tag': 'eval', 'type': 'store', 'value': 'myFunction();\nfunction myFunction(){{\n btnNameVar="{}";\n return "support";\n}}'.format(self.vars['btnName1'])})
 
             self.vars['var_eval'] = self.driver.execute_script('return myFunction();\nfunction myFunction(){{\n btnNameVar="{}";\n return "support";\n}};'.format(self.vars['btnName1']))
@@ -177,10 +176,18 @@ class TestLocSc(unittest.TestCase):
                 var_loc_select[1])).select_by_visible_text('American Express')
             waiter()
             action_end({'param': 'American Express', 'selectors': [{'css': 'myclass'}, {'xpath': '//*[@id="cardType"]'}], 'tag': '', 'type': 'select', 'value': None})
-            action_start({'param': 'window.scrollTo(0, document.body.scrollHeight);', 'selectors': [], 'tag': 'eval', 'type': 'script', 'value': None})
-            self.driver.execute_script('window.scrollTo(0, document.body.scrollHeight);')
+            action_start({'param': '{window.scrollTo(0, document.body.scrollHeight);}', 'selectors': [], 'tag': 'eval', 'type': 'script', 'value': None})
+            self.driver.execute_script('{window.scrollTo(0, document.body.scrollHeight);}')
             waiter()
-            action_end({'param': 'window.scrollTo(0, document.body.scrollHeight);', 'selectors': [], 'tag': 'eval', 'type': 'script', 'value': None})
+            action_end({'param': '{window.scrollTo(0, document.body.scrollHeight);}', 'selectors': [], 'tag': 'eval', 'type': 'script', 'value': None})
+            action_start({'param': '{{window.scrollTo(0, {});}}'.format(self.vars['pos']), 'selectors': [], 'tag': 'eval', 'type': 'script', 'value': None})
+            self.driver.execute_script('{{window.scrollTo(0, {});}}'.format(self.vars['pos']))
+            waiter()
+            action_end({'param': '{{window.scrollTo(0, {});}}'.format(self.vars['pos']), 'selectors': [], 'tag': 'eval', 'type': 'script', 'value': None})
+            action_start({'param': "{var event = new InputEvent('input', { bubbles: true,cancelable: false,data: true });}", 'selectors': [], 'tag': 'eval', 'type': 'script', 'value': None})
+            self.driver.execute_script("{var event = new InputEvent('input', { bubbles: true,cancelable: false,data: true });}")
+            waiter()
+            action_end({'param': "{var event = new InputEvent('input', { bubbles: true,cancelable: false,data: true });}", 'selectors': [], 'tag': 'eval', 'type': 'script', 'value': None})
             action_start({'param': 'for i in range(10):\n  if i % 2 == 0:\n    print(i)', 'selectors': [], 'tag': '', 'type': 'rawcode', 'value': None})
 
             for i in range(10):

--- a/tests/unit/modules/_selenium/test_selenium_builder.py
+++ b/tests/unit/modules/_selenium/test_selenium_builder.py
@@ -124,6 +124,7 @@ class TestSeleniumScriptGeneration(ExecutorTestCase):
 
                             # exec, rawcode, go, edit
                             "scriptEval(\"{alert('This is ${sparta}');}\")",
+                            "scriptEval(\"{alert('Alert');}\")",
                             {"rawCode": "for i in range(10):\n  if i % 2 == 0:\n    print(i)"},
                             "go(http:\\blazemeter.com)",
                             {"editContentById(editor)": "lo-la-lu"},
@@ -635,6 +636,7 @@ class TestSeleniumScriptGeneration(ExecutorTestCase):
                             "closeWindow('that_window')",
                             "submitByName(\"toPort\")",
                             "scriptEval(\"alert('This is Sparta');\")",
+                            "scriptEval(\"{alert('This is ${red_pill}');}\")",
                             {"rawCode": "for i in range(10):\n  if i % 2 == 0:\n    print(i)"},
                             {"dragByID(address)": "elementByName(toPort)"},
                             "switchFrameByName('my_frame')",
@@ -1365,7 +1367,8 @@ class TestSeleniumScriptGeneration(ExecutorTestCase):
                         "variables": {
                             "my_xpath_locator": "/html/body/div[3]",
                             "red_pill": "take_it,",
-                            "name": "Name"
+                            "name": "Name",
+                            "pos": 100
                         },
                         "timeout": "3.5s",
                         "requests": [
@@ -1499,7 +1502,20 @@ class TestSeleniumScriptGeneration(ExecutorTestCase):
                                     },
                                     {
                                         "type": "scriptEval",
-                                        "param": "window.scrollTo(0, document.body.scrollHeight);"
+                                        "param": "{window.scrollTo(0, document.body.scrollHeight);}"
+                                    },
+                                    {
+                                        "type": "scriptEval",
+                                        "param": "{window.scrollTo(0, ${pos});}"
+                                    },
+                                    {
+                                        "type": "scriptEval",
+                                        "param": "{"
+                                                 "var event = new InputEvent('input', { "
+                                                 "bubbles: true,"
+                                                 "cancelable: false,"
+                                                 "data: true });"
+                                                 "}"
                                     },
                                     {
                                         "type": "rawCode",


### PR DESCRIPTION
* when there is no variable in the JS block don't escape

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
