### PR TITLE
TT-4660: Wrapped send marker code in try block

### DIFF
--- a/bzt/resources/selenium_extras.py
+++ b/bzt/resources/selenium_extras.py
@@ -1,7 +1,7 @@
 # Utility functions and classes for Taurus Selenium tests
 import numbers
 import time
-
+import logging
 from apiritif import get_transaction_handlers, set_transaction_handlers, get_from_thread_store, get_iteration, \
     external_handler, CSVReaderPerThread
 
@@ -24,6 +24,7 @@ BYS = {
     'linktext': By.LINK_TEXT
 }
 
+log = logging.getLogger(__name__)
 
 def find_element_by_shadow(shadow_loc):
     """
@@ -172,7 +173,10 @@ def add_flow_markers():
 
 
 def _send_marker(stage, params):
-    _get_driver().execute_script("/* FLOW_MARKER test-case-%s */" % stage, params)
+    try:
+        _get_driver().execute_script("/* FLOW_MARKER test-case-%s */" % stage, params)
+    except Exception as exc:
+        log.error("Failed to send flow marker: %s %s due to %s", stage, params, exc)
 
 
 def _send_start_flow_marker(*args, **kwargs):  # for apiritif. remove when compatibiltiy code in


### PR DESCRIPTION
**Context**:
- It has been observed that when Taurus executes the /* FLOW_MARKER test-case-stop */ script command, that gets sent to Doduo, which sends it to Charmander, an error is encountered: urllib3.exceptions.ProtocolError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response')).
- Even though the test step has completed, apiritif is unable to end the transaction in the test_requests.py file generated by Taurus, while executing Functional test steps.
- As a result, the whole test appears to have failed, despite individual steps passing.

**Fix**:
- A try-except block around the execute_script in send_markers method, would handle the exception, not relay it to apiritif, so that the transaction could end, and data.blazemeter could get the status and message fields in the POST request body, which would get written to the grid_nodes_data collection document of the MongoDB, with which the test run status is determined.

Each PR must conform to [Developer's Guide](https://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [x] Description of PR explains the context of change
- [x] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
