### PR TITLE
Add support for jmeter-grpc-request plugin.

### DIFF
--- a/bzt/jmx/grpc.py
+++ b/bzt/jmx/grpc.py
@@ -1,0 +1,46 @@
+import json
+from urllib import parse
+
+from bzt.jmx.base import JMX
+from bzt.jmx.tools import ProtocolHandler
+from lxml import etree
+
+numeric_types = (int, float, complex)
+
+
+class GRPCProtocolHandler(ProtocolHandler):
+    def get_sampler_pair(self, request):
+        if isinstance(request.body, dict):
+            request.body = json.dumps(request.body)
+
+        if isinstance(request.metadata, dict):
+            request.metadata = json.dumps(request.metadata)
+
+        parsed_url = parse.urlparse(request.url)
+        timeout = self.safe_time(request.timeout)
+
+        full_method = parsed_url.path
+        if full_method[0] == '/':
+            full_method = full_method[1:]
+
+        grpc = etree.Element("vn.zalopay.benchmark.GRPCSampler",
+                             guiclass="vn.zalopay.benchmark.GRPCSamplerGui",
+                             testclass="vn.zalopay.benchmark.GRPCSampler",
+                             testname=request.label)
+
+        grpc.append(JMX._string_prop("GRPCSampler.protoFolder", request.protoFolder))
+        grpc.append(JMX._string_prop("GRPCSampler.libFolder", request.libFolder))
+        grpc.append(JMX._string_prop("GRPCSampler.metadata", request.metadata))
+        grpc.append(JMX._bool_prop("GRPCSampler.tls", parsed_url.scheme == "https"))
+        grpc.append(JMX._bool_prop("GRPCSampler.tlsDisableVerification", request.tlsDisableVerification))
+        grpc.append(JMX._string_prop("GRPCSampler.host", parsed_url.hostname))
+        grpc.append(JMX._string_prop("GRPCSampler.port", parsed_url.port))
+        grpc.append(JMX._string_prop("GRPCSampler.fullMethod", full_method))
+        grpc.append(JMX._string_prop("GRPCSampler.deadline", timeout))
+        grpc.append(JMX._string_prop("GRPCSampler.channelAwaitTermination", timeout))
+        grpc.append(JMX._string_prop("GRPCSampler.maxInboundMessageSize", request.maxInboundMessageSize))
+        grpc.append(JMX._string_prop("GRPCSampler.maxInboundMetadataSize", request.maxInboundMetadataSize))
+        grpc.append(JMX._string_prop("GRPCSampler.requestJson", request.body))
+
+        children = etree.Element("hashTree")
+        return grpc, children

--- a/bzt/jmx/tools.py
+++ b/bzt/jmx/tools.py
@@ -37,6 +37,9 @@ class RequestCompiler(RequestVisitor):
     def visit_mqttrequest(self, request):
         return self.jmx_builder.compile_request(request)
 
+    def visit_grpcrequest(self, request):
+        return self.jmx_builder.compile_request(request)
+
     def visit_hierarchichttprequest(self, request):
         return self.jmx_builder.compile_request(request)
 

--- a/bzt/requests_model.py
+++ b/bzt/requests_model.py
@@ -79,7 +79,7 @@ class HTTPRequest(BodyRequest):
     NAME = "request"
 
     def __init__(self, config, scenario, engine, pure_body_file=False):
-        super(HTTPRequest, self).__init__(config, scenario, engine, pure_body_file=False)
+        super(HTTPRequest, self).__init__(config, scenario, engine, pure_body_file=pure_body_file)
         msg = "Option 'url' is mandatory for request but not found in %s" % config
         self.url = self.config.get("url", TaurusConfigError(msg))
         self.label = str(self.config.get("label", self.url))

--- a/bzt/requests_model.py
+++ b/bzt/requests_model.py
@@ -47,42 +47,18 @@ class Request(object):
             val = default
         return val
 
-
-class HTTPRequest(Request):
-    NAME = "request"
-
-    def __init__(self, config, scenario, engine, pure_body_file=False):
-        self.engine = engine
-        self.log = self.engine.log.getChild(self.__class__.__name__)
-        super(HTTPRequest, self).__init__(config, scenario)
-        msg = "Option 'url' is mandatory for request but not found in %s" % config
-        self.url = self.config.get("url", TaurusConfigError(msg))
-        self.label = str(self.config.get("label", self.url))
-        self.method = self.config.get("method", "GET")
-        if not has_variable_pattern(self.method):
-            self.method = self.method.upper()
-
-        self.headers = self.config.get("headers", {})
-
-        self.keepalive = self.config.get('keepalive', None)
-        self.timeout = self.config.get('timeout', None)
-        self.follow_redirects = self.config.get('follow-redirects', None)
-        self.body = self._get_body(pure_body_file=pure_body_file)
-
     def get_think_time(self, full=False):
         think_time = self.priority_option('think-time')
         if think_time:
             return parse_think_time(think_time=think_time, full=full)
 
