### PR TITLE
MOB-48382: Check if playwright is still on frozen version fix if not

### DIFF
--- a/bzt/modules/javascript.py
+++ b/bzt/modules/javascript.py
@@ -564,6 +564,7 @@ class PLAYWRIGHT(RequiredTool):
                     self.log.warning("Frozen version not found in installed packages, will re-install %s", package_name)
             except CALL_PROBLEMS as exc:
                 self.log.debug("%s check of forced version failed: %s", package_name, exc)
+                version_changed = True
 
         # npx playwright install is not needed to run again if version did not change and is frozen
         if frozen_version is None or version_changed:

--- a/bzt/modules/javascript.py
+++ b/bzt/modules/javascript.py
@@ -514,6 +514,25 @@ class PlaywrightTestPackage(NPMPackage):
     PACKAGE_NAME = "@playwright/test" if os.environ.get("PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION", None) is None \
         else "@playwright/test@" + os.environ.get("PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION")
 
+    def check_if_installed(self):
+        if not super().check_if_installed():
+            return False
+        # Check if installed version is expected version if we force version
+        if os.environ.get("PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION", None) is None:
+            # Not forcing version, any installed is good
+            return True
+
+        cmdline = [self.npm.tool_path, "list"]
+        try:
+            out, _ = self.call(cmdline)
+            version_changed = self.PACKAGE_NAME not in out
+            if version_changed:
+                self.log.warning("Frozen version not found in installed packages, will re-install %s", self.PACKAGE_NAME)
+            return not version_changed
+        except CALL_PROBLEMS as exc:
+            self.log.debug("%s check of forced version failed: %s", self.PACKAGE_NAME, exc)
+            return False
+
 class PlaywrightCustomReporter(NPMLocalModulePackage):
     PACKAGE_NAME = "@taurus/playwright-custom-reporter@1.0.0"
     PACKAGE_LOCAL_PATH = "./playwright-custom-reporter"
@@ -535,8 +554,19 @@ class PLAYWRIGHT(RequiredTool):
     def install(self):
         frozen_version = os.environ.get("PLAYWRIGHT_PACKAGE_FORCED_VERSION", None)
         package_name = "playwright" if frozen_version is None else "playwright@" + frozen_version
-        # npx playwright install is not needed to run again if version did not change (is frozen)
-        if frozen_version is None:
+        version_changed = False
+        if frozen_version:
+            cmdline = ["npm", "list"]
+            try:
+                out, _ = self.call(cmdline)
+                version_changed = package_name not in out
+                if version_changed:
+                    self.log.warning("Frozen version not found in installed packages, will re-install %s", package_name)
+            except CALL_PROBLEMS as exc:
+                self.log.debug("%s check of forced version failed: %s", package_name, exc)
+
+        # npx playwright install is not needed to run again if version did not change and is frozen
+        if frozen_version is None or version_changed:
             # Do not install deps for browsers if we know it will fail because of user permissions (linux & non-root)
             if is_linux() and hasattr(os, "geteuid") and os.geteuid() != 0:
                 self.install_cmd(cmdline = ["npx", package_name, "install"])

--- a/tests/unit/modules/_selenium/test_javascript.py
+++ b/tests/unit/modules/_selenium/test_javascript.py
@@ -520,6 +520,30 @@ class TestPlaywrightInstallation(BZTestCase):
             self.assertIn("install", second_call_args)
             self.assertIn("--with-deps", second_call_args)
 
+    @patch('bzt.modules.javascript.is_linux')
+    def test_playwright_install_frozen_version_npm_list_oserror(self, mock_is_linux):
+        """Test that Playwright re-installs when npm list raises OSError during version check"""
+        mock_is_linux.return_value = False
+
+        playwright = PLAYWRIGHT(tools_dir=self.tools_dir)
+        os.makedirs(self.tools_dir, exist_ok=True)
+
+        # First call (npm list) raises OSError; second call is the actual install
+        playwright.call = MagicMock(side_effect=[OSError("npm list failed"), ("", "")])
+
+        with patch.dict(os.environ, {'PLAYWRIGHT_PACKAGE_FORCED_VERSION': '1.40.0'}):
+            playwright.install()
+
+            self.assertEqual(playwright.call.call_count, 2)
+            first_call_args = playwright.call.call_args_list[0][0][0]
+            self.assertEqual(first_call_args, ["npm", "list"])
+
+            second_call_args = playwright.call.call_args_list[1][0][0]
+            self.assertIn("npx", second_call_args)
+            self.assertIn("playwright@1.40.0", second_call_args)
+            self.assertIn("install", second_call_args)
+            self.assertIn("--with-deps", second_call_args)
+
     def test_playwright_install_creates_tools_dir(self):
         """Test that Playwright install creates tools_dir if it doesn't exist"""
         import tempfile

--- a/tests/unit/modules/_selenium/test_javascript.py
+++ b/tests/unit/modules/_selenium/test_javascript.py
@@ -589,3 +589,91 @@ class TestPlaywrightInstallation(BZTestCase):
             self.assertIn("playwright", call_args)
             # Make sure it's not versioned by default
             self.assertTrue(any("playwright" in str(arg) and "@" not in str(arg) for arg in call_args if "playwright" in str(arg)))
