### PR TITLE
MOB-44668 fix jmx rampup causing test ending sooner than expected

### DIFF
--- a/bzt/modules/pyscripts/jmxrampup.py
+++ b/bzt/modules/pyscripts/jmxrampup.py
@@ -128,7 +128,7 @@ class JmeterRampupProcess(object):
         try:
             sock.connect((beanshell_addr, beanshell_port + 1))
             sock.settimeout(1)
-            script = (f'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
+            script = (f'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_Steps","1");'
                       f'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","{desired_users}");')
             sock.sendall(script.encode())
 

--- a/tests/unit/modules/pyscripts/test_jmxrampup.py
+++ b/tests/unit/modules/pyscripts/test_jmxrampup.py
@@ -45,9 +45,9 @@ class TestJmeterRampupProcess(BZTestCase):
                             self.assertIn('Setting concurrency: (5, 100300.0)', self.log_recorder.info_buff.getvalue())
                             mock_socket.socket().connect.assert_called_with(('localhost', 9001))
                             mock_socket.socket().sendall.assert_has_calls([
-                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
+                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_Steps","1");'
                                      b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","3");'),
-                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
+                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_Steps","1");'
                                      b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","5");')
                             ])
 
@@ -131,7 +131,7 @@ class TestJmeterRampupProcess(BZTestCase):
                             self.assertIn('Setting concurrency: (5, 100000.0)', self.log_recorder.info_buff.getvalue())
                             mock_socket.socket().connect.assert_called_with(('localhost', 9001))
                             mock_socket.socket().sendall.assert_has_calls([
-                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
+                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_Steps","1");'
                                           b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","5");')
                             ])
 
@@ -168,13 +168,13 @@ class TestJmeterRampupProcess(BZTestCase):
                             self.assertIn('Setting concurrency: (5, 100450.0)', self.log_recorder.info_buff.getvalue())
                             mock_socket.socket().connect.assert_called_with(('localhost', 9001))
                             mock_socket.socket().sendall.assert_has_calls([
-                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
+                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_Steps","1");'
                                           b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","2");'),
-                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
+                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_Steps","1");'
                                           b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","3");'),
-                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
+                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_Steps","1");'
                                           b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","4");'),
-                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
+                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_Steps","1");'
                                           b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","5");')
                             ])
 
@@ -211,13 +211,13 @@ class TestJmeterRampupProcess(BZTestCase):
                               self.assertIn('Setting concurrency: (500, 100059', self.log_recorder.info_buff.getvalue())
                               mock_socket.socket().connect.assert_called_with(('localhost', 9001))
                               mock_socket.socket().sendall.assert_has_calls([
-                                  mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
+                                  mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_Steps","1");'
                                             b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","10");'),
-                                  mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
+                                  mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_Steps","1");'
                                             b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","176");'),
-                                  mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
+                                  mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_Steps","1");'
                                             b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","342");'),
-                                  mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
+                                  mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_Steps","1");'
                                             b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","500");'),
                               ])
 
@@ -275,9 +275,9 @@ class TestJmeterRampupProcess(BZTestCase):
                             self.assertIn('Setting concurrency: (5, 100300.0)', self.log_recorder.info_buff.getvalue())
                             mock_socket.socket().connect.assert_called_with(('localhost', 9001))
                             mock_socket.socket().sendall.assert_has_calls([
-                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
+                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_Steps","1");'
                                           b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","3");'),
-                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_RampUp","0");'
+                                mock.call(b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_Steps","1");'
                                           b'org.apache.jmeter.util.JMeterUtils.setProperty("BM_CTG_TargetLevel","5");')
                             ])
 


### PR DESCRIPTION
Test length is rampup + hold. In case we change number of users during runtime and original test has rampup it will end prematurely. Setting steps to 1 will fix it without touching original rampup value.

Each PR must conform to [Developer's Guide](https://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
