### PR TITLE
fix: Listing of dictionaries (modules)

### DIFF
--- a/bzt/cli.py
+++ b/bzt/cli.py
@@ -286,7 +286,7 @@ class CLI(object):
 
         if self.options.verbose:
             modules = sys.modules.copy()
-            for module_name in modules:
+            for module_name in list(modules):
                 version = str(getattr(modules[module_name], '__version__', ""))
                 file = getattr(modules[module_name], '__file__', "")
                 if version:

--- a/site/dat/docs/changes/fix-update-cli.change
+++ b/site/dat/docs/changes/fix-update-cli.change
@@ -1,0 +1,1 @@
+Fix cli.py update. loop/dictionary errors 


### PR DESCRIPTION
List dictionaries (modules) in list() due to "RuntimeError "occurred: set size changed during iteration" when processing version information.

This response is a fix for issue #1724 (https://github.com/Blazemeter/taurus/issues/1724)
