### PR TITLE
BZSL-2606 update urwid to be compatible with flusk and mitm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ psutil>=5.6.6
 pyvirtualdisplay; sys_platform != 'win32'
 pyyaml
 requests>=2.18.1
-urwid==2.1.2
+urwid==2.6.16
 terminaltables>=3.1.0
 molotov!=2.3
 influxdb >= 5.3


### PR DESCRIPTION
Update urwid to be compatible with the latest version of flusk and mitm libraries.
The differences between the previous and latest version are minor. 