### PR TITLE
US47936 added connect timeout. Made request and connect timeout confi…

### DIFF
--- a/bzt/modules/blazemeter/blazemeter_reporter.py
+++ b/bzt/modules/blazemeter/blazemeter_reporter.py
@@ -149,8 +149,11 @@ class BlazeMeterUploader(Reporter, AggregatorListener, MonitoringListener, Singl
         happysocks_address = self.settings.get("happysocks-address")
         if happysocks_address and self._sess_id and signature:
             self.log.info(f"Engine metrics will be sent to '{happysocks_address}'")
+            request_timeout = self.settings.get("happysocks-request-timeout", 10)
+            connect_timeout = self.settings.get("happysocks-connect-timeout", 7)
             self.happysocks_client = HappysocksClient(happysocks_address, self._sess_id, signature,
-                                                      happysocks_verbose_logging, happysocks_verify_ssl)
+                                                      happysocks_verbose_logging, happysocks_verify_ssl,
+                                                      request_timeout, connect_timeout)
         else:
             reason = ""
             if not happysocks_address:


### PR DESCRIPTION
- added connect timeout. Made request and connect timeout configurable via settings to be adjustable from bza if needed.
  - setting very low connect timeout (e.g 0.1) results in the same error message we occasionally saw in bzt.log
  - default connect timeout was 1s which was too low
- log time to connect
- added logging when connected/disconnected to make it clear the operation was successful