### PR TITLE
MOB-48126: Do not propagate playwright returncode 1 as bzt error

### DIFF
--- a/bzt/modules/javascript.py
+++ b/bzt/modules/javascript.py
@@ -17,7 +17,7 @@ import json
 import os
 from abc import abstractmethod
 
-from bzt import TaurusConfigError
+from bzt import TaurusConfigError, ToolError
 from bzt.modules import SubprocessedExecutor
 from bzt.modules.aggregator import ResultsReader, ConsolidatingAggregator
 from bzt.utils import TclLibrary, RequiredTool, Node, CALL_PROBLEMS, RESOURCES_DIR, FileReader
@@ -182,6 +182,26 @@ class PlaywrightTester(JavaScriptExecutor):
 
     def has_results(self):
         return True
+
+    def check(self):
+        ret_code = self.process.poll()
+        if ret_code is not None:
+            if ret_code != 0:
+                if ret_code == 1 and self._tests_ran():
+                    self.log.debug(
+                        "Playwright process exited with code 1 and tests were run - treating as normal completion"
+                    )
+                    return True
+                msg = "Test runner %s (%s) has failed with retcode %s"
+                raise ToolError(msg % (self.label, self.__class__.__name__, ret_code),
+                                self.get_error_diagnostics())
+            return True
+        return False
+
+    def _tests_ran(self):
+        if self.reader and os.path.exists(self.reader.filename):
+            return os.path.getsize(self.reader.filename) > 0
+        return False
 
 
 class PlaywrightLogReader(ResultsReader):

--- a/tests/unit/modules/_selenium/test_javascript.py
+++ b/tests/unit/modules/_selenium/test_javascript.py
@@ -402,6 +402,109 @@ class TestPlaywrightExecutor(SeleniumTestCase):
         self.assertTrue(os.path.isabs(script_path) or script_path.startswith("~"))
         self.assertIn(".bzt/playwright", script_path)
 
+    def test_playwright_exit_code1_with_tests_ran(self):
+        """Exit code 1 should not raise when tests ran (some failed)."""
+        self.prepare({
+            'execution': {
+                "executor": "playwright",
+                "iterations": 1,
+                "scenario": {"script": RESOURCES_DIR + "playwright"}
+            }
+        })
+        mock_process = MagicMock()
+        mock_process.poll.return_value = 1
+        self.obj.runner.process = mock_process
+        self.obj.runner._tests_ran = MagicMock(return_value=True)
+
+        self.assertTrue(self.obj.runner.check())
+
+    def test_playwright_exit_code1_without_tests_ran(self):
+        """Exit code 1 should raise ToolError when no tests ran (config error)."""
+        self.prepare({
+            'execution': {
+                "executor": "playwright",
+                "iterations": 1,
+                "scenario": {"script": RESOURCES_DIR + "playwright"}
+            }
+        })
+        mock_process = MagicMock()
+        mock_process.poll.return_value = 1
+        self.obj.runner.process = mock_process
+        self.obj.runner._tests_ran = MagicMock(return_value=False)
+
+        with self.assertRaises(ToolError):
+            self.obj.runner.check()
+
+    def test_playwright_crash_exit_code_raises(self):
+        """Non-1 non-zero exit (e.g. 134 OOM) should raise ToolError even if tests ran."""
+        self.prepare({
+            'execution': {
+                "executor": "playwright",
+                "iterations": 1,
+                "scenario": {"script": RESOURCES_DIR + "playwright"}
+            }
+        })
+        mock_process = MagicMock()
+        mock_process.poll.return_value = 134
+        self.obj.runner.process = mock_process
+        self.obj.runner._tests_ran = MagicMock(return_value=True)
+
+        with self.assertRaises(ToolError):
+            self.obj.runner.check()
+
+    def test_tests_ran_file_exists_with_content(self):
+        """_tests_ran returns True when result file exists and is non-empty."""
+        self.prepare({
+            'execution': {
+                "executor": "playwright",
+                "iterations": 1,
+                "scenario": {"script": RESOURCES_DIR + "playwright"}
+            }
+        })
+        filename = self.obj.runner.reader.filename
+        with patch('bzt.modules.javascript.os.path.exists', return_value=True) as mock_exists, \
+                patch('bzt.modules.javascript.os.path.getsize', return_value=42) as mock_getsize:
+            self.assertTrue(self.obj.runner._tests_ran())
+            mock_exists.assert_called_once_with(filename)
+            mock_getsize.assert_called_once_with(filename)
+
+    def test_tests_ran_file_exists_empty(self):
+        """_tests_ran returns False when result file exists but is empty."""
+        self.prepare({
+            'execution': {
+                "executor": "playwright",
+                "iterations": 1,
+                "scenario": {"script": RESOURCES_DIR + "playwright"}
+            }
+        })
+        with patch('bzt.modules.javascript.os.path.exists', return_value=True), \
+                patch('bzt.modules.javascript.os.path.getsize', return_value=0):
+            self.assertFalse(self.obj.runner._tests_ran())
+
+    def test_tests_ran_file_absent(self):
+        """_tests_ran returns False when result file does not exist."""
+        self.prepare({
+            'execution': {
+                "executor": "playwright",
+                "iterations": 1,
+                "scenario": {"script": RESOURCES_DIR + "playwright"}
+            }
+        })
+        with patch('bzt.modules.javascript.os.path.exists', return_value=False):
+            self.assertFalse(self.obj.runner._tests_ran())
+
+    def test_tests_ran_no_reader(self):
+        """_tests_ran returns False when reader is None."""
+        self.prepare({
+            'execution': {
+                "executor": "playwright",
+                "iterations": 1,
+                "scenario": {"script": RESOURCES_DIR + "playwright"}
+            }
+        })
+        self.obj.runner.reader = None
+        self.assertFalse(self.obj.runner._tests_ran())
+
 
 class TestPlaywrightInstallation(BZTestCase):
     """Test PLAYWRIGHT tool installation logic"""


### PR DESCRIPTION
When test fails on assertion, playwright return 1. We want to return as bzt error just problem with test definition/run not failing test cases.

Each PR must conform to [Developer's Guide](https://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
