### PR TITLE
DE23608 Fix retry get status with timeout

### DIFF
--- a/bzt/bza.py
+++ b/bzt/bza.py
@@ -55,8 +55,8 @@ def get_with_retry(method):
                 return method(self, *args, **kwargs)
             except NETWORK_PROBLEMS:
                 self.log.debug("Error making request: %s", traceback.format_exc())
-                self.log.warning("Failed to make request, will retry in %s sec...", self.user.timeout)
-                time.sleep(self.user.timeout)
+                self.log.warning("Failed to make request, will retry in %s sec...", self.timeout)
+                time.sleep(self.timeout)
 
     return _impl
 


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
