### PR TITLE
DE24850: Publish action in Scriptless test causes broken execution

### DIFF
--- a/bzt/modules/_apiritif/generator.py
+++ b/bzt/modules/_apiritif/generator.py
@@ -1647,14 +1647,16 @@ from selenium.webdriver.common.keys import Keys
             value=ast.Num(self._get_scenario_timeout(), kind="")))]
         body = data_sources + timeout_setup + target_init + handlers + store_block
 
-        if self.bzm_tdo_settings:
-            names = self.bzm_tdo_settings.keys()
-            values = self.bzm_tdo_settings.values()
-            bzm_args = ast.Dict(
-                keys=[self._gen_expr(name) for name in names],
-                values=[self._gen_expr(val) for val in values])
+        if self.do_testdata_orchestration:
+            bzm_extras_args = []
+            if self.bzm_tdo_settings:
+                names = self.bzm_tdo_settings.keys()
+                values = self.bzm_tdo_settings.values()
+                bzm_extras_args = ast.Dict(
+                    keys=[self._gen_expr(name) for name in names],
+                    values=[self._gen_expr(val) for val in values])
             body = body + [ast.Assign(targets=[ast_attr("self.bzm_extras")], value=ast_call(func=ast_attr("BzmExtras"),
-                                                                                            args=[bzm_args]))]
+                                                                                            args=[bzm_extras_args]))]
 
         if self.generate_external_handler:
             body = self._wrap_with_try_except(body)

--- a/bzt/resources/bzm_extras.py
+++ b/bzt/resources/bzm_extras.py
@@ -11,8 +11,9 @@ class BzmExtras(object):
         self.publish_map = {}
 
     def do_testdata_orchestration(self, operation, entity_name, target_name=""):
-        if self.settings.get('master_publish_url') is None:
-            raise TaurusException("Publish URL is not defined")
+        if self.settings is None or self.settings.get('master_publish_url') is None:
+            raise TaurusException("Can't perform Test Data Orchestration. API Publish URL was not provided to the "
+                                  "test!")
         if operation not in ["publish", "un-publish"]:
             raise TaurusException(f"Invalid operation for publishing, must be either 'publish' or 'un-publish', "
                                   f"received {operation}")


### PR DESCRIPTION
Display proper message when publish action is run when there is not master publish url param in the test.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
