### PR TITLE
Upgrade setuptools to fix CVE-2025-47273

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,4 @@ python-socketio>=5.8.0
 h11>=0.16.0
 websocket-client>=1.5.1
 urllib3==1.26.17
-# Set setuptools to 65.5.0 until this issue will be resolved https://github.com/pypa/setuptools/issues/4496
-# 65.5.0 is last version that supports python 3.7.0
-setuptools==65.5.0
+setuptools>=78.1.1


### PR DESCRIPTION
upgraded setuptools to fix CVE-2025-47273

Each PR must conform to [Developer's Guide](https://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [X] Description of PR explains the context of change
- [X] Unit tests cover the change, no broken tests
- [X] No static analysis warnings (Codacy etc.)
- [X] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
