### PR TITLE
Fix jQuery extraction

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1616,11 +1616,11 @@ class JMeter(RequiredTool):
             return
 
         # Fix CVE-2016-10707 in jquery
-        jquery_src_dir = os.path.join(jmeter_dir, "jquery-dist-3.6.0")
+        jquery_src_dir = os.path.join(jmeter_dir, "jquery-dist-3.6.1")
         jquery_target_dir = os.path.join(jmeter_dir,
             "bin/report-template/sbadmin2-1.0.7/bower_components/jquery/")
-        jquery_tar = os.path.join(jmeter_dir, "jquery-dist-3.6.0.tar.gz")
-        self.__download_additions([["https://github.com/jquery/jquery-dist/archive/3.6.0.tar.gz",
+        jquery_tar = os.path.join(jmeter_dir, "jquery-dist-3.6.1.tar.gz")
+        self.__download_additions([["https://github.com/jquery/jquery-dist/archive/3.6.1.tar.gz",
                                     jquery_tar]])
         shutil.unpack_archive(jquery_tar, jmeter_dir)
         shutil.rmtree(jquery_target_dir, ignore_errors=True)

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1618,13 +1618,12 @@ class JMeter(RequiredTool):
         # Fix CVE-2016-10707 in jquery
         jquery_src_dir = os.path.join(jmeter_dir, "jquery-dist-3.6.0")
         jquery_target_dir = os.path.join(jmeter_dir,
-            "bin/report-template/sbadmin2-1.0.7/bower_components/jquery")
+            "bin/report-template/sbadmin2-1.0.7/bower_components/jquery/")
         jquery_tar = os.path.join(jmeter_dir, "jquery-dist-3.6.0.tar.gz")
         self.__download_additions([["https://github.com/jquery/jquery-dist/archive/3.6.0.tar.gz",
                                     jquery_tar]])
         shutil.unpack_archive(jquery_tar, jmeter_dir)
         shutil.rmtree(jquery_target_dir, ignore_errors=True)
-        os.makedirs(jquery_target_dir)
         shutil.move(jquery_src_dir, jquery_target_dir)
         os.remove(jquery_tar)
 


### PR DESCRIPTION
This PR fixes the issue that the jQuery archive contents were moved to the subfolder `jquery-dist-3.6.0`. So instead of `jmeter/bin/report-template/sbadmin2-1.0.7/bower_components/jquery/` the jQuery contents would be extracted to `jmeter/bin/report-template/sbadmin2-1.0.7/bower_components/jquery/jquery-dist-3.6.0/`. I also updated to the latest version.

Quick checklist:
- [x] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
