### PR TITLE
DE24953: Do not treat 302 Found as error sample

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1333,7 +1333,7 @@ class JTLErrorsReader(object):
 
         a_msg, name = get_child_assertion(element)
 
-        if not rc.startswith("2"):  # this sample is failed
+        if not rc.startswith("2") and not rc.startswith("3"):  # this sample is failed
             e_msg = element.get("rm", default="")
             url = element.xpath(self.url_xpath)
             url = url[0].text if url else element.get("lb")

--- a/tests/resources/jmeter/jtl/error-302.jtl
+++ b/tests/resources/jmeter/jtl/error-302.jtl
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testResults version="1.2">
+<sample t="3490" lt="0" ts="1693221702610" s="false" lb="Transaction Controller 1" rc="200" rm="Number of samples in transaction : 12, number of failing samples : 1" tn="Thread Group-ThreadStarter 1-1" dt="" de="" by="1156" ng="2" na="2">
+  <sample t="103" lt="12" ts="1693221702611" s="true" lb="jp@gc - Dummy Sampler 1" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="114" ng="1" na="1">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <sample t="247" lt="9" ts="1693221702714" s="true" lb="jp@gc - Dummy Sampler 2" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="114" ng="1" na="1">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <sample t="338" lt="31" ts="1693221702961" s="true" lb="jp@gc - Dummy Sampler 3" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="114" ng="1" na="1">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <sample t="148" lt="4" ts="1693221703299" s="true" lb="jp@gc - Dummy Sampler 4" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="114" ng="1" na="1">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <sample t="340" lt="49" ts="1693221703448" s="true" lb="jp@gc - Dummy Sampler 5" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="114" ng="1" na="1">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <sample t="220" lt="43" ts="1693221703788" s="true" lb="jp@gc - Dummy Sampler 6" rc="302" rm="Found" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="9" ng="1" na="1">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <sample t="421" lt="47" ts="1693221704009" s="true" lb="jp@gc - Dummy Sampler 7" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="114" ng="1" na="1">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <sample t="481" lt="47" ts="1693221704430" s="true" lb="jp@gc - Dummy Sampler 8" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="114" ng="1" na="1">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <sample t="158" lt="32" ts="1693221704912" s="true" lb="jp@gc - Dummy Sampler 9" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="114" ng="1" na="1">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <sample t="481" lt="40" ts="1693221705070" s="false" lb="jp@gc - Dummy Sampler 10" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="7" ng="1" na="1">
+    <assertionResult>
+      <name>Response Assertion</name>
+      <failure>true</failure>
+      <error>false</error>
+      <failureMessage>Test failed: text expected to contain /Dummy Sampler/</failureMessage>
+    </assertionResult>
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+    <responseData class="java.lang.String">Testing</responseData>
+    <samplerData class="java.lang.String">Dummy Sampler used to simulate requests and responses
+without actual network activity. This helps debugging tests.</samplerData>
+  </sample>
+  <sample t="304" lt="45" ts="1693221705562" s="true" lb="jp@gc - Dummy Sampler 11" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="114" ng="2" na="2">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <sample t="249" lt="46" ts="1693221705866" s="true" lb="jp@gc - Dummy Sampler 12" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="114" ng="2" na="2">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <responseHeader class="java.lang.String"></responseHeader>
+  <requestHeader class="java.lang.String"></requestHeader>
+  <responseData class="java.lang.String">Non-TEXT response data, cannot record: ()</responseData>
+</sample>
+<sample t="3053" lt="0" ts="1693221709647" s="false" lb="Transaction Controller 3" rc="200" rm="Number of samples in transaction : 12, number of failing samples : 1" tn="Thread Group-ThreadStarter 1-1" dt="" de="" by="1165" ng="4" na="4">
+  <sample t="183" lt="5" ts="1693221709647" s="true" lb="jp@gc - Dummy Sampler 1-2" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="114" ng="3" na="3">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <sample t="385" lt="35" ts="1693221709830" s="true" lb="jp@gc - Dummy Sampler 2-2" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="114" ng="3" na="3">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <sample t="347" lt="29" ts="1693221710215" s="true" lb="jp@gc - Dummy Sampler 3-2" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="114" ng="3" na="3">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <sample t="153" lt="1" ts="1693221710562" s="true" lb="jp@gc - Dummy Sampler 4-2" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="114" ng="3" na="3">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <sample t="76" lt="2" ts="1693221710715" s="true" lb="jp@gc - Dummy Sampler 5-2" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="114" ng="3" na="3">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <sample t="189" lt="20" ts="1693221710791" s="true" lb="jp@gc - Dummy Sampler 6-2" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="9" ng="3" na="3">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <sample t="190" lt="7" ts="1693221710980" s="true" lb="jp@gc - Dummy Sampler 7-2" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="114" ng="3" na="3">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <sample t="54" lt="18" ts="1693221711171" s="true" lb="jp@gc - Dummy Sampler 8-2" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="114" ng="3" na="3">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <sample t="206" lt="47" ts="1693221711225" s="true" lb="jp@gc - Dummy Sampler 9-2" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="114" ng="3" na="3">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <sample t="436" lt="35" ts="1693221711432" s="false" lb="jp@gc - Dummy Sampler 10-2" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="16" ng="4" na="4">
+    <assertionResult>
+      <name>Response Assertion</name>
+      <failure>true</failure>
+      <error>false</error>
+      <failureMessage>Test failed: text expected to contain /Dummy Sampler/</failureMessage>
+    </assertionResult>
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+    <responseData class="java.lang.String">This should fail</responseData>
+    <samplerData class="java.lang.String">Dummy Sampler used to simulate requests and responses
+without actual network activity. This helps debugging tests.</samplerData>
+  </sample>
+  <sample t="457" lt="22" ts="1693221711868" s="true" lb="jp@gc - Dummy Sampler 11-2" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="114" ng="4" na="4">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <sample t="377" lt="13" ts="1693221712325" s="true" lb="jp@gc - Dummy Sampler 12-2" rc="200" rm="OK" tn="Thread Group-ThreadStarter 1-1" dt="text" de="" by="114" ng="4" na="4">
+    <responseHeader class="java.lang.String"></responseHeader>
+    <requestHeader class="java.lang.String"></requestHeader>
+  </sample>
+  <responseHeader class="java.lang.String"></responseHeader>
+  <requestHeader class="java.lang.String"></requestHeader>
+  <responseData class="java.lang.String">Non-TEXT response data, cannot record: ()</responseData>
+</sample>
+
+</testResults>

