### PR TITLE
US47990 send disc space metric to happysocks

### DIFF
--- a/bzt/modules/blazemeter/engine_metrics.py
+++ b/bzt/modules/blazemeter/engine_metrics.py
@@ -41,7 +41,7 @@ class EngineMetricsBuffer:
 class HappysocksMetricsConverter:
     # mapped names similar to MonitoringBuffer.get_monitoring_json
     metrics_mapping = {'cpu': 'cpu', 'mem': 'mem', 'bytes-recv': 'network_io', 'engine-loop': 'busy_taurus',
-                       'conn-all': 'connections'}
+                       'conn-all': 'connections', 'disk-space': 'disk_space'}
 
     @staticmethod
     def to_metrics_batch(raw_metrics: List[dict], session_id, master_id=None, calibration_id=None,

--- a/tests/unit/modules/blazemeter/test_engine_metrics.py
+++ b/tests/unit/modules/blazemeter/test_engine_metrics.py
@@ -71,6 +71,7 @@ class TestHappysocksMetricsConverter(BZTestCase):
             {'source': 'local', 'ts': 1678892271.3985019, 'bytes-recv': 2485},
             {'source': 'local', 'ts': 1678892271.3985019, 'conn-all': 63},
             {'source': 'local', 'ts': 1678892271.3985019, 'engine-loop': 10},
+            {'source': 'local', 'ts': 1678892271.3985019, 'disk-space': 30.6},
         ], 'r-v4-64102f1ab8795890049369', 100, 200, 300)
         self.assertEqual(result, [
             {
@@ -89,6 +90,7 @@ class TestHappysocksMetricsConverter(BZTestCase):
                     'network_io': 2485,
                     'connections': 63,
                     'busy_taurus': 10,
+                    'disk_space': 30.6,
                 }
             },
         ])


### PR DESCRIPTION
- send disc space metric to happysocks for auto scaling
- fixed issue with reconnect after initial connection failure
  - socket.io client can handle reconnect itself in thread, but unfortunately only if the initial connect succeeded
  - otherwise we must reconnect ourselves, until connect succeeds