+
+
+class TestPlaywrightTestPackageInstallation(BZTestCase):
+    """Tests for PlaywrightTestPackage.check_if_installed()"""
+
+    def setUp(self):
+        super(TestPlaywrightTestPackageInstallation, self).setUp()
+        self.node_mock = MagicMock()
+        self.node_mock.tool_path = "node"
+        self.npm_mock = MagicMock()
+        self.npm_mock.tool_path = "npm"
+        self.tools_dir = "~/.bzt/playwright"
+
+    def _create_package(self):
+        return PlaywrightTestPackage(
+            tools_dir=self.tools_dir,
+            node_tool=self.node_mock,
+            npm_tool=self.npm_mock,
+        )
+
+    def test_check_if_installed_super_returns_false(self):
+        """When the parent require() check fails, return False without calling npm list"""
+        pkg = self._create_package()
+        pkg.call = MagicMock(return_value=("", ""))
+
+        result = pkg.check_if_installed()
+
+        self.assertFalse(result)
+        pkg.call.assert_called_once()
+
+    def test_check_if_installed_no_forced_version(self):
+        """When no forced version is set, any installed version is acceptable and npm list is not called"""
+        pkg = self._create_package()
+        pkg.call = MagicMock(return_value=("@playwright/test is installed", ""))
+
+        with patch.dict(os.environ, {}, clear=False):
+            if 'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION' in os.environ:
+                del os.environ['PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION']
+
+            result = pkg.check_if_installed()
+
+        self.assertTrue(result)
+        pkg.call.assert_called_once()
+
+    def test_check_if_installed_forced_version_correct(self):
+        """When forced version matches the installed version, return True"""
+        pkg = self._create_package()
+        pkg.call = MagicMock(side_effect=[
+            ("@playwright/test is installed", ""),
+            ("@playwright/test@1.40.0 node_modules/@playwright/test", ""),
+        ])
+
+        with patch.object(PlaywrightTestPackage, 'PACKAGE_NAME', '@playwright/test@1.40.0'):
+            with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': '1.40.0'}):
+                result = pkg.check_if_installed()
+
+        self.assertTrue(result)
+        self.assertEqual(pkg.call.call_count, 2)
+        second_call_args = pkg.call.call_args_list[1][0][0]
+        self.assertEqual(second_call_args, [self.npm_mock.tool_path, "list"])
+
+    def test_check_if_installed_forced_version_mismatch(self):
+        """When forced version is not present in npm list output, return False"""
+        pkg = self._create_package()
+        pkg.call = MagicMock(side_effect=[
+            ("@playwright/test is installed", ""),
+            ("@playwright/test@1.39.0 node_modules/@playwright/test", ""),
+        ])
+
+        with patch.object(PlaywrightTestPackage, 'PACKAGE_NAME', '@playwright/test@1.40.0'):
+            with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': '1.40.0'}):
+                result = pkg.check_if_installed()
+
+        self.assertFalse(result)
+        self.assertEqual(pkg.call.call_count, 2)
+
+    def test_check_if_installed_npm_list_call_fails(self):
+        """When npm list raises an OSError, return False"""
+        pkg = self._create_package()
+        pkg.call = MagicMock(side_effect=[
+            ("@playwright/test is installed", ""),
+            OSError("npm list failed"),
+        ])
+
+        with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': '1.40.0'}):
+            result = pkg.check_if_installed()
+
+        self.assertFalse(result)

--- a/tests/unit/modules/_selenium/test_javascript.py
+++ b/tests/unit/modules/_selenium/test_javascript.py
@@ -483,15 +483,42 @@ class TestPlaywrightInstallation(BZTestCase):
             self.assertIn("--with-deps", call_args)
 
     def test_playwright_install_frozen_version(self):
-        """Test that Playwright install is skipped when version is frozen"""
+        """Test that Playwright install is skipped when frozen version is already installed"""
         playwright = PLAYWRIGHT(tools_dir=self.tools_dir)
-        playwright.call = MagicMock(return_value=("", ""))
+        # npm list returns output containing the frozen version
+        playwright.call = MagicMock(return_value=("playwright@1.40.0 node_modules/playwright", ""))
 
         with patch.dict(os.environ, {'PLAYWRIGHT_PACKAGE_FORCED_VERSION': '1.40.0'}):
             playwright.install()
 
-            # Should NOT call install when version is frozen
-            playwright.call.assert_not_called()
+            # Should call npm list once to check the installed version
+            playwright.call.assert_called_once_with(["npm", "list"])
+
+    @patch('bzt.modules.javascript.is_linux')
+    def test_playwright_install_frozen_version_changed(self, mock_is_linux):
+        """Test that Playwright re-installs when installed version differs from frozen version"""
+        mock_is_linux.return_value = False
+
+        playwright = PLAYWRIGHT(tools_dir=self.tools_dir)
+        os.makedirs(self.tools_dir, exist_ok=True)
+
+        # npm list returns a different (old) version — frozen version NOT present
+        playwright.call = MagicMock(return_value=("playwright@1.39.0 node_modules/playwright", ""))
+
+        with patch.dict(os.environ, {'PLAYWRIGHT_PACKAGE_FORCED_VERSION': '1.40.0'}):
+            playwright.install()
+
+            # First call: npm list version check
+            first_call_args = playwright.call.call_args_list[0][0][0]
+            self.assertEqual(first_call_args, ["npm", "list"])
+
+            # Second call: npx playwright@1.40.0 install --with-deps
+            self.assertEqual(playwright.call.call_count, 2)
+            second_call_args = playwright.call.call_args_list[1][0][0]
+            self.assertIn("npx", second_call_args)
+            self.assertIn("playwright@1.40.0", second_call_args)
+            self.assertIn("install", second_call_args)
+            self.assertIn("--with-deps", second_call_args)
 
     def test_playwright_install_creates_tools_dir(self):
         """Test that Playwright install creates tools_dir if it doesn't exist"""


### PR DESCRIPTION
Customer had in shellexec unnecessary `npm install` commands which updated playwright to latest version which did not matched installed browsers. We are forcing playwright/test package back to expected version if something like this happened.

Customer block which broke things:
```
services:
- module: shellexec
  prepare:  
    - npm install
    - npm install csv-parse
```    

Each PR must conform to [Developer's Guide](https://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
