### PR TITLE
Updating Version of Jmeter to 5.6.2

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1580,25 +1580,9 @@ class JMeter(RequiredTool):
         # these jars should be replaced with newer version in order to fix some vulnerabilities
         # component name and download link in https://repo1.maven.org/maven2/
         affected_components = {
-            # Needs to be <1.4.18 for old Jmeters https://stackoverflow.com/questions/30812293/com-thoughtworks-xstream-security-forbiddenclassexception
-            "xstream": "com/thoughtworks/xstream/xstream/1.4.20/xstream-1.4.20.jar",
-            "jackson-annotations": "com/fasterxml/jackson/core/jackson-annotations/2.15.0/jackson-annotations-2.15.0.jar",
-            "jackson-core": "com/fasterxml/jackson/core/jackson-core/2.15.0/jackson-core-2.15.0.jar",
-            "jackson-databind": "com/fasterxml/jackson/core/jackson-databind/2.15.0/jackson-databind-2.15.0.jar",
-            "json-smart": "net/minidev/json-smart/2.4.8/json-smart-2.4.8.jar",
-            "jsoup": "org/jsoup/jsoup/1.15.3/jsoup-1.15.3.jar",
             "snakeyaml": "org/yaml/snakeyaml/2.0/snakeyaml-2.0.jar",
-            "okhttp": "com/squareup/okhttp3/okhttp/4.10.0/okhttp-4.10.0.jar",
-            "commons-text": "org/apache/commons/commons-text/1.10.0/commons-text-1.10.0.jar",
-            "xmlgraphics-commons": "org/apache/xmlgraphics/xmlgraphics-commons/2.8/xmlgraphics-commons-2.8.jar"}
-
-        if LooseVersion(self.version) <= LooseVersion('5.6.2'):  # log4j must be fixed till jmeter 5.4.3
-            affected_names = ["log4j-core", "log4j-api", "log4j-slf4j-impl", "log4j-1.2-api"]
-            fixed_version = '2.19.0'
-            maven_link = "org/apache/logging/log4j/{name}/{ver}/{name}-{ver}.jar"
-
-            for name in affected_names:
-                affected_components[name] = maven_link.format(name=name, ver=fixed_version)
+            "batik-bridge": "org/apache/xmlgraphics/batik-bridge/1.17/batik-bridge-1.17.jar",
+            }
 
         jar_files = [_file for _file in os.listdir(lib_dir) if _file.endswith(".jar")]
         for jar_file in jar_files:
@@ -1628,6 +1612,7 @@ class JMeter(RequiredTool):
         self.__install_plugins_manager(pm_installer_path)
         self.__install_plugins()
         # Apply JAR vulnerability fixes
+        self.__download_additions(self._get_jar_fixes(lib_dir))
         
         cleaner = JarCleaner(self.log)
         cleaner.clean(lib_dir)

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1398,8 +1398,8 @@ class JMeter(RequiredTool):
     PLUGINS_MANAGER_LINK = 'https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-manager/{version}/jmeter-plugins-manager-{version}.jar'
     COMMAND_RUNNER_VERSION = "2.2"
     COMMAND_RUNNER_LINK = 'https://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/{version}/cmdrunner-{version}.jar'
-    VERSION = "5.4.3"
-    VERSION_LATEST = "5.5"
+    VERSION = "5.6.2"
+    VERSION_LATEST = "5.6.2"
 
     def __init__(self, config=None, props=None, **kwargs):
         settings = config or BetterDict()
@@ -1592,7 +1592,7 @@ class JMeter(RequiredTool):
             "commons-text": "org/apache/commons/commons-text/1.10.0/commons-text-1.10.0.jar",
             "xmlgraphics-commons": "org/apache/xmlgraphics/xmlgraphics-commons/2.8/xmlgraphics-commons-2.8.jar"}
 
-        if LooseVersion(self.version) <= LooseVersion('5.4.3'):  # log4j must be fixed till jmeter 5.4.3
+        if LooseVersion(self.version) <= LooseVersion('5.6.2'):  # log4j must be fixed till jmeter 5.4.3
             affected_names = ["log4j-core", "log4j-api", "log4j-slf4j-impl", "log4j-1.2-api"]
             fixed_version = '2.19.0'
             maven_link = "org/apache/logging/log4j/{name}/{ver}/{name}-{ver}.jar"
@@ -1644,8 +1644,8 @@ class JMeter(RequiredTool):
         self.__install_plugins_manager(pm_installer_path)
         self.__install_plugins()
         # Apply JAR vulnerability fixes