-    def get_header(self, name):
-        def dic_lower(dic):
-            return {str(k).lower(): str(dic[k]).lower() for k in dic}
 
-        scenario_headers = dic_lower(self.scenario.get_headers())
-        request_headers = dic_lower(self.headers)
-        headers = BetterDict.from_dict(scenario_headers)
-        headers.merge(request_headers)
-        return headers.get(name.lower(), None)
+class BodyRequest(Request):
+    def __init__(self, config, scenario, engine, pure_body_file=False):
+        super(BodyRequest, self).__init__(config, scenario)
+        self.engine = engine
+        self.log = self.engine.log.getChild(self.__class__.__name__)
+        self.body = self._get_body(pure_body_file=pure_body_file)
 
     def _get_body(self, pure_body_file=False):
         body = self.config.get('body', None)
@@ -99,16 +75,63 @@ class HTTPRequest(Request):
         return body
 
 
+class HTTPRequest(BodyRequest):
+    NAME = "request"
+
+    def __init__(self, config, scenario, engine, pure_body_file=False):
+        super(HTTPRequest, self).__init__(config, scenario, engine, pure_body_file=False)
+        msg = "Option 'url' is mandatory for request but not found in %s" % config
+        self.url = self.config.get("url", TaurusConfigError(msg))
+        self.label = str(self.config.get("label", self.url))
+        self.method = self.config.get("method", "GET")
+        if not has_variable_pattern(self.method):
+            self.method = self.method.upper()
+
+        self.headers = self.config.get("headers", {})
+
+        self.keepalive = self.config.get('keepalive', None)
+        self.timeout = self.config.get('timeout', None)
+        self.follow_redirects = self.config.get('follow-redirects', None)
+
+    def get_header(self, name):
+        def dic_lower(dic):
+            return {str(k).lower(): str(dic[k]).lower() for k in dic}
+
+        scenario_headers = dic_lower(self.scenario.get_headers())
+        request_headers = dic_lower(self.headers)
+        headers = BetterDict.from_dict(scenario_headers)
+        headers.merge(request_headers)
+        return headers.get(name.lower(), None)
+
+
 class MQTTRequest(Request):
     def __init__(self, config, scenario):
         super(MQTTRequest, self).__init__(config, scenario)
         self.method = config.get('cmd')
         self.label = str(self.config.get("label", self.method))
 
-    def get_think_time(self, full):
-        think_time = self.priority_option('think-time')
-        if think_time:
-            return parse_think_time(think_time=think_time, full=full)
+
+class GRPCRequest(BodyRequest):
+    def __init__(self, config, scenario, engine):
+        super(GRPCRequest, self).__init__(config, scenario, engine, False)
+
+        url_msg = "Option 'url' is mandatory for request but not found in %s" % config
+        self.url = self.config.get("url", default=TaurusConfigError(url_msg))
+
+        proto_msg = "Option 'grpc-proto-folder' is mandatory for request but not found in %s" % config
+        self.protoFolder = self.priority_option('grpc-proto-folder', default=TaurusConfigError(proto_msg))
+
+        self.libFolder = self.priority_option('grpc-lib-folder', default='')
+        self.maxInboundMessageSize = self.priority_option('grpc-max-inbound-message-size', default=4194304)
+        self.maxInboundMetadataSize = self.priority_option('grpc-max-inbound-metadata-size', default=8192)
+        self.tlsDisableVerification = self.priority_option('tls-disable-verification', default=False)
+        self.timeout = self.priority_option("timeout", default="5s")
+
+        self.label = str(self.config.get("label", default=self.url))
+        self.metadata = self.config.get("metadata", default='')
+        self.body = self._get_body(pure_body_file=False)
+        if self.body is None:
+            self.body = ''
 
 
 class HierarchicHTTPRequest(HTTPRequest):
@@ -369,6 +392,8 @@ class HierarchicRequestParser(RequestParser):
             return TearDownBlock(do_requests, req)
         elif self.scenario.get("protocol") == "mqtt":
             return MQTTRequest(req, self.scenario)
