### PR TITLE
Patch 4

### DIFF
--- a/site/dat/docs/ExecutionSettings.md
+++ b/site/dat/docs/ExecutionSettings.md
@@ -64,7 +64,7 @@ Available settings are:
 
  - `concurrency` - number of target concurrent virtual users
  - `ramp-up` - ramp-up time to reach target concurrency
- - `hold-for` - time to hold target concurrency
+ - `hold-for` - time to hold target concurrency. Define this value explicitly for long-running tests to have them terminate gracefully.
  - `iterations` - limit scenario iterations number
  - `throughput` - apply RPS shaper, limiting maximum RPS to throughput, requires `ramp-up` and/or `hold-for`
  - `steps` - allows users to apply stepping ramp-up for concurrency and rps, requires `ramp-up`

--- a/site/dat/docs/Locust.md
+++ b/site/dat/docs/Locust.md
@@ -1,9 +1,9 @@
 # Locust.io Executor
-[Locust.io](http://locust.io/) is Python-based load generating tool where you have full freedom of programming test scenario in Python language. It uses resource-efficient coroutine approach.
+[Locust.io](http://locust.io/) is a Python-based load generating tool where you have full freedom of programming test scenarios in the Python language. It uses a resource-efficient coroutine approach. The Locust package is not installed automatically by Taurus, please install it manually using `pip install locust`.
 
-Locust package is not installed automatically by Taurus, please install it manually: `pip install locust`
+Note that for Locust, the `iterations` option means the quantity of requests, not the number of cycles of the scenario (as the last can contain more than one request). The following load profile settings have no effect for this executor: `throughput` and `steps` 
 
-Make note that for Locust `iterations` option means quantity of requests, not cycles of scenario (as the last can contains more than one request). Following load profile settings has no effect for this executor: `throughput` and `steps` 
+Tip: Define the `hold-for` value explicitly to allow long-running tests to terminate gracefully. 
 
 Taurus appends `PYTHONPATH` with path to artifacts directory and current working directory. Make sure you have no module name clashes (for example, don't name your locustfile as `locust.py`).
 
@@ -14,6 +14,7 @@ execution:
 - executor: locust
   concurrency: 10
   ramp-up: 1m
+  hold-for: 2m
   iterations: 1000
   scenario: example
 

--- a/site/dat/docs/changes/doc-locust-hold-for.change
+++ b/site/dat/docs/changes/doc-locust-hold-for.change
@@ -1,0 +1,1 @@
+Added the hold-for option to the Locust example and mentioned it's needed for long running tasks


### PR DESCRIPTION
Added the hold-for option to the Locust example in the doc and mentioned that it's needed for long running tasks, because the default value makes them time out in blazemeter. Some minor copy-editing.
No code change, just doc.