--- a/tests/unit/modules/jmeter/test_JTLReader.py
+++ b/tests/unit/modules/jmeter/test_JTLReader.py
@@ -207,19 +207,18 @@ class TestJTLErrorsReader(BZTestCase):
         self.configure(RESOURCES_DIR + "/jmeter/jtl/resource_tc.jtl")
         self.obj.read_file()
         values = self.obj.get_data(sys.maxsize)
-        self.assertEqual(4, len(values.get("")))
+        self.assertEqual(3, len(values.get("")))
         self.assertEqual(values.get('')[0].get("msg"), "message")
-        self.assertEqual(values.get('')[1].get("msg"), "FOUND")
+        self.assertEqual(values.get('')[1].get("msg"), "NOT FOUND")
+        self.assertEqual(values.get('')[1].get("cnt"), 3)
         self.assertEqual(values.get('')[2].get("msg"), "second message")
-        self.assertEqual(values.get('')[3].get("msg"), "NOT FOUND")
-        self.assertEqual(values.get('')[3].get("cnt"), 2)
 
-        self.assertEqual(values.get('tc1')[0].get("msg"), "FOUND")
+        self.assertEqual(values.get('tc1')[0].get("msg"), "NOT FOUND")
         self.assertEqual(values.get("tc1")[0].get("type"), KPISet.ERRTYPE_SUBSAMPLE)
         self.assertEqual(values.get('tc3')[0].get("msg"), "message")
         self.assertEqual(values.get("tc3")[0].get("type"), KPISet.ERRTYPE_ERROR)
-        self.assertEqual(values.get("tc3")[1].get("type"), KPISet.ERRTYPE_ERROR)
         self.assertEqual(values.get('tc3')[1].get("msg"), "second message")
+        self.assertEqual(values.get("tc3")[1].get("type"), KPISet.ERRTYPE_ERROR)
         self.assertEqual(values.get('tc4')[0].get("msg"), "NOT FOUND")
         self.assertEqual(values.get("tc4")[0].get("type"), KPISet.ERRTYPE_SUBSAMPLE)
         self.assertEqual(values.get('tc5')[0].get("msg"), "NOT FOUND")
@@ -262,6 +261,28 @@ class TestJTLErrorsReader(BZTestCase):
     def test_macos_unicode_parsing_is_not_supported(self):
         self.configure(RESOURCES_DIR + "/jmeter/jtl/standard-errors.jtl")
         self.obj.read_file(final_pass=True)  # shouldn't fail with "ParserError: Unicode parsing is not supported"
+
+    def test_302(self):
+        self.configure(RESOURCES_DIR + "/jmeter/jtl/error-302.jtl")
+        self.obj.read_file(final_pass=True)
+        values = self.obj.get_data(sys.maxsize)
+
+        assert_msg = "Test failed: text expected to contain /Dummy Sampler/"
+
+        self.assertEqual(1, len(values.get("")))
+        self.assertEqual(values.get('')[0].get("msg"), assert_msg)
+        self.assertEqual(values.get('')[0].get("type"), KPISet.ERRTYPE_ASSERT)
+        self.assertEqual(values.get('')[0].get("cnt"), 2)
+
+        self.assertEqual(1, len(values.get("Transaction Controller 1")))
+        self.assertEqual(values.get("Transaction Controller 1")[0].get("msg"), assert_msg)
+        self.assertEqual(values.get("Transaction Controller 1")[0].get("type"), KPISet.ERRTYPE_ASSERT)
+        self.assertEqual(values.get("Transaction Controller 1")[0].get("cnt"), 1)
+
+        self.assertEqual(1, len(values.get("Transaction Controller 3")))
+        self.assertEqual(values.get("Transaction Controller 3")[0].get("msg"), assert_msg)
+        self.assertEqual(values.get("Transaction Controller 3")[0].get("type"), KPISet.ERRTYPE_ASSERT)
+        self.assertEqual(values.get("Transaction Controller 3")[0].get("cnt"), 1)
 
 
 class TestJTLReader(BZTestCase):


### PR DESCRIPTION
JMeter mark as failed return codes >= 400 by default. Marking 302 as error can hide real failing sample (e.g. with assertion error)

I added unit test with jtl from defect (test_302) but I needed to change existing unit test (test_resource_tc) which expected 302 to be marked as error.

I tried to search for reasoning to mark 3xx as errors in `JTLErrorsReader` and the test, but was not able to found any.
