### PR TITLE
US47068 report engine metrics to happysocks

### DIFF
--- a/bzt/modules/blazemeter/engine_metrics.py
+++ b/bzt/modules/blazemeter/engine_metrics.py
@@ -1,0 +1,77 @@
+import copy
+import logging
+import math
+from collections import deque
+from operator import itemgetter
+from typing import List
+
+
+class EngineMetricsBuffer:
+    """
+    Acts as a buffer for engine metrics coming from various sources. Engine metrics have the following form:
+    [
+        {'source': 'local', 'ts': 1678892271.3985019, 'cpu': 9.4},
+        {'source': 'local', 'ts': 1678892271.3985019, 'mem': 55.6},
+        {'source': 'local', 'ts': 1678892271.3985019, 'bytes-sent': 26302},
+        {'source': 'local', 'ts': 1678892271.3985019, 'bytes-recv': 2485},
+        {'source': 'local', 'ts': 1678892271.3985019, 'conn-all': 63},
+        ...
+    ]
+    """
+    def __init__(self, max_len=500):
+        self._log = logging.getLogger(self.__class__.__name__)
+        self.queue = deque(maxlen=max_len)
+
+    def record_data(self, data: List[dict]):
+        if len(self.queue) + len(data) > self.queue.maxlen:
+            self._log.debug(f"Engine metrics queue overflow, max size {self.queue.maxlen} reached")
+        for item in data:
+            self.queue.append(item)
+
+    def get_data(self) -> List[dict]:
+        return list(self.queue)
+
+    def clear(self):
+        self.queue.clear()
+
+
+class HappysocksMetricsConverter:
+    known_metrics = {'cpu', 'mem'}
+
+    @staticmethod
+    def to_metrics_batch(raw_metrics: List[dict], session_id, master_id=None, calibration_id=None,
+                         calibration_step_id=None) -> List[dict]:
+        """
+        Converts engine metrics from internal format where each record holds single metric value into format expected by
+        happysocks service.
+        """
+        metrics_per_ts = dict()
+        for raw_item in raw_metrics:
+            raw_item_copy = copy.deepcopy(raw_item)
+            source = raw_item_copy.pop('source')
+            ts = math.floor(raw_item_copy.pop('ts') * 1000)
+            for metric_name, metric_value in raw_item_copy.items():
+                if metric_name in HappysocksMetricsConverter.known_metrics:
+                    key = frozenset({'source': source, 'ts': ts}.items())
+                    metrics_bag = metrics_per_ts.get(key)
+                    if not metrics_bag:
+                        metrics_bag = HappysocksMetricsConverter.new_metrics_bag(source, ts, session_id, master_id,
+                                                                                 calibration_id, calibration_step_id)
+                        metrics_per_ts[key] = metrics_bag
+                    metrics_bag['values'][metric_name] = metric_value
+        return sorted(list(metrics_per_ts.values()), key=itemgetter('timestamp'))
+
+    @staticmethod
+    def new_metrics_bag(source, ts, session_id, master_id, calibration_id, calibration_step_id):
+        metrics_bag = dict()
+        metrics_bag['metadata'] = {'source': source, 'entityId': session_id}
+        if master_id:
+            metrics_bag['metadata']['masterId'] = master_id
+        # if we are doing calibration then add info to metadata
+        if calibration_id:
+            metrics_bag['metadata']['calibrationId'] = calibration_id
+        if calibration_step_id:
+            metrics_bag['metadata']['calibrationStepId'] = calibration_step_id
+        metrics_bag['timestamp'] = ts
+        metrics_bag['values'] = dict()
+        return metrics_bag

--- a/bzt/modules/monitoring.py
+++ b/bzt/modules/monitoring.py
@@ -6,6 +6,7 @@ import time
 import traceback
 from abc import abstractmethod
 from collections import OrderedDict, namedtuple
+from typing import List
 
 import csv
 import psutil
@@ -94,7 +95,7 @@ class Monitoring(Service, Singletone):
 
 class MonitoringListener(object):
     @abstractmethod
-    def monitoring_data(self, data):
+    def monitoring_data(self, data: List[dict]):
         pass
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ requests>=2.18.1
 urwid
 terminaltables>=3.1.0
 molotov!=2.3
