### PR TITLE
BZTR-1694: Add OpenModelThreadGroup to ThreadGroupHandler

### DIFF
--- a/bzt/jmx/threadgroups.py
+++ b/bzt/jmx/threadgroups.py
@@ -182,8 +182,12 @@ class ArrivalsThreadGroup(AbstractDynamicThreadGroup):
         rate_prop.text = str(rate)
 
 
+class OpenModelThreadGroup(AbstractDynamicThreadGroup):
+    XPATH = r'jmeterTestPlan>hashTree>hashTree>OpenModelThreadGroup'
+
+
 class ThreadGroupHandler(object):
-    CLASSES = [ThreadGroup, SteppingThreadGroup, UltimateThreadGroup, ConcurrencyThreadGroup, ArrivalsThreadGroup]
+    CLASSES = [ThreadGroup, SteppingThreadGroup, UltimateThreadGroup, ConcurrencyThreadGroup, ArrivalsThreadGroup, OpenModelThreadGroup]
 
     def __init__(self, logger):
         self.log = logger.getChild(self.__class__.__name__)


### PR DESCRIPTION
Each PR must conform to [Developer's Guide](https://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
  - Added OpenModelThreadGroup to the ThreadGroupHandler so torero can detect OpenModelThread Group for blazemeter
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
