### PR TITLE
BZJU-643. Avoid 0.001 in rps value in order to reduce timeouts

### DIFF
--- a/bzt/jmx/tools.py
+++ b/bzt/jmx/tools.py
@@ -201,8 +201,8 @@ class LoadSettingsProcessor(object):
         if self.load.ramp_up:
             if isinstance(self.load.throughput, numeric_types) and self.load.duration:
                 start_rps = self.load.throughput / float(self.load.duration)
-                start_rps = max(start_rps, 0.001)  # avoid zeroing
-                start_rps = min(start_rps, 1.0)  # avoid starting too fast
+                if start_rps < 1.0:
+                    start_rps = 1.0  # avoid zeroing
             else:
                 start_rps = 1
 


### PR DESCRIPTION
https://perforce.atlassian.net/browse/BZJU-643

In this task we found that timeout was caused by rps mechanism. In case of 0 steps jmeter plugin tries to divide the process by 2 steps and first is starting from 0.001 rps. It caused delays. The PR fixes the problem