### PR TITLE
MOB-38657: Add unhandledPromptBehavior: ignore capability across all browser options

### DIFF
--- a/bzt/modules/_apiritif/generator.py
+++ b/bzt/modules/_apiritif/generator.py
@@ -1304,12 +1304,7 @@ from selenium.webdriver.common.keys import Keys
             ast.Assign(
                 targets=[ast.Name(id="options")],
                 value=ast_call(
-                    func=ast_attr("webdriver.FirefoxOptions"))),
-            ast.Expr(
-                ast_call(
-                    func=ast_attr("options.set_capability"),
-                    args=[ast.Constant("unhandledPromptBehavior", kind=""),
-                          ast.Constant("ignore", kind="")]))]
+                    func=ast_attr("webdriver.FirefoxOptions")))]
 
         return firefox_options + self._get_headless_setup()
 

--- a/bzt/modules/_apiritif/generator.py
+++ b/bzt/modules/_apiritif/generator.py
@@ -1271,7 +1271,13 @@ from selenium.webdriver.common.keys import Keys
             options = self._get_webkitgtk_options()
         else:
             if self.selenium_version.startswith("4"):
-                options = [ast.Assign(targets=[ast.Name(id="options")], value=ast_call(func=ast_attr("ArgOptions")))]
+                options = [
+                    ast.Assign(targets=[ast.Name(id="options")], value=ast_call(func=ast_attr("ArgOptions"))),
+                    ast.Expr(
+                        ast_call(
+                            func=ast_attr("options.set_capability"),
+                            args=[ast.Constant("unhandledPromptBehavior", kind=""),
+                                  ast.Constant("ignore", kind="")]))]
             else:
                 options = [ast.Assign(targets=[ast_attr("options")], value=ast_attr("None"))]
 
@@ -1298,7 +1304,12 @@ from selenium.webdriver.common.keys import Keys
             ast.Assign(
                 targets=[ast.Name(id="options")],
                 value=ast_call(
-                    func=ast_attr("webdriver.FirefoxOptions")))]
+                    func=ast_attr("webdriver.FirefoxOptions"))),
+            ast.Expr(
+                ast_call(
+                    func=ast_attr("options.set_capability"),
+                    args=[ast.Constant("unhandledPromptBehavior", kind=""),
+                          ast.Constant("ignore", kind="")]))]
 
         return firefox_options + self._get_headless_setup()
 
@@ -1333,7 +1344,12 @@ from selenium.webdriver.common.keys import Keys
         edge_options = [
             ast.Assign(
                 targets=[ast.Name(id="options")],
-                value=ast_call(func=ast_attr("webdriver.EdgeOptions")))]
+                value=ast_call(func=ast_attr("webdriver.EdgeOptions"))),
+            ast.Expr(
+                ast_call(
+                    func=ast_attr("options.set_capability"),
+                    args=[ast.Constant("unhandledPromptBehavior", kind=""),
+                          ast.Constant("ignore", kind="")]))]
 
         return edge_options + self._get_headless_setup()
 
@@ -1341,7 +1357,12 @@ from selenium.webdriver.common.keys import Keys
         return [
             ast.Assign(
                 targets=[ast.Name(id="options")],
-                value=ast_call(func=ast_attr("webdriver.WebKitGTKOptions")))]
+                value=ast_call(func=ast_attr("webdriver.WebKitGTKOptions"))),
+            ast.Expr(
+                ast_call(
+                    func=ast_attr("options.set_capability"),
+                    args=[ast.Constant("unhandledPromptBehavior", kind=""),
+                          ast.Constant("ignore", kind="")]))]
 
     def _get_firefox_profile(self):
         capabilities = sorted(self.capabilities.keys())

--- a/bzt/modules/console.py
+++ b/bzt/modules/console.py
@@ -30,7 +30,7 @@ from bzt.utils import numeric_types
 from logging import StreamHandler
 from urwid import LineBox, ListBox, RIGHT, CENTER, BOTTOM, CLIP, GIVEN, ProgressBar
 from urwid import Text, Pile, WEIGHT, Filler, Columns, Widget, CanvasCombine
