### PR TITLE
TG-2299 Loop Over Data scriptless action with Default Entity

### DIFF
--- a/bzt/modules/_apiritif/generator.py
+++ b/bzt/modules/_apiritif/generator.py
@@ -964,7 +964,8 @@ from selenium.webdriver.common.keys import Keys
             data_sources.append(ast.Dict(keys, values))
 
         entity = action_config.get("loopOverData").replace(".", "_").replace("/", "_").replace("\\", "_")\
-            .replace(":", "_")
+            .replace(":", "_").replace("-", "_")
+
 
         csv_reader = '{}_csv_reader'.format(entity)
         elements = [ast.Assign(targets=[ast.Name(id=csv_reader, ctx=ast.Store())],


### PR DESCRIPTION
[TG-2299](https://perforce.atlassian.net/browse/TG-2299)

Loop Over Data scriptless action not working over default data entity

Name of the csv in data-sources coming from Scriptless not matches the entity name in the loopOverData action.

Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