+python-socketio==5.8.0
+websocket-client==1.5.1

--- a/tests/unit/modules/blazemeter/test_engine_metrics.py
+++ b/tests/unit/modules/blazemeter/test_engine_metrics.py
@@ -1,0 +1,201 @@
+import sys
+
+from modules.blazemeter.engine_metrics import EngineMetricsBuffer, HappysocksMetricsConverter
+from unit import BZTestCase
+
+
+class TestEngineMetricsBuffer(BZTestCase):
+
+    def test_empty(self):
+        buffer = EngineMetricsBuffer()
+        data = buffer.get_data()
+        self.assertEqual(data, [])
+
+    def test_push_get(self):
+        buffer = EngineMetricsBuffer()
+        buffer.record_data([
+            {'source': 'local', 'ts': 1678892271.3985019, 'cpu': 9.4},
+            {'source': 'local', 'ts': 1678892271.3985019, 'mem': 55.6},
+            {'source': 'local', 'ts': 1678892271.3985019, 'bytes-sent': 26302},
+        ])
+        data1 = buffer.get_data()
+        self.assertIsInstance(data1, list)
+        self.assertEqual(len(data1), 3)
+        data2 = buffer.get_data()
+        self.assertIsInstance(data2, list)
+        self.assertEqual(len(data2), 3)
+        self.assertEqual(data1, data2)
+
+    def test_limit_reached(self):
+        buffer = EngineMetricsBuffer(2)
+        buffer.record_data([
+            {'source': 'local', 'ts': 1678892271.3985019, 'cpu': 9.4},
+            {'source': 'local', 'ts': 1678892271.3985019, 'mem': 55.6},
+            {'source': 'local', 'ts': 1678892271.3985019, 'bytes-sent': 26302},
+        ])
+        data = buffer.get_data()
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 2)
+        self.assertEqual(len(list(filter(lambda item: 'mem' in item, data))), 1)
+        self.assertEqual(len(list(filter(lambda item: 'bytes-sent' in item, data))), 1)
+
+    def test_clear(self):
+        buffer = EngineMetricsBuffer(2)
+        buffer.record_data([
+            {'source': 'local', 'ts': 1678892271.3985019, 'cpu': 9.4},
+        ])
+        buffer.clear()
+        data = buffer.get_data()
+        self.assertIsInstance(data, list)
+        self.assertEqual(len(data), 0)
+
+
+class TestHappysocksMetricsConverter(BZTestCase):
+
+    def setUp(self):
+        super().setUp()
+        sys.stdout = self.stdout_backup  # super().setUp() disables sys.stdout, restore it
+
+    def tearDown(self):
+        super().tearDown()
+
+    def test_empty(self):
+        result = HappysocksMetricsConverter.to_metrics_batch([], 'r-v4-64102f1ab8795890049369', 100, 200, 300)
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 0)
+
+    def test_known_metrics(self):
+        result = HappysocksMetricsConverter.to_metrics_batch([
+            {'source': 'local', 'ts': 1678892271.3985019, 'cpu': 9.4},
+            {'source': 'local', 'ts': 1678892271.3985019, 'mem': 55.6},
+        ], 'r-v4-64102f1ab8795890049369', 100, 200, 300)
+        self.assertEqual(result, [
+            {
+                'metadata': {
+                    'source': 'local',
+                    'entityId': 'r-v4-64102f1ab8795890049369',
+                    'masterId': 100,
+                    'calibrationId': 200,
+                    'calibrationStepId': 300,
+                },
+                'timestamp': 1678892271398,
+                'values': {
+                    'cpu': 9.4,
+                    'mem': 55.6,
+                }
+            },
+        ])
+
+    def test_multi_metrics(self):
+        result = HappysocksMetricsConverter.to_metrics_batch([
+            {'source': 'local', 'ts': 1678892271.3985019, 'cpu': 9.4, 'mem': 55.6},
+            {'source': 'local', 'ts': 1678892300.4565019, 'mem': 35.6},
+        ], 'r-v4-64102f1ab8795890049369', 100, 200, 300)
+        self.assertEqual(result, [
+            {
+                'metadata': {
+                    'source': 'local',
+                    'entityId': 'r-v4-64102f1ab8795890049369',
+                    'masterId': 100,
+                    'calibrationId': 200,
+                    'calibrationStepId': 300,
+                },
+                'timestamp': 1678892271398,
+                'values': {
+                    'cpu': 9.4,
+                    'mem': 55.6,
+                }
+            },
+            {
+                'metadata': {
+                    'source': 'local',
+                    'entityId': 'r-v4-64102f1ab8795890049369',
+                    'masterId': 100,
+                    'calibrationId': 200,
+                    'calibrationStepId': 300,
+                },
+                'timestamp': 1678892300456,
+                'values': {
+                    'mem': 35.6,
+                }
+            },
+        ])
+
+    def test_unknown_metrics(self):
+        result = HappysocksMetricsConverter.to_metrics_batch([
+            {'source': 'local', 'ts': 1678892271.3985019, 'unknown': 2485},
+        ], 'r-v4-64102f1ab8795890049369', 100, 200, 300)
+        self.assertEqual(result, [])
+
+    def test_multiple_timestamps(self):
+        result = HappysocksMetricsConverter.to_metrics_batch([
+            {'source': 'local', 'ts': 1678892271.3985019, 'cpu': 9.4},
+            {'source': 'local', 'ts': 1678892300.4565019, 'mem': 55.6},
+        ], 'r-v4-64102f1ab8795890049369', 100, 200, 300)
+        self.assertEqual(result, [
+            {
+                'metadata': {
+                    'source': 'local',
+                    'entityId': 'r-v4-64102f1ab8795890049369',
+                    'masterId': 100,
+                    'calibrationId': 200,
+                    'calibrationStepId': 300,
+                },
+                'timestamp': 1678892271398,
+                'values': {
+                    'cpu': 9.4,
+                }
+            },
+            {
+                'metadata': {
+                    'source': 'local',
+                    'entityId': 'r-v4-64102f1ab8795890049369',
+                    'masterId': 100,
+                    'calibrationId': 200,
+                    'calibrationStepId': 300,
+                },
+                'timestamp': 1678892300456,
+                'values': {
+                    'mem': 55.6,
+                }
+            },
+        ])
+
+    def test_no_calibration(self):
+        result = HappysocksMetricsConverter.to_metrics_batch([
+            {'source': 'local', 'ts': 1678892271.3985019, 'cpu': 9.4},
+            {'source': 'local', 'ts': 1678892271.3985019, 'mem': 55.6},
+        ], 'r-v4-64102f1ab8795890049369', 100)
+        self.assertEqual(result, [
+            {
+                'metadata': {
+                    'source': 'local',
+                    'entityId': 'r-v4-64102f1ab8795890049369',
+                    'masterId': 100,
+                },
+                'timestamp': 1678892271398,
+                'values': {
+                    'cpu': 9.4,
+                    'mem': 55.6,
+                }
+            },
+        ])
+
+    def test_no_master_id(self):
+        result = HappysocksMetricsConverter.to_metrics_batch([
+            {'source': 'local', 'ts': 1678892271.3985019, 'cpu': 9.4},
+            {'source': 'local', 'ts': 1678892271.3985019, 'mem': 55.6},
+        ], 'r-v4-64102f1ab8795890049369')
+        self.assertEqual(result, [
+            {
+                'metadata': {
+                    'source': 'local',
+                    'entityId': 'r-v4-64102f1ab8795890049369',
+                },
+                'timestamp': 1678892271398,
+                'values': {
+                    'cpu': 9.4,
+                    'mem': 55.6,
+                }
+            },
+        ])


### PR DESCRIPTION
- support for sending engine metrics to happysocks service in batch
- metrics are only sent if _happysocks-address_ setting is set, session_id and signature is available
- master_id, calibration-id, calibration-step-id is sent if available in parameters
- setting _happysocks-verbose-logging_ enables verbose logging for socketio network communication
- setting _happysocks-verify-ssl_ allows to disable ssl verification for localhost development
- setting _monitoring-buffer-limit_ controls buffer limit for both old and new engine metrics
- setting _engine-metrics-send-interval_ controls send interval, being 5s by default
- unit tests were implemented


Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
