### PR TITLE
change nodejs 12-->14, include apt-utils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,14 @@ ENV APT_INSTALL="apt-get -y install --no-install-recommends"
 ENV APT_UPDATE="apt-get -y update"
 ENV PIP_INSTALL="python3 -m pip install"
 
-ADD https://deb.nodesource.com/setup_12.x /tmp
+ADD https://deb.nodesource.com/setup_14.x /tmp
 ADD https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb /tmp
 ADD https://packages.microsoft.com/config/ubuntu/21.04/packages-microsoft-prod.deb /tmp
 COPY dist/bzt*whl /tmp
 
 WORKDIR /tmp
 # add node repo and call 'apt-get update'
-RUN bash ./setup_12.x && $APT_INSTALL build-essential python3-pip python3.9-dev net-tools
+RUN bash ./setup_14.x && $APT_INSTALL build-essential python3-pip python3.9-dev net-tools apt-utils
 
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
 


### PR DESCRIPTION
fix: nodejs12 not build docker
- I switched to ver14 because I can no longer build with nodejs12.

fix: apt-utils warning
- Warnings due to apt-utils not being installed have been addressed.
