### PR TITLE
US47068 fixed handling of reconnect

### DIFF
--- a/bzt/modules/blazemeter/engine_metrics.py
+++ b/bzt/modules/blazemeter/engine_metrics.py
@@ -76,7 +76,7 @@ class HappysocksMetricsConverter:
     @staticmethod
     def new_metrics_bag(source, ts, session_id, master_id, calibration_id, calibration_step_id):
         metrics_bag = dict()
-        metrics_bag['metadata'] = {'source': source, 'entityId': session_id}
+        metrics_bag['metadata'] = {'type': 'engine-health', 'source': source, 'entityId': session_id}
         if master_id:
             metrics_bag['metadata']['masterId'] = master_id
         # if we are doing calibration then add info to metadata

--- a/tests/unit/modules/blazemeter/test_engine_metrics.py
+++ b/tests/unit/modules/blazemeter/test_engine_metrics.py
@@ -75,6 +75,7 @@ class TestHappysocksMetricsConverter(BZTestCase):
         self.assertEqual(result, [
             {
                 'metadata': {
+                    'type': 'engine-health',
                     'source': 'local',
                     'entityId': 'r-v4-64102f1ab8795890049369',
                     'masterId': 100,
@@ -100,6 +101,7 @@ class TestHappysocksMetricsConverter(BZTestCase):
         self.assertEqual(result, [
             {
                 'metadata': {
+                    'type': 'engine-health',
                     'source': 'local',
                     'entityId': 'r-v4-64102f1ab8795890049369',
                     'masterId': 100,
@@ -114,6 +116,7 @@ class TestHappysocksMetricsConverter(BZTestCase):
             },
             {
                 'metadata': {
+                    'type': 'engine-health',
                     'source': 'local',
                     'entityId': 'r-v4-64102f1ab8795890049369',
                     'masterId': 100,
@@ -141,6 +144,7 @@ class TestHappysocksMetricsConverter(BZTestCase):
         self.assertEqual(result, [
             {
                 'metadata': {
+                    'type': 'engine-health',
                     'source': 'local',
                     'entityId': 'r-v4-64102f1ab8795890049369',
                     'masterId': 100,
@@ -154,6 +158,7 @@ class TestHappysocksMetricsConverter(BZTestCase):
             },
             {
                 'metadata': {
+                    'type': 'engine-health',
                     'source': 'local',
                     'entityId': 'r-v4-64102f1ab8795890049369',
                     'masterId': 100,
@@ -175,6 +180,7 @@ class TestHappysocksMetricsConverter(BZTestCase):
         self.assertEqual(result, [
             {
                 'metadata': {
+                    'type': 'engine-health',
                     'source': 'local',
                     'entityId': 'r-v4-64102f1ab8795890049369',
                     'masterId': 100,
@@ -195,6 +201,7 @@ class TestHappysocksMetricsConverter(BZTestCase):
         self.assertEqual(result, [
             {
                 'metadata': {
+                    'type': 'engine-health',
                     'source': 'local',
                     'entityId': 'r-v4-64102f1ab8795890049369',
                 },

--- a/tests/unit/test_bza.py
+++ b/tests/unit/test_bza.py
@@ -1,5 +1,5 @@
 from logging import Logger
-from unittest.mock import patch
+from unittest.mock import patch, PropertyMock
 from socketio.exceptions import ConnectionError
 import time
 
@@ -140,6 +140,7 @@ class TestHappysocksClient(BZTestCase):
     def test_disconnect_not_connected(self, mock_socketio_class):
         # prepare mocks
         sio = mock_socketio_class.return_value
+        sio.connected = False
         # perform test
         client = HappysocksClient("https://happysocks-5100-tester-dev.blazemeter.net", "r-v4-64102f1ab8795890049369",
                                   "ci12NC02NDEwMmYxYWI", True, True)
@@ -150,6 +151,7 @@ class TestHappysocksClient(BZTestCase):
     def test_disconnect_connected(self, mock_socketio_class):
         # prepare mocks
         sio = mock_socketio_class.return_value
+        type(sio).connected = PropertyMock(side_effect=[True, False])
         # perform test
         client = HappysocksClient("https://happysocks-5100-tester-dev.blazemeter.net", "r-v4-64102f1ab8795890049369",
                                   "ci12NC02NDEwMmYxYWI", True, True)
@@ -162,7 +164,7 @@ class TestHappysocksClient(BZTestCase):
     def test_send_engine_metrics(self, mock_socketio_class):
         # prepare mocks
         sio = mock_socketio_class.return_value
-        sio.connected.return_value = True
+        sio.connected = False
         # perform test
         client = HappysocksClient("https://prod-rc.blazemeter.com/hs", "r-v4-64102f1ab8795890049369",
                                   "ci12NC02NDEwMmYxYWI", True, True)


### PR DESCRIPTION
Fixes the following error in bzt.log:

```
[2023-04-22 17:46:16,027 INFO HappysocksClient] Connecting to happysocks server https://prod-rc.blazemeter.com/hs/api-ws
[2023-04-22 17:46:16,027 ERROR Engine.blazemeter] Failed to send engine metrics
Traceback (most recent call last):
  File "/usr/local/taurus-cloud/python/lib/python3.10/site-packages/bzt/bza.py", line 829, in connect
    self._sio.connect(self._happysocks_address, namespaces=[HappysocksEngineNamespace.NAMESPACE],
  File "/usr/local/lib/python3.10/dist-packages/socketio/client.py", line 306, in connect
    raise exceptions.ConnectionError('Already connected')
socketio.exceptions.ConnectionError: Already connected

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/taurus-cloud/python/lib/python3.10/site-packages/bzt/modules/blazemeter/blazemeter_reporter.py", line 392, in check
    self._send_engine_metrics()
  File "/usr/local/taurus-cloud/python/lib/python3.10/site-packages/bzt/modules/blazemeter/blazemeter_reporter.py", line 454, in _send_engine_metrics
    self.happysocks_client.send_engine_metrics(metrics_batch)
  File "/usr/local/taurus-cloud/python/lib/python3.10/site-packages/bzt/bza.py", line 849, in send_engine_metrics
    self.connect()
  File "/usr/local/taurus-cloud/python/lib/python3.10/site-packages/bzt/bza.py", line 832, in connect
    raise TaurusNetworkError(f"Failed to connect to happysocks server {full_address}") from e
bzt.TaurusNetworkError: Failed to connect to happysocks server https://prod-rc.blazemeter.com/hs/api-ws
```

- removed the internal connected flag and we rely on the one in socket io only as it keeps it up to date