-from urwid.decoration import Padding
+from urwid import Padding
 from urwid.font import Thin6x6Font
 from urwid.graphics import BigText
 from urwid.listbox import SimpleListWalker

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ psutil>=7.2.2,<7.3.0
 pyvirtualdisplay; sys_platform != 'win32'
 pyyaml
 requests>=2.32.4
-urwid>=3.0.2
+urwid>=3.0.2,<4
 terminaltables3>=4.0.0
 molotov>=2.6
 influxdb >= 5.3.2

--- a/tests/resources/selenium/capabilities_options_for_remote_edge.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_edge.py
@@ -30,6 +30,7 @@ class TestRemoteSc(unittest.TestCase):
 
         timeout = 30.0
         options = webdriver.EdgeOptions()
+        options.set_capability('unhandledPromptBehavior', 'ignore')
         options.ignore_local_proxy_environment_variables()
         options.add_argument('one')
         options.add_argument('two')

--- a/tests/resources/selenium/capabilities_options_for_remote_other.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_other.py
@@ -20,7 +20,7 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import waiter, add_flow_markers, get_locator
+from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
 
 
 class TestLocScRemote(unittest.TestCase):
@@ -30,6 +30,7 @@ class TestLocScRemote(unittest.TestCase):
 
         timeout = 30.0
         options = ArgOptions()
+        options.set_capability('unhandledPromptBehavior', 'ignore')
         options.ignore_local_proxy_environment_variables()
         options.add_argument('one')
         options.add_argument('two')

--- a/tests/resources/selenium/capabilities_options_for_remote_safari.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_safari.py
@@ -30,6 +30,7 @@ class TestRemoteSc(unittest.TestCase):
 
         timeout = 30.0
         options = webdriver.WebKitGTKOptions()
+        options.set_capability('unhandledPromptBehavior', 'ignore')
         options.ignore_local_proxy_environment_variables()
         options.add_argument('one')
         options.add_argument('two')

--- a/tests/resources/selenium/capabilities_options_for_remote_safari_s3.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_safari_s3.py
@@ -29,6 +29,7 @@ class TestLocScRemote(unittest.TestCase):
 
         timeout = 30.0
         options = webdriver.WebKitGTKOptions()
+        options.set_capability('unhandledPromptBehavior', 'ignore')
         options.add_argument('one')
         options.add_argument('two')
         from selenium.webdriver.remote.remote_connection import RemoteConnection


### PR DESCRIPTION
**Root Cause**:
- unhandledPromptBehavior: ignore was inconsistently applied — only Chrome had it in its options method (_get_chrome_options); Firefox had it buried in profile methods only.
- Edge, WebKitGTK (Safari/MiniBrowser), and the ArgOptions fallback (triggered when no explicit browser: is set in YAML and browser is chosen externally, e.g. via BlazeMeter UI) had no unhandledPromptBehavior set at all The ArgOptions path is the most impactful gap — any remote cloud run without an explicit browser: in YAML silently skipped this capability.

**Fix**:
- Added options.set_capability('unhandledPromptBehavior', 'ignore') to all browser options methods in generator.py:
	- _get_firefox_options() — was missing; only existed in profile methods
	- _get_edge_options() — was entirely absent
	- _get_webkitgtk_options() — was entirely absent
	- ArgOptions fallback in _get_options() — was entirely absent; this covers remote runs where browser is selected outside of taurus YAML (e.g. BlazeMeter cloud UI)
- Chrome (_get_chrome_options) was already correct — no change

**Test Cases Covered**:
- Chrome (local) — capability already present via _get_chrome_options; unchanged
- Firefox (local) — capability now set at options level, consistent with Chrome
- Edge (local, Selenium 4+) — capability now set via _get_edge_options
- Safari/MiniBrowser (remote BlazeMeter grid) — capability now set via _get_webkitgtk_options

Remote run with no explicit browser in YAML (e.g. BlazeMeter cloud) — capability now set via ArgOptions fallback; this was the primary reported failure case (test_requests.py showed ArgOptions() with no unhandledPromptBehavior)

Each PR must conform to [Developer's Guide](https://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