-        self.__download_additions(self._get_jar_fixes(lib_dir))
-        self._fix_jquery_in_jmeter(jmeter_dir)
+        # self.__download_additions(self._get_jar_fixes(lib_dir))
+        # self._fix_jquery_in_jmeter(jmeter_dir)
 
         cleaner = JarCleaner(self.log)
         cleaner.clean(lib_dir)

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1611,22 +1611,6 @@ class JMeter(RequiredTool):
 
         return direct_install_tools
 
-    def _fix_jquery_in_jmeter(self, jmeter_dir):
-        if not self.fix_jars or LooseVersion(self.version) < LooseVersion('5.0.0'):
-            return
-
-        # Fix CVE-2016-10707 in jquery
-        jquery_src_dir = os.path.join(jmeter_dir, "jquery-dist-3.6.1")
-        jquery_target_dir = os.path.join(jmeter_dir,
-            "bin/report-template/sbadmin2-1.0.7/bower_components/jquery/")
-        jquery_tar = os.path.join(jmeter_dir, "jquery-dist-3.6.1.tar.gz")
-        self.__download_additions([["https://github.com/jquery/jquery-dist/archive/3.6.1.tar.gz",
-                                    jquery_tar]])
-        shutil.unpack_archive(jquery_tar, jmeter_dir)
-        shutil.rmtree(jquery_target_dir, ignore_errors=True)
-        shutil.move(jquery_src_dir, jquery_target_dir)
-        os.remove(jquery_tar)
-
     def install(self):
         jmeter_dir = get_full_path(self.tool_path, step_up=2)
         lib_dir = os.path.join(jmeter_dir, 'lib')
@@ -1644,9 +1628,7 @@ class JMeter(RequiredTool):
         self.__install_plugins_manager(pm_installer_path)
         self.__install_plugins()
         # Apply JAR vulnerability fixes
-        # self.__download_additions(self._get_jar_fixes(lib_dir))
-        # self._fix_jquery_in_jmeter(jmeter_dir)
-
+        
         cleaner = JarCleaner(self.log)
         cleaner.clean(lib_dir)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ molotov!=2.3
 influxdb >= 5.3
 python-socketio>=5.8.0
 websocket-client>=1.5.1
-urllib3==1.26.16
+urllib3>=2.0.6

--- a/site/dat/docs/changes/fix-update-jmeter-version-and-jars.change
+++ b/site/dat/docs/changes/fix-update-jmeter-version-and-jars.change
@@ -1,0 +1,1 @@
+Upgrading Jmeter Version to 5.6.2 and making sure Some Associated Jar Files are up to date

--- a/tests/unit/modules/jmeter/test_JMeterTool.py
+++ b/tests/unit/modules/jmeter/test_JMeterTool.py
@@ -15,8 +15,8 @@ class TestJMeterTool(BZTestCase):
     def test_get_jar_fixes(self):
         lib_dir_path = get_full_path(__file__, step_up=1)
         lib_dir_content = [
-            "xstream-1.4.15.jar",   # lib with some vulnerability, must be replaced
-            "log4j-core-2.16.jar",  # only old jmeter versions contains affected log4j components
+            "snakeyaml-2.0.jar",   # lib with some vulnerability, must be replaced
+            "batik-bridge-1.17.jar",  # only old jmeter versions contains affected log4j components
             "some-other-lib-0.99.jar"]  # other jar, mustn't be touched
         listdir = lambda _: lib_dir_content
         self.obj.version = '5.0.0'
@@ -27,11 +27,11 @@ class TestJMeterTool(BZTestCase):
             jar_tools = self.obj._get_jar_fixes(lib_dir_path)
             target_tools_list = [
                 [
-                    'https://repo1.maven.org/maven2/com/thoughtworks/xstream/xstream/1.4.20/xstream-1.4.20.jar',
-                    os.path.join(lib_dir_path, 'xstream-1.4.20.jar')],
+                    'https://repo1.maven.org/maven2/org/yaml/snakeyaml/2.0/snakeyaml-2.0.jar',
+                    os.path.join(lib_dir_path, 'snakeyaml-2.0.jar')],
                 [
-                    'https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.19.0/log4j-core-2.19.0.jar',
-                    os.path.join(lib_dir_path, 'log4j-core-2.19.0.jar')]]
+                    'https://repo1.maven.org/maven2/org/apache/xmlgraphics/batik-bridge/1.17/batik-bridge-1.17.jar',
+                    os.path.join(lib_dir_path, 'batik-bridge-1.17.jar')]]
             self.assertEqual(target_tools_list, jar_tools)
         finally:
             os.listdir = saved_listdir


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Updating JMETER Version to 5.6.2.

Quick checklist:
- [X] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [x] Documentation update ('available in the unstable snapshot' warning if necessary)
- [x] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
