### PR TITLE
Doc: Removed Newman executor from doc index

### DIFF
--- a/site/dat/docs/Index.md
+++ b/site/dat/docs/Index.md
@@ -19,7 +19,6 @@
     1. [Mocha Executor](Mocha.md)
     1. [Molotov Executor](Molotov.md)
     1. [NUnit Executor](NUnit.md)
-    1. [Postman/Newman Executor](Postman.md)
     1. [PyTest Executor](PyTest.md)
     1. [Robot Executor](Robot.md)
     1. [RSpec Executor](RSpec.md)

--- a/site/dat/docs/changes/doc-newman-executor.change
+++ b/site/dat/docs/changes/doc-newman-executor.change
@@ -1,0 +1,1 @@
+Removed Newman executor from doc index


### PR DESCRIPTION
Doc update: Removed Newman executor link from doc index page. No code change.