### PR TITLE
DE24946: Taurus: LoopOverData: csv without headers issue

### DIFF
--- a/bzt/resources/selenium_extras.py
+++ b/bzt/resources/selenium_extras.py
@@ -554,5 +554,9 @@ def get_csv_reader_for_entity_loop(data_sources, entity_name):
     if not filename:
         raise TaurusException("Data entity name '{}' for 'loopOverData' not found in 'data-sources'!".format(entity_name))
 
+    # fieldnames can't be empty array otherwise the csv reader will not read the header
+    if isinstance(fieldnames, list) and len(fieldnames) == 0:
+        fieldnames = None
+
     return CSVReaderPerThread(filename=filename, fieldnames=fieldnames, loop=False, quoted=quoted, delimiter=delimiter,
                               encoding=encoding)


### PR DESCRIPTION
* when data source does not specify variable-names then the header is not read from CSV file

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