+        elif self.scenario.get("protocol") == "grpc":
+            return GRPCRequest(req, self.scenario, self.engine)
         else:
             return HierarchicHTTPRequest(req, self.scenario, self.engine)
 

--- a/bzt/resources/10-base-config.yml
+++ b/bzt/resources/10-base-config.yml
@@ -11,6 +11,7 @@ modules:
     protocol-handlers:
       http: bzt.jmx.http.HTTPProtocolHandler
       mqtt: bzt.jmx.mqtt.MQTTProtocolHandler
+      grpc: bzt.jmx.grpc.GRPCProtocolHandler
   locust:
     class: bzt.modules._locustio.LocustIOExecutor
   molotov:

--- a/site/dat/docs/JMeter.md
+++ b/site/dat/docs/JMeter.md
@@ -1150,3 +1150,76 @@ scenarios:
 Here you see three sensors ('publisher') and one checker ('subscriber'). Messages that created by sensors
 must be handled by broker and redirected to appropriate subscribers.
 All logic blocks, data sources and many other functionality of JMeter Executor are available with mqtt protocol as well.
+
+
+## gRPC Protocol Load Testing
+
+JMeter tool can also perform load testing of gRPC services, via [jmeter-grpc-request](https://github.com/zalopay-oss/jmeter-grpc-request) plugin.
+
+Here's a very basic request (the `url` and `grpc-proto-folder` fields are required):
+
+```yaml
+# Install the relevant JMeter plugin
+modules:
+  jmeter:
+    plugins:
+      - jmeter-grpc-request
+
+scenarios:
+  hello-world:
+    protocol: grpc
+    grpc-proto-folder: /path/to/protobuf/folder
+    requests:
+    - url: http://api.example.com:8888/com.example.HelloWorldService/sayHello
+```
+
+Here's the full set of options:
+
+```yaml
+scenarios:
+  my-req:
+    protocol: grpc
+    # These options can be set at the scenario level, or at the request level
+    timeout: 5s
+    grpc-proto-folder: /path/to/protobuf/folder
+    grpc-lib-folder: /path/to/grpc/lib/folder
+    grpc-max-inbound-message-size: 4194304
+    grpc-max-inbound-metadata-size: 8192
+    tls-disable-verification: false
+      
+    requests:
+      # The URL is parsed into (scheme, hostname, port, path) which are propagated to the jmeter-grpc-request plugin
+      # The "path" component of the URL is used as the "Full Method" param
+      # If the scheme is "https" then the SSL/TLS param will be set to "true"
+    - url: http://api.example.com:8888/com.example.HelloWorldService/sayHello  # url to hit
+      label: homepage  # sampler label, defaults to the value of url
+
+      # Request body can be sepcified as a JSON string, as a dictionary, or as JSON in a separate file
+      body: '{ "param1": "value1", "param2": value2 }'  # if present, will be used as body
+      body:  # nested attributes will be converted to JSON
+        param1: value1
+        param2: value2
+      body-file: path/to/file.json  # this file contents will be used as request body
+
+      # Request metadata can be sepcified as a JSON string or as a dictionary
+      metadata: 'key1:value1,key2:value2'
+      metadata: '{"key1":"Value1", "key2":"value2"}'
+      metadata:
+        key1: Value1
+        key2: value2
+
+      # These options can be set at the scenario level, or at the request level
+      timeout: 5s  # Timeout is used for both "deadline" and "channelAwaitTermination"
+      grpc-proto-folder: /path/to/protobuf/folder
+      grpc-lib-folder: /path/to/grpc/lib/folder
+      grpc-max-inbound-message-size: 4194304
+      grpc-max-inbound-metadata-size: 8192
+      tls-disable-verification: false
+      
+      extract-regexp: {}  # same as described for HTTP sampler above
+      extract-jsonpath: {}  # same as described for HTTP sampler above
+      assert: []  # same as described for HTTP sampler above
+      jsr223: []  # same as described for HTTP sampler above
+```
+
+All logic blocks, data sources and many other functionality of JMeter Executor are available with grpc protocol as well.

--- a/site/dat/docs/changes/feat-jmeter-grpc-request.change
+++ b/site/dat/docs/changes/feat-jmeter-grpc-request.change
@@ -1,0 +1,1 @@
+Added support for jmeter-grpc-request plugin.


### PR DESCRIPTION
There is a JMeter plugin [jmeter-grpc-request](https://github.com/zalopay-oss/jmeter-grpc-request) that enables performing load testing of gRPC services. This PR implements a new `grpc` protocol handler that creates a sampler using this plugin.

---
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [x] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
