### PR TITLE
BZJU-575 Temp Revert "Update latest version to latest jmeter version (#1810)"

### DIFF
--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1485,7 +1485,7 @@ class JMeter(RequiredTool):
     COMMAND_RUNNER_VERSION = "2.2"
     COMMAND_RUNNER_LINK = 'https://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/{version}/cmdrunner-{version}.jar'
     VERSION = "5.5"
-    VERSION_LATEST = "5.6.3"
+    VERSION_LATEST = "5.6.2"
 
     def __init__(self, config=None, props=None, **kwargs):
         settings = config or BetterDict()


### PR DESCRIPTION
This reverts commit 672ebe10d77baba3b2611087136d4fc0ef1cf4e1.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
