### PR TITLE
US47924: Add link to BZM jmeter mirror

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1702,6 +1702,7 @@ class JarCleaner(object):
 class JMeterMirrorsManager(MirrorsManager):
     MIRRORS_SOURCE = "https://jmeter.apache.org/download_jmeter.cgi"
     DOWNLOAD_LINK = "https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-{version}.zip"
+    BZM_REGISTRY_LINK = "https://packages.blazemeter.com/jmeter/apache-jmeter-{version}.zip"
 
     def __init__(self, http_client, parent_logger, jmeter_version):
         self.jmeter_version = jmeter_version
@@ -1719,6 +1720,7 @@ class JMeterMirrorsManager(MirrorsManager):
                 link_tail = "/jmeter/binaries/apache-jmeter-{version}.zip".format(version=self.jmeter_version)
                 links = [link.strip('<option value="').strip('">') + link_tail for link in option_elements]
         links.append(self.DOWNLOAD_LINK.format(version=self.jmeter_version))
+        links.append(self.BZM_REGISTRY_LINK.format(version=self.jmeter_version))
         self.log.debug('Total mirrors: %d', len(links))
         # place HTTPS links first, preserving the order of HTTP links
         sorted_links = sorted(links, key=lambda l: l.startswith("https"), reverse=True)

--- a/site/dat/docs/changes/feat-add-bzm-jmeter-mirror-link.change
+++ b/site/dat/docs/changes/feat-add-bzm-jmeter-mirror-link.change
@@ -1,0 +1,1 @@
+Add blazemeter jmeter mirror link as fallback

--- a/tests/unit/modules/jmeter/test_JMeterExecutor.py
+++ b/tests/unit/modules/jmeter/test_JMeterExecutor.py
@@ -431,6 +431,25 @@ class TestJMeterExecutor(ExecutorTestCase):
         finally:
             os.environ["TAURUS_DISABLE_DOWNLOADS"] = ""
 
+    def test_blazemeter_mirror_tried(self):
+        path = os.path.abspath(BUILD_DIR + "jmeter-taurus/bin/jmeter" + EXE_SUFFIX)
+        self.obj.mock_install = False
+
+        shutil.rmtree(os.path.dirname(os.path.dirname(path)), ignore_errors=True)
+        self.assertFalse(os.path.exists(path))
+        try:
+            os.environ["TAURUS_DISABLE_DOWNLOADS"] = "true"
+            self.configure({"execution": [{"scenario": {"requests": ["http://localhost"]}}], })
+            self.obj.settings.merge({"path": path})
+
+            self.sniff_log(self.obj.log)
+            self.assertRaises(TaurusInternalException, self.obj.prepare)
+
+            msg = "Error while downloading https://packages.blazemeter.com/jmeter/apache-jmeter-"
+            self.assertIn(msg, self.log_recorder.err_buff.getvalue())
+        finally:
+            os.environ["TAURUS_DISABLE_DOWNLOADS"] = ""
+
     def test_timers(self):
         with open(os.path.join(RESOURCES_DIR, "yaml/timers.yml")) as config_file:
             config = yaml.full_load(config_file.read())


### PR DESCRIPTION
Added link to packages.blazemeter.com/jmeter/ mirror as fallback after apache archive one.
