### PR TITLE
US47068 fixed problem with "RuntimeError: dictionary changed size dur…

### DIFF
--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -285,9 +285,10 @@ class CLI(object):
                 self.handle_exception(exc)
 
         if self.options.verbose:
-            for module_name in sys.modules:
-                version = str(getattr(sys.modules[module_name], '__version__', ""))
-                file = getattr(sys.modules[module_name], '__file__', "")
+            modules = sys.modules.copy()
+            for module_name in modules:
+                version = str(getattr(modules[module_name], '__version__', ""))
+                file = getattr(modules[module_name], '__file__', "")
                 if version:
                     module_name = "-".join((module_name, version))
                     self.log.debug("\t{}\t{}".format(module_name, file))


### PR DESCRIPTION
- fixed problem with dictionary changing size during iteration in Jenkins build:

```
11:07:51  [2023-04-24 09:07:51,606 ERROR root] RuntimeError: dictionary changed size during iteration
11:07:51  [2023-04-24 09:07:51,606 DEBUG root] Exception: Traceback (most recent call last):
11:07:51    File "/usr/local/lib/python3.10/dist-packages/bzt/cli.py", line 679, in main
11:07:51      code = executor.perform(parsed_configs)
11:07:51    File "/usr/local/lib/python3.10/dist-packages/bzt/cli.py", line 288, in perform
11:07:51      for module_name in sys.modules:
11:07:51  RuntimeError: dictionary changed size during iteration
```