### PR TITLE
US44730-add a flag to send over errors to bza

### DIFF
--- a/bzt/engine/engine.py
+++ b/bzt/engine/engine.py
@@ -349,6 +349,7 @@ class Engine(object):
         for module in modules:
             if module in self.prepared:
                 try:
+                    module.is_error = True if self.stopping_reason else None
                     module.post_process()
                 except BaseException as exc:
                     if isinstance(exc, KeyboardInterrupt):
@@ -356,6 +357,7 @@ class Engine(object):
                     else:
                         self.log.debug("post_process: %s\n%s", exc, traceback.format_exc())
                     if not self.stopping_reason:
+                        module.is_error = True
                         self.stopping_reason = exc
                     if not exc_value:
                         exc_value = exc

--- a/bzt/engine/modules.py
+++ b/bzt/engine/modules.py
@@ -46,6 +46,7 @@ class EngineModule(object):
         self.engine = None
         self.settings = BetterDict()
         self.parameters = BetterDict()
+        self.is_error = None
 
     def prepare(self):
         """

--- a/tests/unit/modules/jmeter/test_JTLReader.py
+++ b/tests/unit/modules/jmeter/test_JTLReader.py
@@ -359,6 +359,6 @@ class TestJTLReader(BZTestCase):
                u'throughput': 0}
 
         subj = new()
-        items = list(subj.items()) + [('concurrency', subj.concurrency)]
+        items = list(subj.items()) + [('concurrency', subj['concurrency'])]
         self.assertEqual(exp, enc_dec_iter(items))
         self.assertEqual('{"100.0": 0.1}', to_json(new().get(KPISet.PERCENTILES), indent=None))


### PR DESCRIPTION
Adds a flag is_error to the modules abstract class so BZA can get an indication that an error occurred in Taurus.
