### PR TITLE
US47924: Change link to BZM jmeter mirror

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1702,7 +1702,7 @@ class JarCleaner(object):
 class JMeterMirrorsManager(MirrorsManager):
     MIRRORS_SOURCE = "https://jmeter.apache.org/download_jmeter.cgi"
     DOWNLOAD_LINK = "https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-{version}.zip"
-    BZM_REGISTRY_LINK = "https://packages.blazemeter.com/jmeter/apache-jmeter-{version}.zip"
+    BZM_REGISTRY_LINK = "https://storage.googleapis.com/packages.blazemeter.com/jmeter/apache-jmeter-{version}.zip"
 
     def __init__(self, http_client, parent_logger, jmeter_version):
         self.jmeter_version = jmeter_version

--- a/tests/unit/modules/jmeter/test_JMeterExecutor.py
+++ b/tests/unit/modules/jmeter/test_JMeterExecutor.py
@@ -445,7 +445,7 @@ class TestJMeterExecutor(ExecutorTestCase):
             self.sniff_log(self.obj.log)
             self.assertRaises(TaurusInternalException, self.obj.prepare)
 
-            msg = "Error while downloading https://packages.blazemeter.com/jmeter/apache-jmeter-"
+            msg = "Error while downloading https://storage.googleapis.com/packages.blazemeter.com/jmeter/apache-jmeter-"
             self.assertIn(msg, self.log_recorder.err_buff.getvalue())
         finally:
             os.environ["TAURUS_DISABLE_DOWNLOADS"] = ""


### PR DESCRIPTION
Due certificate problems on direct use of packages.blazemeter.com/jmeter/, using new url https://storage.googleapis.com/packages.blazemeter.com/jmeter/
