### PR TITLE
SPAR-2754: Validate should not be called when just launching existing test

### DIFF
--- a/bzt/modules/blazemeter/cloud_provisioning.py
+++ b/bzt/modules/blazemeter/cloud_provisioning.py
@@ -279,7 +279,9 @@ class CloudProvisioning(MasterProvisioning):
             self.router.resolve_test(config_for_cloud, files_for_cloud, del_files)
 
         self.router.sanitize_test()
-        self._validate_taurus_yml()
+
+        if not self.launch_existing_test:
+            self._validate_taurus_yml()
 
         self.report_name = self.settings.get("report-name", self.report_name)
         if self.report_name == 'ask' and sys.stdin.isatty():

--- a/tests/unit/modules/test_cloudProvisioning.py
+++ b/tests/unit/modules/test_cloudProvisioning.py
@@ -1200,9 +1200,9 @@ class TestCloudProvisioning(BZTestCase):
         self.obj.settings["launch-existing-test"] = True
 
         self.obj.prepare()
-        self.assertEqual(13, len(self.mock.requests))
+        self.assertEqual(11, len(self.mock.requests))
         self.obj.startup()
-        self.assertEqual(14, len(self.mock.requests))
+        self.assertEqual(12, len(self.mock.requests))
 
     def test_launch_existing_test_by_id(self):
         self.configure(
@@ -1217,9 +1217,9 @@ class TestCloudProvisioning(BZTestCase):
         self.obj.settings["launch-existing-test"] = True
 
         self.obj.prepare()
-        self.assertEqual(13, len(self.mock.requests))
+        self.assertEqual(11, len(self.mock.requests))
         self.obj.startup()
-        self.assertEqual(14, len(self.mock.requests))
+        self.assertEqual(12, len(self.mock.requests))
 
     def test_launch_existing_test_not_found_by_id(self):
         self.configure(
@@ -1257,9 +1257,9 @@ class TestCloudProvisioning(BZTestCase):
         self.obj.settings["test"] = "foo"
 
         self.obj.prepare()
-        self.assertEqual(13, len(self.mock.requests))
+        self.assertEqual(11, len(self.mock.requests))
         self.obj.startup()
-        self.assertEqual(14, len(self.mock.requests))
+        self.assertEqual(12, len(self.mock.requests))
 
     def test_launch_test_by_link(self):
         self.configure(
@@ -1296,9 +1296,9 @@ class TestCloudProvisioning(BZTestCase):
 
         self.obj.prepare()
         self.assertIsInstance(self.obj.router, CloudTaurusTest)
-        self.assertEqual(10, len(self.mock.requests))
+        self.assertEqual(8, len(self.mock.requests))
         self.obj.startup()
-        self.assertEqual(11, len(self.mock.requests))
+        self.assertEqual(9, len(self.mock.requests))
 
     def test_update_test_by_link(self):
         self.configure(
@@ -1388,9 +1388,9 @@ class TestCloudProvisioning(BZTestCase):
 
         self.obj.prepare()
         self.assertIsInstance(self.obj.router, CloudTaurusTest)
-        self.assertEqual(10, len(self.mock.requests))
+        self.assertEqual(8, len(self.mock.requests))
         self.obj.startup()
-        self.assertEqual(11, len(self.mock.requests))
+        self.assertEqual(9, len(self.mock.requests))
 
     def test_lookup_test_ids(self):
         self.configure(
@@ -1429,9 +1429,9 @@ class TestCloudProvisioning(BZTestCase):
 
         self.obj.prepare()
         self.assertIsInstance(self.obj.router, CloudTaurusTest)
-        self.assertEqual(10, len(self.mock.requests))
+        self.assertEqual(8, len(self.mock.requests))
         self.obj.startup()
-        self.assertEqual(11, len(self.mock.requests))
+        self.assertEqual(9, len(self.mock.requests))
 
     def test_lookup_test_different_type(self):
         self.configure(


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
