### PR TITLE
BZTR-1191 urllib3=1.26.17

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ molotov!=2.3
 influxdb >= 5.3
 python-socketio>=5.8.0
 websocket-client>=1.5.1
-urllib3==1.26.16
+urllib3==1.26.17


### PR DESCRIPTION
promote urllib3=1.26.17 to fix torero CVE-2023-43804