### PR TITLE
MOB-38657: Native dialog blocking JS execution in dialogs_replace() when no answer is pre-programmed

### DIFF
--- a/bzt/resources/selenium_extras.py
+++ b/bzt/resources/selenium_extras.py
@@ -227,9 +227,6 @@ def dialogs_replace():
           window.__webdriverOriginalAlert = window.alert;
           window.__webdriverNextAlert = null;
           window.alert = function(msg) {
-            if (window.__webdriverNextAlert === null) {
-                window.__webdriverOriginalAlert(msg);
-            }
             window.__webdriverNextAlert = null; 
             window.__webdriverAlerts.push(msg); 
           };
@@ -239,11 +236,8 @@ def dialogs_replace():
           window.confirm = function(msg) {
             window.__webdriverConfirms.push(msg);
             var res = window.__webdriverNextConfirm;
-            if (res === null) {
-                return window.__webdriverPrevConfirm(msg);
-            }
             window.__webdriverNextConfirm = null;
-            return res;
+            return res !== null ? res : true;
           };
           window.__webdriverPrompts = [];
           window.__webdriverNextPrompts = true;


### PR DESCRIPTION
JIRA: https://perforce.atlassian.net/browse/MOB-38657

**Root Cause**

-  In bzt/resources/selenium_extras.py, the dialogs_replace() function overrides window.alert and window.confirm with custom JavaScript implementations. However, when no answer has been pre-programmed (i.e. window.__webdriverNextAlert === null /
   window.__webdriverNextConfirm === null), the overrides fall back to calling the original native dialog:

  // window.alert override
  if (window.__webdriverNextAlert === null) {
      window.__webdriverOriginalAlert(msg);  // fires native blocking dialog
  }

  // window.confirm override
  if (res === null) {
      return window.__webdriverPrevConfirm(msg);  // fires native blocking dialog
  }

-  Since __webdriverNextAlert and __webdriverNextConfirm are initialised to null, the first dialog encountered always fires a native modal. Once a native dialog is open, Chrome's JS thread is blocked and every subsequent execute/sync command
  (e.g. document.readyState checks) returns:

  { "error": "unexpected alert open", "status_code": 500 }

 - This happens even when the session was started with unhandledPromptBehavior: "ignore" — per the W3C WebDriver spec, "ignore" does not suppress unexpected alert open errors; it only prevents the driver from auto-dismissing the dialog.
  execute/sync physically cannot run JavaScript while a native modal is blocking the browser UI thread.

**Fix**

 - Remove the native fallback calls from both overrides. The purpose of dialogs_replace() is to intercept dialogs and capture their text — the native dialog should never fire. For window.confirm, return true (simulate OK) as the default when no
  answer is pre-programmed, so confirm-dependent page logic continues to work.

  bzt/resources/selenium_extras.py

  // Before
  window.alert = function(msg) {
      if (window.__webdriverNextAlert === null) {
          window.__webdriverOriginalAlert(msg);
      }
      window.__webdriverNextAlert = null;
      window.__webdriverAlerts.push(msg);
  };

  // After
  window.alert = function(msg) {
      window.__webdriverNextAlert = null;
      window.__webdriverAlerts.push(msg);
  };

  // Before
  window.confirm = function(msg) {
      window.__webdriverConfirms.push(msg);
      var res = window.__webdriverNextConfirm;
      if (res === null) {
          return window.__webdriverPrevConfirm(msg);
      }
      window.__webdriverNextConfirm = null;
      return res;
  };

  // After
  window.confirm = function(msg) {
      window.__webdriverConfirms.push(msg);
      var res = window.__webdriverNextConfirm;
      window.__webdriverNextConfirm = null;
      return res !== null ? res : true;
  };

**Test Cases to Cover**

  - assertdialog on alert without prior answerdialog — page triggers an alert; test asserts dialog text via dialogs_get_next_alert(). Must not throw unexpected alert open. Dialog text must be captured correctly.
  - assertdialog on alert with prior answerdialog: #ok — dialogs_answer_on_next_alert('#ok') sets __webdriverNextAlert = true before the alert fires. Behaviour must be unchanged.
  - assertdialog on confirm without prior answerdialog — page triggers a confirm; dialogs_get_next_confirm() returns the message. Confirm must default to true (OK), not block execution.
  - assertdialog on confirm with prior answerdialog — pre-programmed true/false answer is returned correctly.
  - assertdialog on prompt — no change in behaviour; verify prompt capture still works and native dialog is not fired.
  - Subsequent commands after dialog — after an alert fires on a page, subsequent WebDriver commands (execute/sync, element interaction, navigation) complete successfully with no unexpected alert open error.
  - Regression: existing generated test fixtures — tests/resources/selenium/generated_from_requests_v2.py and generated_from_requests_v2_4_10.py cover the answerdialog + assertdialog sequence and must continue to pass.:

Each PR must conform to [Developer's Guide](https://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
