### PR TITLE
BZJU-587 fix chrome urls

### DIFF
--- a/bzt/modules/_selenium.py
+++ b/bzt/modules/_selenium.py
@@ -304,7 +304,7 @@ class WebDriver(RequiredTool):
 
 class ChromeDriver(WebDriver):
     VERSION = "116.0.5845.96"
-    DOWNLOAD_LINK = "https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/" \
+    DOWNLOAD_LINK = "https://storage.googleapis.com/chrome-for-testing-public/" \
                     "{version}/{arch}/chromedriver-{arch}.zip"
     HIGHEST_OLD_VERSION = "114.0.5735.90"
     OLD_DOWNLOAD_LINK = "https://chromedriver.storage.googleapis.com/{version}/chromedriver_{arch}.zip"

--- a/tests/unit/modules/_selenium/test_selenium_executor.py
+++ b/tests/unit/modules/_selenium/test_selenium_executor.py
@@ -438,7 +438,7 @@ class TestReportReader(BZTestCase):
         arch, ext = chrome_driver._get_arch_and_ext_for_chromedriver()
         chrome_driver._expand_download_link()
         self.assertEqual(
-            'https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing'
+            'https://storage.googleapis.com/chrome-for-testing-public'
             '/116.0.5845.96/' + arch + '/chromedriver-' + arch + '.zip',
             chrome_driver.download_link)
         settings = {"version": "110.0.5481.77"}


### PR DESCRIPTION
Links from https://googlechromelabs.github.io/chrome-for-testing/#stable

[2024-03-07T11:24:09.429Z] 11:24:09 INFO: Latest stable version of chromedriver is 122.0.6261.94
[2024-03-07T11:24:09.429Z] 11:24:09 INFO: Used version of chromedriver is 122.0.6261.94
[2024-03-07T11:24:09.429Z] 11:24:09 INFO: Latest stable version of geckodriver is 0.34.0
[2024-03-07T11:24:09.429Z] 11:24:09 INFO: Used version of geckodriver is 0.34.0
[2024-03-07T11:24:09.429Z] 11:24:09 INFO: Installing ChromeDriver 122.0.6261.94...
[2024-03-07T11:24:09.429Z] 11:24:09 INFO: Downloading: https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/122.0.6261.94/linux64/chromedriver-linux64.zip
[2024-03-07T11:24:09.786Z] 11:24:09 ERROR: Error while downloading https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/122.0.6261.94/linux64/chromedriver-linux64.zip: Unsuccessful download from https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/122.0.6261.94/linux64/chromedriver-linux64.zip
[2024-03-07T11:24:09.786Z] 11:24:09 WARNING: ChromeDriver download failed: No more links to try

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
