### PR TITLE
SPAR-2680: Properly handle when duration or steps are none

### DIFF
--- a/bzt/modules/pyscripts/jmxrampup.py
+++ b/bzt/modules/pyscripts/jmxrampup.py
@@ -179,9 +179,8 @@ class JmeterRampupProcess(object):
         users_pers_step = (users - cur_users)/steps
 
         prev_concurrency = cur_users
-        users_list.append((cur_users, float(cur_time)))
-        for i in range(steps + 1):
-            concurrency = cur_users + (floor(users_pers_step*(i) + 0.5))
+        for i in range(steps):
+            concurrency = cur_users + (floor(users_pers_step*(i+1) + 0.5))
             if concurrency != prev_concurrency:
                 users_list.append((concurrency, cur_time + step_time*i))
                 prev_concurrency = concurrency

--- a/tests/unit/modules/pyscripts/test_jmxrampup.py
+++ b/tests/unit/modules/pyscripts/test_jmxrampup.py
@@ -40,14 +40,11 @@ class TestJmeterRampupProcess(BZTestCase):
                             rampup.run()
 
                             self.assertIn('Got new rampup configuration', self.log_recorder.info_buff.getvalue())
-                            self.assertIn('Rampup plan: deque([(1, 100000.0), (3, 100300.0), (5, 100600.0)])', self.log_recorder.info_buff.getvalue())
-                            self.assertIn('Setting concurrency: (1, 100000.0)', self.log_recorder.info_buff.getvalue())
-                            self.assertIn('Setting concurrency: (3, 100300.0)', self.log_recorder.info_buff.getvalue())
-                            self.assertIn('Setting concurrency: (5, 100600.0)', self.log_recorder.info_buff.getvalue())
+                            self.assertIn('Rampup plan: deque([(3, 100000.0), (5, 100300.0)])', self.log_recorder.info_buff.getvalue())
+                            self.assertIn('Setting concurrency: (3, 100000.0)', self.log_recorder.info_buff.getvalue())
+                            self.assertIn('Setting concurrency: (5, 100300.0)', self.log_recorder.info_buff.getvalue())
                             mock_socket.socket().connect.assert_called_with(('localhost', 9001))
                             mock_socket.socket().sendall.assert_has_calls([
-                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
-                                          b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","1");'),
                                 mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
                                      b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","3");'),
                                 mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
@@ -129,14 +126,11 @@ class TestJmeterRampupProcess(BZTestCase):
                             rampup.run()
 
                             self.assertIn('Got new rampup configuration', self.log_recorder.info_buff.getvalue())
-                            self.assertIn('Rampup plan: deque([(1, 100000.0), (5, 100000.0)])', self.log_recorder.info_buff.getvalue())
+                            self.assertIn('Rampup plan: deque([(5, 100000.0)])', self.log_recorder.info_buff.getvalue())
 
-                            self.assertIn('Setting concurrency: (1, 100000.0)', self.log_recorder.info_buff.getvalue())
                             self.assertIn('Setting concurrency: (5, 100000.0)', self.log_recorder.info_buff.getvalue())
                             mock_socket.socket().connect.assert_called_with(('localhost', 9001))
                             mock_socket.socket().sendall.assert_has_calls([
-                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
-                                          b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","1");'),
                                 mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
                                           b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","5");')
                             ])
@@ -167,16 +161,13 @@ class TestJmeterRampupProcess(BZTestCase):
                             rampup.run()
 
                             self.assertIn('Got new rampup configuration', self.log_recorder.info_buff.getvalue())
-                            self.assertIn('Rampup plan: deque([(1, 100000.0), (2, 100150.0), (3, 100300.0), (4, 100450.0), (5, 100600.0)])', self.log_recorder.info_buff.getvalue())
-                            self.assertIn('Setting concurrency: (1, 100000.0)', self.log_recorder.info_buff.getvalue())
-                            self.assertIn('Setting concurrency: (2, 100150.0)', self.log_recorder.info_buff.getvalue())
-                            self.assertIn('Setting concurrency: (3, 100300.0)', self.log_recorder.info_buff.getvalue())
-                            self.assertIn('Setting concurrency: (4, 100450.0)', self.log_recorder.info_buff.getvalue())
-                            self.assertIn('Setting concurrency: (5, 100600.0)', self.log_recorder.info_buff.getvalue())
+                            self.assertIn('Rampup plan: deque([(2, 100000.0), (3, 100150.0), (4, 100300.0), (5, 100450.0)])', self.log_recorder.info_buff.getvalue())
+                            self.assertIn('Setting concurrency: (2, 100000.0)', self.log_recorder.info_buff.getvalue())
+                            self.assertIn('Setting concurrency: (3, 100150.0)', self.log_recorder.info_buff.getvalue())
+                            self.assertIn('Setting concurrency: (4, 100300.0)', self.log_recorder.info_buff.getvalue())
+                            self.assertIn('Setting concurrency: (5, 100450.0)', self.log_recorder.info_buff.getvalue())
                             mock_socket.socket().connect.assert_called_with(('localhost', 9001))
                             mock_socket.socket().sendall.assert_has_calls([
-                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
-                                          b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","1");'),
                                 mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
                                           b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","2");'),
                                 mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
@@ -236,14 +227,11 @@ class TestJmeterRampupProcess(BZTestCase):
                             rampup.run()
 
                             self.assertIn('Got new rampup configuration', self.log_recorder.info_buff.getvalue())
-                            self.assertIn('Rampup plan: deque([(1, 100000.0), (3, 100300.0), (5, 100600.0)])', self.log_recorder.info_buff.getvalue())
-                            self.assertIn('Setting concurrency: (1, 100000.0)', self.log_recorder.info_buff.getvalue())
-                            self.assertIn('Setting concurrency: (3, 100300.0)', self.log_recorder.info_buff.getvalue())
-                            self.assertIn('Setting concurrency: (5, 100600.0)', self.log_recorder.info_buff.getvalue())
+                            self.assertIn('Rampup plan: deque([(3, 100000.0), (5, 100300.0)])', self.log_recorder.info_buff.getvalue())
+                            self.assertIn('Setting concurrency: (3, 100000.0)', self.log_recorder.info_buff.getvalue())
+                            self.assertIn('Setting concurrency: (5, 100300.0)', self.log_recorder.info_buff.getvalue())
                             mock_socket.socket().connect.assert_called_with(('localhost', 9001))
                             mock_socket.socket().sendall.assert_has_calls([
-                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
-                                          b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","1");'),
                                 mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
                                           b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","3");'),
                                 mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
