### PR TITLE
BZSL-2612 - downgrade the version of urwid. It is causing issues with…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ psutil>=5.6.6
 pyvirtualdisplay; sys_platform != 'win32'
 pyyaml
 requests>=2.18.1
-urwid==2.6.16
+urwid==2.6.15
 terminaltables>=3.1.0
 molotov!=2.3
 influxdb >= 5.3


### PR DESCRIPTION
The previos version of urwid is causing issues see here: https://github.com/mitmproxy/mitmproxy/issues/7227

This should fix it and keep the dependencies intact