### PR TITLE
US47188: RFE BSTGlobal: Run publishing between functional iterations

### DIFF
--- a/bzt/modules/_apiritif/executor.py
+++ b/bzt/modules/_apiritif/executor.py
@@ -90,8 +90,16 @@ class ApiritifNoseExecutor(SubprocessedExecutor):
         filename = self.engine.create_artifact("test_requests", ".py")
         scenario = self.get_scenario()
 
+        bzm_tdo_settings = None
+        if self.engine.config.get("settings").get("master_publish_url"):
+            bzm_tdo_settings = {
+                "master_publish_url": self.engine.config.get("settings").get("master_publish_url"),
+                "master_signature": self.engine.config.get("settings").get("master_signature")
+            }
+
         if self.test_mode == "apiritif":
-            builder = ApiritifScriptGenerator(scenario, self.label, executor=self, test_mode=self.test_mode)
+            builder = ApiritifScriptGenerator(scenario, self.label, executor=self, test_mode=self.test_mode,
+                                              bzm_tdo_settings=bzm_tdo_settings)
             builder.verbose = self.__is_verbose()
         else:
             wdlog = self.engine.create_artifact('webdriver', '.log')
@@ -119,7 +127,8 @@ class ApiritifNoseExecutor(SubprocessedExecutor):
                 capabilities=capabilities,
                 wd_addr=remote, test_mode=self.test_mode,
                 generate_external_handler=True if self.settings.get('plugins-path', False) else False,
-                selenium_version=selenium_version)
+                selenium_version=selenium_version,
+                bzm_tdo_settings=bzm_tdo_settings)
 
         builder.build_source_code()
         builder.save(filename)

--- a/bzt/resources/bzm_extras.py
+++ b/bzt/resources/bzm_extras.py
@@ -1,0 +1,37 @@
+import requests
+import uuid
+from bzt import TaurusException
+
+
+# Allows for calling Blazemeter Test Data API Orchestration (publish, un-publish)
+class BzmExtras(object):
+
+    def __init__(self, settings=None):
+        self.settings = settings
+        self.publish_map = {}
+
+    def do_testdata_orchestration(self, operation, entity_name, target_name=""):
+        if self.settings.get('master_publish_url') is None:
+            raise TaurusException("Publish URL is not defined")
+        if self.settings.get('master_signature') is None:
+            raise TaurusException("Publish Signature is not defined")
+        if operation not in ["publish", "un-publish"]:
+            raise TaurusException(f"Invalid operation for publishing, must be either 'publish' or 'un-publish', "
+                                  f"received {operation}")
+
+        if operation == "publish":
+            session_id = str(uuid.uuid4())
+            self.publish_map[entity_name + target_name] = session_id
+        else:
+            session_id = self.publish_map[entity_name + target_name]
+
+        post_obj = {'operation': operation, 'entity': entity_name, 'sessionId': session_id}
+        if target_name:
+            post_obj['target'] = target_name
+
+        url = f'{self.settings.get("master_publish_url")}?signature={self.settings.get("master_signature")}'
+
+        post_response = requests.post(url, json=post_obj)
+        if post_response.status_code >= 400:
+            raise TaurusException(
+                f"Publish data failed, status code: {post_response.status_code}, reason: {post_response.reason}")

--- a/tests/resources/selenium/generated_from_requests_td_publish.py
+++ b/tests/resources/selenium/generated_from_requests_td_publish.py
@@ -1,0 +1,58 @@
+# coding=utf-8
+
+import logging
+import random
+import string
+import sys
+import unittest
+from time import time, sleep
+
+import apiritif
+
+import os
+import re
+from selenium import webdriver
+from selenium.common.exceptions import NoSuchElementException, TimeoutException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.support.ui import Select
+from selenium.webdriver.support import expected_conditions as econd
+from selenium.webdriver.support.wait import WebDriverWait
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.options import ArgOptions
+from bzt.resources.selenium_extras import get_locator, waiter
+from bzt.resources.bzm_extras import BzmExtras
+
+class TestPublishSc(unittest.TestCase):
+
+    def setUp(self):
+        self.vars = {}
+        
+        timeout = 30.0
+        options = webdriver.FirefoxOptions()
+        profile = webdriver.FirefoxProfile()
+        profile.set_preference('webdriver.log.file', '/somewhere/webdriver.log')
+        options.set_capability('unhandledPromptBehavior', 'ignore')
+        self.driver = webdriver.Firefox(profile, options=options)
+        self.driver.implicitly_wait(timeout)
+        apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows={}, scenario_name='publish_sc')
+        self.bzm_extras = BzmExtras({'master_publish_url': 'https://tdm.blazemeter.com/api/v1/publish', 'master_signature': 'kjflaksj3jk3jj3j12saf3'})
+    
+
+    def _1_None(self):
+        with apiritif.smart_transaction('None'):
+            
+            do_testdata_orchestration = self.bzm_extras.do_testdata_orchestration
+            
+            do_testdata_orchestration('publish', 'entity1', 'target1')
+            
+            do_testdata_orchestration = self.bzm_extras.do_testdata_orchestration
+            
+            do_testdata_orchestration('un-publish', 'entity1', 'target1')
+
+    def test_publishsc(self):
+        self._1_None()
+
+    def tearDown(self):
+        if self.driver:
+            self.driver.quit()

--- a/tests/unit/modules/_selenium/test_selenium_builder.py
+++ b/tests/unit/modules/_selenium/test_selenium_builder.py
@@ -3082,3 +3082,30 @@ class TestSelenium3Only(SeleniumTestCase):
         self.obj_prepare()
         exp_file = RESOURCES_DIR + "selenium/capabilities_options_for_remote_safari_s3.py"
         self.assertFilesEqual(exp_file, self.obj.script, python_files=True)
+
+    def test_testdata_publish(self):
+        self.configure({
+            "settings": {
+                "master_publish_url": "https://tdm.blazemeter.com/api/v1/publish",
+                "master_signature": "kjflaksj3jk3jj3j12saf3",
+            },
+            "execution": [{
+                "executor": "apiritif",
+                "scenario": "publish_sc"}],
+            "scenarios": {
+                "publish_sc": {
+                    "requests": [{
+                        "actions": [
+                            {
+                                "type": "rawCode",
+                                "param": "do_testdata_orchestration('publish', 'entity1', 'target1')",
+                            },
+                            {
+                                "type": "rawCode",
+                                "param": "do_testdata_orchestration('un-publish', 'entity1', 'target1')",
+                            }
+                        ]}]}}})
+        self.obj.prepare()
+        exp_file = RESOURCES_DIR + "selenium/generated_from_requests_td_publish.py"
+        str_to_replace = (self.obj.engine.artifacts_dir + os.path.sep).replace('\\', '\\\\')
+        self.assertFilesEqual(exp_file, self.obj.script, str_to_replace, "/somewhere/", python_files=True)


### PR DESCRIPTION
Introduced new method to be called for triggering blazedata publishing.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
