### PR TITLE
FIx selenium webdriver.log

### DIFF
--- a/bzt/modules/_apiritif/generator.py
+++ b/bzt/modules/_apiritif/generator.py
@@ -1242,8 +1242,8 @@ from selenium.webdriver.common.keys import Keys
                     func=ast_attr("Service"),
                     keywords=[
                         ast.keyword(
-                            arg="log_file",
-                            value=ast.Str(self.wdlog, kind=""))]))]
+                            arg="service_args",
+                            value=ast.List(elts=[ast.Str(f"--log-path={self.wdlog}", kind="")]))]))]
 
     def _get_firefox_options(self):
         firefox_options = [

--- a/tests/resources/selenium/external_logging_4_10.py
+++ b/tests/resources/selenium/external_logging_4_10.py
@@ -36,7 +36,7 @@ class TestSample(unittest.TestCase):
             options.add_argument('--disable-dev-shm-usage')
             options.add_argument('--disable-gpu')
             options.set_capability('unhandledPromptBehavior', 'ignore')
-            service = Service(log_file='/somewhere/webdriver.log')
+            service = Service(service_args=['--log-path=/somewhere/webdriver.log'])
             self.driver = webdriver.Chrome(service=service, options=options)
             self.driver.implicitly_wait(timeout)
             apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows={},

--- a/tests/resources/selenium/generated_from_requests_flow_markers_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_flow_markers_4_10.py
@@ -34,7 +34,7 @@ class TestLocSc(unittest.TestCase):
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--disable-gpu')
         options.set_capability('unhandledPromptBehavior', 'ignore')
-        service = Service(log_file='/somewhere/webdriver.log')
+        service = Service(service_args=['--log-path=/somewhere/webdriver.log'])
         self.driver = webdriver.Chrome(service=service, options=options)
         self.driver.implicitly_wait(timeout)
         add_flow_markers()

--- a/tests/resources/selenium/generated_from_requests_foreach_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_foreach_4_10.py
@@ -34,7 +34,7 @@ class TestLocSc(unittest.TestCase):
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--disable-gpu')
         options.set_capability('unhandledPromptBehavior', 'ignore')
-        service = Service(log_file='/somewhere/webdriver.log')
+        service = Service(service_args=['--log-path=/somewhere/webdriver.log'])
         self.driver = webdriver.Chrome(service=service, options=options)
         self.driver.implicitly_wait(timeout)
         apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows={},

--- a/tests/resources/selenium/generated_from_requests_if_then_else_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_if_then_else_4_10.py
@@ -34,7 +34,7 @@ class TestLocSc(unittest.TestCase):
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--disable-gpu')
         options.set_capability('unhandledPromptBehavior', 'ignore')
-        service = Service(log_file='/somewhere/webdriver.log')
+        service = Service(service_args=['--log-path=/somewhere/webdriver.log'])
         self.driver = webdriver.Chrome(service=service, options=options)
         self.driver.implicitly_wait(timeout)
         apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows={},

--- a/tests/resources/selenium/generated_from_requests_shadow_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_shadow_4_10.py
@@ -34,7 +34,7 @@ class TestLocSc(unittest.TestCase):
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--disable-gpu')
         options.set_capability('unhandledPromptBehavior', 'ignore')
-        service = Service(log_file='/somewhere/webdriver.log')
+        service = Service(service_args=['--log-path=/somewhere/webdriver.log'])
         self.driver = webdriver.Chrome(service=service, options=options)
         self.driver.implicitly_wait(timeout)
         apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows={},


### PR DESCRIPTION
## Description
The new selenium version no longer accepts `log_file` as an argument since version 4.0.0 (released in October 2021). In the new version `log_path` should be passed as part of `service_args`. Due to this change chrome wasn't generating any logs during the test run. 

### Generated script
Here is an example of generated apiritif test and generated `wedriver.log` file.
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/fcab793d-d89c-486d-9129-85e7c20df0f2">



Each PR must conform to [Developer's Guide](http://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [x] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
