### PR TITLE
[MOB-43620] Scholastic:  Browser Performance test stopping after 12 min/55 iterations

### DIFF
--- a/bzt/modules/_apiritif/generator.py
+++ b/bzt/modules/_apiritif/generator.py
@@ -182,6 +182,7 @@ from selenium.webdriver.common.keys import Keys
         self.bzm_tdo_settings = bzm_tdo_settings
         self.do_testdata_orchestration = False
         self.has_action_ids = False
+        self._needs_remote_patch = False
 
     def _parse_action_params(self, expr, name):
         res = expr.match(name)
@@ -1155,7 +1156,7 @@ from selenium.webdriver.common.keys import Keys
                 body.extend(self._get_service(browser))
 
         if browser == 'firefox':
-            body.extend(self._gen_remote_patch_ast())
+            self._needs_remote_patch = True
             if LooseVersion(self.selenium_version) > self.SELENIUM_491_VERSION:
                 body.extend(self._get_firefox_profile_v410() + [self._get_firefox_webdriver_4_10()])
             elif LooseVersion(self.selenium_version) > self.SELENIUM_413_VERSION:
@@ -1164,18 +1165,18 @@ from selenium.webdriver.common.keys import Keys
                 body.extend(self._get_firefox_profile() + [self._get_firefox_webdriver()])
 
         elif browser == 'chrome':
-            body.extend(self._gen_remote_patch_ast())
+            self._needs_remote_patch = True
             if LooseVersion(self.selenium_version) > self.SELENIUM_413_VERSION:
                 body.extend(self._get_chrome_profile_v414() + [self._get_chrome_webdriver()])
             else:
                 body.extend(self._get_chrome_profile() + [self._get_chrome_webdriver()])
 
         elif browser == 'edge':
-            body.extend(self._gen_remote_patch_ast())
+            self._needs_remote_patch = True
             body.extend([self._get_edge_webdriver()])
 
         elif browser == 'remote':
-            body.extend(self._gen_remote_patch_ast())
+            self._needs_remote_patch = True
             if self.selenium_version.startswith("4"):
                 if LooseVersion(self.selenium_version) > self.SELENIUM_413_VERSION:
                     remote_profile = self._get_remote_profile_v414() + [self._get_remote_webdriver()]
@@ -1607,7 +1608,13 @@ from selenium.webdriver.common.keys import Keys
             stmts.extend(self._gen_logging())
 
         stmts.extend(self._gen_data_source_readers())
-        stmts.append(self._gen_classdef())
+        classdef = self._gen_classdef()
+
+        if self._needs_remote_patch:
+            stmts.extend(self._gen_remote_patch_ast())
+            stmts.append(gen_empty_line_stmt())
+
+        stmts.append(classdef)
 
         stmts = self._gen_imports() + stmts
 

--- a/bzt/modules/_apiritif/generator.py
+++ b/bzt/modules/_apiritif/generator.py
@@ -1665,6 +1665,15 @@ from selenium.webdriver.common.keys import Keys
                         level=0
                     )
                 )
+            if self._needs_remote_patch:
+                imports.append(
+                    ast.ImportFrom(
+                        module='selenium.webdriver.remote.remote_connection',
+                        names=[ast.alias(name='RemoteConnection', asname=None)],
+                        level=0
+                    )
+                )
+                imports.append(ast.Import(names=[ast.alias(name='copy', asname=None)]))
             self.selenium_extras.add("get_locator")
             self.selenium_extras.add("waiter")
             extra_names = [ast.alias(name=name, asname=None) for name in self.selenium_extras]
@@ -2593,15 +2602,6 @@ from selenium.webdriver.common.keys import Keys
         return mod
 
     def _gen_remote_patch_ast(self):
-        import_ast = [
-            ast.ImportFrom(
-                module='selenium.webdriver.remote.remote_connection',
-                names=[ast.alias(name='RemoteConnection', asname=None)],
-                level=0
-            ),
-            ast.Import(names=[ast.alias(name='copy', asname=None)]),
-        ]
-
         assign_original = ast.Assign(
             targets=[ast.Name(id='_original_execute', ctx=ast.Store())],
             value=ast_attr('RemoteConnection.execute')
@@ -2719,12 +2719,26 @@ from selenium.webdriver.common.keys import Keys
                                                 keywords=[]
                                             )
                                         ),
-                                        ast.Expr(
-                                            value=ast.Call(
-                                                func=ast.Name(id='sleep', ctx=ast.Load()),
-                                                args=[ast.Name(id='delay', ctx=ast.Load())],
-                                                keywords=[]
-                                            )
+                                        ast.If(
+                                            test=ast.Compare(
+                                                left=ast.Name(id='attempt', ctx=ast.Load()),
+                                                ops=[ast.Lt()],
+                                                comparators=[ast.BinOp(
+                                                    left=ast.Name(id='retries', ctx=ast.Load()),
+                                                    op=ast.Sub(),
+                                                    right=ast.Constant(value=1)
+                                                )]
+                                            ),
+                                            body=[
+                                                ast.Expr(
+                                                    value=ast.Call(
+                                                        func=ast.Name(id='sleep', ctx=ast.Load()),
+                                                        args=[ast.Name(id='delay', ctx=ast.Load())],
+                                                        keywords=[]
+                                                    )
+                                                )
+                                            ],
+                                            orelse=[]
                                         )
                                     ]
                                 )
@@ -2748,7 +2762,7 @@ from selenium.webdriver.common.keys import Keys
             value=ast.Name(id='execute_with_retries', ctx=ast.Load())
         )
 
-        return import_ast + [assign_original, func_def, assign_patch]
+        return [assign_original, func_def, assign_patch]
 
     def build_source_code(self):
         self.tree = self._build_tree()

--- a/tests/resources/selenium/capabilities_options_for_remote_chrome.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_chrome.py
@@ -20,10 +20,10 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import get_locator, waiter, add_flow_markers
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import get_locator, waiter, add_flow_markers
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -40,7 +40,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/capabilities_options_for_remote_chrome.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_chrome.py
@@ -22,6 +22,28 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import get_locator, waiter, add_flow_markers
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
 
 class TestLocScRemote(unittest.TestCase):
 
@@ -39,27 +61,6 @@ class TestLocScRemote(unittest.TestCase):
         options.add_argument('two')
         options.add_experimental_option('key1', 'value1')
         options.add_experimental_option('key2', {'key22': 'value22'})
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         options.set_capability('browserName', 'chrome')
         options.set_capability('cap1', 'val1')
         options.set_capability('cap2', 'val2')

--- a/tests/resources/selenium/capabilities_options_for_remote_chrome_s3.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_chrome_s3.py
@@ -19,10 +19,10 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -39,7 +39,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/capabilities_options_for_remote_chrome_s3.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_chrome_s3.py
@@ -21,6 +21,28 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
 
 class TestLocScRemote(unittest.TestCase):
 
@@ -37,27 +59,6 @@ class TestLocScRemote(unittest.TestCase):
         options.add_argument('two')
         options.add_experimental_option('key1', 'value1')
         options.add_experimental_option('key2', {'key22': 'value22'})
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         self.driver = webdriver.Remote(command_executor='http://user:key@remote_web_driver_host:port/wd/hub',
                                        desired_capabilities={'browserName': 'chrome', 'cap1': 'val1', 'cap2': 'val2'},
                                        options=options)

--- a/tests/resources/selenium/capabilities_options_for_remote_edge.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_edge.py
@@ -22,6 +22,28 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
 
 class TestRemoteSc(unittest.TestCase):
 
@@ -33,27 +55,6 @@ class TestRemoteSc(unittest.TestCase):
         options.ignore_local_proxy_environment_variables()
         options.add_argument('one')
         options.add_argument('two')
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         options.set_capability('browserName', 'MicrosoftEdge')
         self.driver = webdriver.Remote(command_executor='http://addr-of-remote-server.com', options=options)
         self.driver.implicitly_wait(timeout)

--- a/tests/resources/selenium/capabilities_options_for_remote_edge.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_edge.py
@@ -20,10 +20,10 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -40,7 +40,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/capabilities_options_for_remote_firefox.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_firefox.py
@@ -20,10 +20,10 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -40,7 +40,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/capabilities_options_for_remote_firefox.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_firefox.py
@@ -22,6 +22,28 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
 
 class TestLocScRemote(unittest.TestCase):
 
@@ -35,27 +57,6 @@ class TestLocScRemote(unittest.TestCase):
         options.add_argument('two')
         options.set_preference('key1', 'value1')
         options.set_preference('key2', {'key22': 'value22'})
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         options.set_capability('browserName', 'firefox')
         options.set_capability('cap1', 'val1')
         options.set_capability('cap2', 'val2')

--- a/tests/resources/selenium/capabilities_options_for_remote_firefox_s3.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_firefox_s3.py
@@ -19,10 +19,10 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -39,7 +39,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/capabilities_options_for_remote_firefox_s3.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_firefox_s3.py
@@ -21,6 +21,28 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
 
 class TestLocScRemote(unittest.TestCase):
 
@@ -33,27 +55,6 @@ class TestLocScRemote(unittest.TestCase):
         options.add_argument('two')
         options.set_preference('key1', 'value1')
         options.set_preference('key2', {'key22': 'value22'})
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         self.driver = webdriver.Remote(command_executor='http://user:key@remote_web_driver_host:port/wd/hub',
                                        desired_capabilities={'browserName': 'firefox', 'cap1': 'val1', 'cap2': 'val2'},
                                        options=options)

--- a/tests/resources/selenium/capabilities_options_for_remote_other.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_other.py
@@ -20,10 +20,10 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import waiter, add_flow_markers, get_locator
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import waiter, add_flow_markers, get_locator
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -40,7 +40,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/capabilities_options_for_remote_other.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_other.py
@@ -22,6 +22,28 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import waiter, add_flow_markers, get_locator
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
 
 class TestLocScRemote(unittest.TestCase):
 
@@ -33,27 +55,6 @@ class TestLocScRemote(unittest.TestCase):
         options.ignore_local_proxy_environment_variables()
         options.add_argument('one')
         options.add_argument('two')
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         options.set_capability('cap1', 'val1')
         options.set_capability('cap2', 'val2')
         self.driver = webdriver.Remote(command_executor='http://user:key@remote_web_driver_host:port/wd/hub',

--- a/tests/resources/selenium/capabilities_options_for_remote_other_s3.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_other_s3.py
@@ -19,10 +19,10 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -39,7 +39,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/capabilities_options_for_remote_other_s3.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_other_s3.py
@@ -21,6 +21,28 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
 
 class TestLocScRemote(unittest.TestCase):
 
@@ -29,27 +51,6 @@ class TestLocScRemote(unittest.TestCase):
 
         timeout = 30.0
         options = None
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         self.driver = webdriver.Remote(command_executor='http://user:key@remote_web_driver_host:port/wd/hub',
                                        desired_capabilities={'cap1': 'val1', 'cap2': 'val2'}, options=options)
         self.driver.implicitly_wait(timeout)

--- a/tests/resources/selenium/capabilities_options_for_remote_safari.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_safari.py
@@ -20,10 +20,10 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -40,7 +40,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/capabilities_options_for_remote_safari.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_safari.py
@@ -22,6 +22,28 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
 
 class TestRemoteSc(unittest.TestCase):
 
@@ -33,27 +55,6 @@ class TestRemoteSc(unittest.TestCase):
         options.ignore_local_proxy_environment_variables()
         options.add_argument('one')
         options.add_argument('two')
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         options.set_capability('browserName', 'safari')
         self.driver = webdriver.Remote(command_executor='http://addr-of-remote-server.com/api/v4/grid/wd/hub',
                                        options=options)

--- a/tests/resources/selenium/capabilities_options_for_remote_safari_s3.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_safari_s3.py
@@ -19,10 +19,10 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -39,7 +39,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/capabilities_options_for_remote_safari_s3.py
+++ b/tests/resources/selenium/capabilities_options_for_remote_safari_s3.py
@@ -21,6 +21,28 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from bzt.resources.selenium_extras import get_locator, add_flow_markers, waiter
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
 
 class TestLocScRemote(unittest.TestCase):
 
@@ -31,27 +53,6 @@ class TestLocScRemote(unittest.TestCase):
         options = webdriver.WebKitGTKOptions()
         options.add_argument('one')
         options.add_argument('two')
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         self.driver = webdriver.Remote(command_executor='http://user:key@remote_web_driver:port/api/v4/grid/wd/hub',
                                        desired_capabilities={'browserName': 'safari', 'cap1': 'val1', 'cap2': 'val2'},
                                        options=options)

--- a/tests/resources/selenium/external_logging.py
+++ b/tests/resources/selenium/external_logging.py
@@ -22,6 +22,29 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import get_locator, action_start, waiter, action_end
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
+
 class TestSample(unittest.TestCase):
 
     def setUp(self):
@@ -35,27 +58,6 @@ class TestSample(unittest.TestCase):
             options.add_argument('--disable-dev-shm-usage')
             options.add_argument('--disable-gpu')
             options.set_capability('unhandledPromptBehavior', 'ignore')
-            from selenium.webdriver.remote.remote_connection import RemoteConnection
-            import copy
-            _original_execute = RemoteConnection.execute
-
-            def execute_with_retries(self, command, params=None):
-                params_copy = copy.deepcopy(params)
-                retries = 3
-                delay = 2
-                last_exc = None
-                for attempt in range(retries):
-                    try:
-                        if (params != params_copy):
-                            return _original_execute(self, command, params_copy)
-                        else:
-                            return _original_execute(self, command, params)
-                    except Exception as e:
-                        last_exc = e
-                        print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                        sleep(delay)
-                raise last_exc
-            RemoteConnection.execute = execute_with_retries
             self.driver = webdriver.Chrome(service_log_path='/somewhere/webdriver.log', options=options)
             self.driver.implicitly_wait(timeout)
             apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows={},

--- a/tests/resources/selenium/external_logging.py
+++ b/tests/resources/selenium/external_logging.py
@@ -20,10 +20,10 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import get_locator, action_start, waiter, action_end
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import get_locator, action_start, waiter, action_end
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -40,7 +40,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/external_logging_4_10.py
+++ b/tests/resources/selenium/external_logging_4_10.py
@@ -23,6 +23,29 @@ from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import get_locator, action_start, waiter, action_end
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
+
 class TestSample(unittest.TestCase):
 
     def setUp(self):
@@ -36,27 +59,6 @@ class TestSample(unittest.TestCase):
             options.add_argument('--disable-dev-shm-usage')
             options.add_argument('--disable-gpu')
             options.set_capability('unhandledPromptBehavior', 'ignore')
-            from selenium.webdriver.remote.remote_connection import RemoteConnection
-            import copy
-            _original_execute = RemoteConnection.execute
-
-            def execute_with_retries(self, command, params=None):
-                params_copy = copy.deepcopy(params)
-                retries = 3
-                delay = 2
-                last_exc = None
-                for attempt in range(retries):
-                    try:
-                        if (params != params_copy):
-                            return _original_execute(self, command, params_copy)
-                        else:
-                            return _original_execute(self, command, params)
-                    except Exception as e:
-                        last_exc = e
-                        print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                        sleep(delay)
-                raise last_exc
-            RemoteConnection.execute = execute_with_retries
             service = Service(service_args=['--log-path=/somewhere/webdriver.log'])
             self.driver = webdriver.Chrome(service=service, options=options)
             self.driver.implicitly_wait(timeout)

--- a/tests/resources/selenium/external_logging_4_10.py
+++ b/tests/resources/selenium/external_logging_4_10.py
@@ -21,10 +21,10 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import get_locator, action_start, waiter, action_end
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import get_locator, action_start, waiter, action_end
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -41,7 +41,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/generated_from_requests.py
+++ b/tests/resources/selenium/generated_from_requests.py
@@ -20,12 +20,12 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
 from bzt.resources.selenium_extras import wait_for, dialogs_replace, open_window, switch_window, dialogs_get_next_prompt, dialogs_answer_on_next_prompt, dialogs_answer_on_next_confirm, dialogs_answer_on_next_alert, dialogs_get_next_alert, switch_frame, dialogs_get_next_confirm, close_window, get_locator, waiter
 reader_1 = apiritif.CSVReaderPerThread('first.csv', loop=True)
 reader_2 = apiritif.CSVReaderPerThread('second.csv', loop=False)
 
-from selenium.webdriver.remote.remote_connection import RemoteConnection
-import copy
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -42,7 +42,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/generated_from_requests.py
+++ b/tests/resources/selenium/generated_from_requests.py
@@ -24,6 +24,28 @@ from bzt.resources.selenium_extras import wait_for, dialogs_replace, open_window
 reader_1 = apiritif.CSVReaderPerThread('first.csv', loop=True)
 reader_2 = apiritif.CSVReaderPerThread('second.csv', loop=False)
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
 
 class TestLocSc(unittest.TestCase):
 
@@ -36,27 +58,6 @@ class TestLocSc(unittest.TestCase):
 
         timeout = 3.5
         options = webdriver.FirefoxOptions()
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         profile = webdriver.FirefoxProfile()
         profile.set_preference('webdriver.log.file', '/somewhere/webdriver.log')
         options.set_capability('unhandledPromptBehavior', 'ignore')

--- a/tests/resources/selenium/generated_from_requests_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_4_10.py
@@ -20,12 +20,12 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
 from bzt.resources.selenium_extras import wait_for, dialogs_replace, open_window, switch_window, dialogs_get_next_prompt, dialogs_answer_on_next_prompt, dialogs_answer_on_next_confirm, dialogs_answer_on_next_alert, dialogs_get_next_alert, switch_frame, dialogs_get_next_confirm, close_window, get_locator, waiter
 reader_1 = apiritif.CSVReaderPerThread('first.csv', loop=True)
 reader_2 = apiritif.CSVReaderPerThread('second.csv', loop=False)
 
-from selenium.webdriver.remote.remote_connection import RemoteConnection
-import copy
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -42,7 +42,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/generated_from_requests_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_4_10.py
@@ -24,6 +24,28 @@ from bzt.resources.selenium_extras import wait_for, dialogs_replace, open_window
 reader_1 = apiritif.CSVReaderPerThread('first.csv', loop=True)
 reader_2 = apiritif.CSVReaderPerThread('second.csv', loop=False)
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
 
 class TestLocSc(unittest.TestCase):
 
@@ -36,27 +58,6 @@ class TestLocSc(unittest.TestCase):
 
         timeout = 3.5
         options = webdriver.FirefoxOptions()
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         profile = webdriver.FirefoxProfile()
         profile.set_preference('webdriver.log.file', '/somewhere/webdriver.log')
         options.profile = profile

--- a/tests/resources/selenium/generated_from_requests_appium_browser.py
+++ b/tests/resources/selenium/generated_from_requests_appium_browser.py
@@ -22,6 +22,28 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import wait_for, get_locator, waiter
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
 
 class TestLocScAppium(unittest.TestCase):
 
@@ -34,27 +56,6 @@ class TestLocScAppium(unittest.TestCase):
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--disable-gpu')
         options.set_capability('unhandledPromptBehavior', 'ignore')
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         options.set_capability('browserName', 'chrome')
         options.set_capability('deviceName', '')
         options.set_capability('platformName', 'android')

--- a/tests/resources/selenium/generated_from_requests_appium_browser.py
+++ b/tests/resources/selenium/generated_from_requests_appium_browser.py
@@ -20,10 +20,10 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import wait_for, get_locator, waiter
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import wait_for, get_locator, waiter
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -40,7 +40,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/generated_from_requests_appium_browser_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_appium_browser_4_10.py
@@ -22,6 +22,28 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import wait_for, get_locator, waiter
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
 
 class TestLocScAppium(unittest.TestCase):
 
@@ -34,27 +56,6 @@ class TestLocScAppium(unittest.TestCase):
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--disable-gpu')
         options.set_capability('unhandledPromptBehavior', 'ignore')
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         options.set_capability('browserName', 'chrome')
         options.set_capability('deviceName', '')
         options.set_capability('platformName', 'android')

--- a/tests/resources/selenium/generated_from_requests_appium_browser_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_appium_browser_4_10.py
@@ -20,10 +20,10 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import wait_for, get_locator, waiter
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import wait_for, get_locator, waiter
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -40,7 +40,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/generated_from_requests_flow_markers.py
+++ b/tests/resources/selenium/generated_from_requests_flow_markers.py
@@ -20,10 +20,10 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import add_flow_markers, get_locator, wait_for, waiter
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import add_flow_markers, get_locator, wait_for, waiter
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -40,7 +40,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/generated_from_requests_flow_markers.py
+++ b/tests/resources/selenium/generated_from_requests_flow_markers.py
@@ -22,6 +22,29 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import add_flow_markers, get_locator, wait_for, waiter
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
+
 class TestLocSc(unittest.TestCase):
 
     def setUp(self):
@@ -33,27 +56,6 @@ class TestLocSc(unittest.TestCase):
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--disable-gpu')
         options.set_capability('unhandledPromptBehavior', 'ignore')
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         self.driver = webdriver.Chrome(
             service_log_path='/somewhere/webdriver.log',
             options=options)

--- a/tests/resources/selenium/generated_from_requests_flow_markers_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_flow_markers_4_10.py
@@ -21,10 +21,10 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import add_flow_markers, get_locator, wait_for, waiter
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import add_flow_markers, get_locator, wait_for, waiter
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -41,7 +41,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/generated_from_requests_flow_markers_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_flow_markers_4_10.py
@@ -23,6 +23,29 @@ from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import add_flow_markers, get_locator, wait_for, waiter
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
+
 class TestLocSc(unittest.TestCase):
 
     def setUp(self):
@@ -34,27 +57,6 @@ class TestLocSc(unittest.TestCase):
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--disable-gpu')
         options.set_capability('unhandledPromptBehavior', 'ignore')
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         service = Service(service_args=['--log-path=/somewhere/webdriver.log'])
         self.driver = webdriver.Chrome(service=service, options=options)
         self.driver.implicitly_wait(timeout)

--- a/tests/resources/selenium/generated_from_requests_foreach.py
+++ b/tests/resources/selenium/generated_from_requests_foreach.py
@@ -22,6 +22,29 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import waiter, get_elements, get_locator
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
+
 class TestLocSc(unittest.TestCase):
 
     def setUp(self):
@@ -33,27 +56,6 @@ class TestLocSc(unittest.TestCase):
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--disable-gpu')
         options.set_capability('unhandledPromptBehavior', 'ignore')
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         self.driver = webdriver.Chrome(
             service_log_path='/somewhere/webdriver.log',
             options=options)

--- a/tests/resources/selenium/generated_from_requests_foreach.py
+++ b/tests/resources/selenium/generated_from_requests_foreach.py
@@ -20,10 +20,10 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import waiter, get_elements, get_locator
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import waiter, get_elements, get_locator
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -40,7 +40,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/generated_from_requests_foreach_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_foreach_4_10.py
@@ -23,6 +23,29 @@ from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import waiter, get_elements, get_locator
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
+
 class TestLocSc(unittest.TestCase):
 
     def setUp(self):
@@ -34,27 +57,6 @@ class TestLocSc(unittest.TestCase):
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--disable-gpu')
         options.set_capability('unhandledPromptBehavior', 'ignore')
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         service = Service(service_args=['--log-path=/somewhere/webdriver.log'])
         self.driver = webdriver.Chrome(service=service, options=options)
         self.driver.implicitly_wait(timeout)

--- a/tests/resources/selenium/generated_from_requests_foreach_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_foreach_4_10.py
@@ -21,10 +21,10 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import waiter, get_elements, get_locator
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import waiter, get_elements, get_locator
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -41,7 +41,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/generated_from_requests_if_then_else.py
+++ b/tests/resources/selenium/generated_from_requests_if_then_else.py
@@ -20,10 +20,10 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import waiter, get_locator
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import waiter, get_locator
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -40,7 +40,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/generated_from_requests_if_then_else.py
+++ b/tests/resources/selenium/generated_from_requests_if_then_else.py
@@ -22,6 +22,29 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import waiter, get_locator
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
+
 class TestLocSc(unittest.TestCase):
 
     def setUp(self):
@@ -33,27 +56,6 @@ class TestLocSc(unittest.TestCase):
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--disable-gpu')
         options.set_capability('unhandledPromptBehavior', 'ignore')
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         self.driver = webdriver.Chrome(
             service_log_path='/somewhere/webdriver.log',
             options=options)

--- a/tests/resources/selenium/generated_from_requests_if_then_else_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_if_then_else_4_10.py
@@ -23,6 +23,29 @@ from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import waiter, get_locator
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
+
 class TestLocSc(unittest.TestCase):
 
     def setUp(self):
@@ -34,27 +57,6 @@ class TestLocSc(unittest.TestCase):
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--disable-gpu')
         options.set_capability('unhandledPromptBehavior', 'ignore')
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         service = Service(service_args=['--log-path=/somewhere/webdriver.log'])
         self.driver = webdriver.Chrome(service=service, options=options)
         self.driver.implicitly_wait(timeout)

--- a/tests/resources/selenium/generated_from_requests_if_then_else_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_if_then_else_4_10.py
@@ -21,10 +21,10 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import waiter, get_locator
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import waiter, get_locator
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -41,7 +41,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/generated_from_requests_loop_variables.py
+++ b/tests/resources/selenium/generated_from_requests_loop_variables.py
@@ -20,10 +20,10 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import get_loop_range, get_locator, waiter
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import get_loop_range, get_locator, waiter
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -40,7 +40,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/generated_from_requests_loop_variables.py
+++ b/tests/resources/selenium/generated_from_requests_loop_variables.py
@@ -22,6 +22,29 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import get_loop_range, get_locator, waiter
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
+
 class TestLocSc(unittest.TestCase):
 
     def setUp(self):
@@ -29,27 +52,6 @@ class TestLocSc(unittest.TestCase):
 
         timeout = 30.0
         options = webdriver.FirefoxOptions()
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         profile = webdriver.FirefoxProfile()
         profile.set_preference('webdriver.log.file', '/somewhere/webdriver.log')
         options.set_capability('unhandledPromptBehavior', 'ignore')

--- a/tests/resources/selenium/generated_from_requests_loop_variables_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_loop_variables_4_10.py
@@ -22,6 +22,29 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import get_loop_range, get_locator, waiter
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
+
 class TestLocSc(unittest.TestCase):
 
     def setUp(self):
@@ -29,27 +52,6 @@ class TestLocSc(unittest.TestCase):
 
         timeout = 30.0
         options = webdriver.FirefoxOptions()
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         profile = webdriver.FirefoxProfile()
         profile.set_preference('webdriver.log.file', '/somewhere/webdriver.log')
         options.profile = profile

--- a/tests/resources/selenium/generated_from_requests_loop_variables_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_loop_variables_4_10.py
@@ -20,10 +20,10 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import get_loop_range, get_locator, waiter
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import get_loop_range, get_locator, waiter
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -40,7 +40,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/generated_from_requests_remote.py
+++ b/tests/resources/selenium/generated_from_requests_remote.py
@@ -20,10 +20,10 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import wait_for, waiter, get_locator, add_flow_markers
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import wait_for, waiter, get_locator, add_flow_markers
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -40,7 +40,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/generated_from_requests_remote.py
+++ b/tests/resources/selenium/generated_from_requests_remote.py
@@ -22,6 +22,29 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import wait_for, waiter, get_locator, add_flow_markers
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
+
 class TestLocScRemote(unittest.TestCase):
 
     def setUp(self):
@@ -29,27 +52,6 @@ class TestLocScRemote(unittest.TestCase):
 
         timeout = 3.5
         options = webdriver.FirefoxOptions()
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         options.set_capability('app', '')
         options.set_capability('browserName', 'firefox')
         options.set_capability('deviceName', '')

--- a/tests/resources/selenium/generated_from_requests_remote_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_remote_4_10.py
@@ -20,10 +20,10 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import wait_for, waiter, get_locator, add_flow_markers
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import wait_for, waiter, get_locator, add_flow_markers
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -40,7 +40,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/generated_from_requests_remote_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_remote_4_10.py
@@ -22,6 +22,29 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import wait_for, waiter, get_locator, add_flow_markers
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
+
 class TestLocScRemote(unittest.TestCase):
 
     def setUp(self):
@@ -29,27 +52,6 @@ class TestLocScRemote(unittest.TestCase):
 
         timeout = 3.5
         options = webdriver.FirefoxOptions()
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         options.set_capability('app', '')
         options.set_capability('browserName', 'firefox')
         options.set_capability('deviceName', '')

--- a/tests/resources/selenium/generated_from_requests_report_inside_actions.py
+++ b/tests/resources/selenium/generated_from_requests_report_inside_actions.py
@@ -24,6 +24,28 @@ from bzt.resources.selenium_extras import dialogs_answer_on_next_confirm, open_w
 reader_1 = apiritif.CSVReaderPerThread('first.csv', loop=True)
 reader_2 = apiritif.CSVReaderPerThread('second.csv', loop=False)
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
 
 class TestLocSc(unittest.TestCase):
 
@@ -36,27 +58,6 @@ class TestLocSc(unittest.TestCase):
  
         timeout = 3.5
         options = webdriver.FirefoxOptions()
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         profile = webdriver.FirefoxProfile()
         profile.set_preference('webdriver.log.file', '/somewhere/webdriver.log')
         options.set_capability('unhandledPromptBehavior', 'ignore')

--- a/tests/resources/selenium/generated_from_requests_report_inside_actions.py
+++ b/tests/resources/selenium/generated_from_requests_report_inside_actions.py
@@ -20,12 +20,12 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
 from bzt.resources.selenium_extras import dialogs_answer_on_next_confirm, open_window, close_window, switch_frame, get_loop_range, get_locator, wait_for, dialogs_answer_on_next_alert, waiter, dialogs_get_next_prompt, dialogs_get_next_alert, dialogs_answer_on_next_prompt, dialogs_replace, switch_window, dialogs_get_next_confirm
 reader_1 = apiritif.CSVReaderPerThread('first.csv', loop=True)
 reader_2 = apiritif.CSVReaderPerThread('second.csv', loop=False)
 
-from selenium.webdriver.remote.remote_connection import RemoteConnection
-import copy
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -42,7 +42,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/generated_from_requests_shadow.py
+++ b/tests/resources/selenium/generated_from_requests_shadow.py
@@ -22,6 +22,29 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import find_element_by_shadow, waiter, wait_for, get_locator
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
+
 class TestLocSc(unittest.TestCase):
 
     def setUp(self):
@@ -33,27 +56,6 @@ class TestLocSc(unittest.TestCase):
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--disable-gpu')
         options.set_capability('unhandledPromptBehavior', 'ignore')
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         self.driver = webdriver.Chrome(service_log_path='/somewhere/webdriver.log', options=options)
         self.driver.implicitly_wait(timeout)
         apiritif.put_into_thread_store(timeout=timeout, func_mode=False, driver=self.driver, windows={},

--- a/tests/resources/selenium/generated_from_requests_shadow.py
+++ b/tests/resources/selenium/generated_from_requests_shadow.py
@@ -20,10 +20,10 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import find_element_by_shadow, waiter, wait_for, get_locator
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import find_element_by_shadow, waiter, wait_for, get_locator
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -40,7 +40,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/generated_from_requests_shadow_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_shadow_4_10.py
@@ -21,10 +21,10 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import find_element_by_shadow, waiter, wait_for, get_locator
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import find_element_by_shadow, waiter, wait_for, get_locator
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -41,7 +41,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/generated_from_requests_shadow_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_shadow_4_10.py
@@ -23,6 +23,29 @@ from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import find_element_by_shadow, waiter, wait_for, get_locator
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
+
 class TestLocSc(unittest.TestCase):
 
     def setUp(self):
@@ -34,27 +57,6 @@ class TestLocSc(unittest.TestCase):
         options.add_argument('--disable-dev-shm-usage')
         options.add_argument('--disable-gpu')
         options.set_capability('unhandledPromptBehavior', 'ignore')
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         service = Service(service_args=['--log-path=/somewhere/webdriver.log'])
         self.driver = webdriver.Chrome(service=service, options=options)
         self.driver.implicitly_wait(timeout)

--- a/tests/resources/selenium/generated_from_requests_td_publish.py
+++ b/tests/resources/selenium/generated_from_requests_td_publish.py
@@ -20,11 +20,11 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
 from bzt.resources.selenium_extras import get_current_iteration, get_locator, waiter
 from bzt.resources.bzm_extras import BzmExtras
 
-from selenium.webdriver.remote.remote_connection import RemoteConnection
-import copy
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -41,7 +41,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/generated_from_requests_td_publish.py
+++ b/tests/resources/selenium/generated_from_requests_td_publish.py
@@ -23,6 +23,29 @@ from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import get_current_iteration, get_locator, waiter
 from bzt.resources.bzm_extras import BzmExtras
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
+
 class TestPublishSc(unittest.TestCase):
 
     def setUp(self):
@@ -30,27 +53,6 @@ class TestPublishSc(unittest.TestCase):
         
         timeout = 30.0
         options = webdriver.FirefoxOptions()
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         profile = webdriver.FirefoxProfile()
         profile.set_preference('webdriver.log.file', '/somewhere/webdriver.log')
         options.set_capability('unhandledPromptBehavior', 'ignore')

--- a/tests/resources/selenium/generated_from_requests_v2.py
+++ b/tests/resources/selenium/generated_from_requests_v2.py
@@ -23,6 +23,29 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import dialogs_answer_on_next_confirm, dialogs_get_next_prompt, dialogs_get_next_alert, dialogs_answer_on_next_alert, wait_for, action_start, get_locator, action_end, waiter, dialogs_answer_on_next_prompt, dialogs_replace, switch_frame, open_window, close_window, dialogs_get_next_confirm, switch_window
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
+
 class TestLocSc(unittest.TestCase):
 
     def setUp(self):
@@ -33,27 +56,6 @@ class TestLocSc(unittest.TestCase):
 
             timeout = 3.5
             options = webdriver.FirefoxOptions()
-            from selenium.webdriver.remote.remote_connection import RemoteConnection
-            import copy
-            _original_execute = RemoteConnection.execute
-
-            def execute_with_retries(self, command, params=None):
-                params_copy = copy.deepcopy(params)
-                retries = 3
-                delay = 2
-                last_exc = None
-                for attempt in range(retries):
-                    try:
-                        if (params != params_copy):
-                            return _original_execute(self, command, params_copy)
-                        else:
-                            return _original_execute(self, command, params)
-                    except Exception as e:
-                        last_exc = e
-                        print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                        sleep(delay)
-                raise last_exc
-            RemoteConnection.execute = execute_with_retries
             profile = webdriver.FirefoxProfile()
             profile.set_preference('webdriver.log.file', '/somewhere/webdriver.log')
             options.set_capability('unhandledPromptBehavior', 'ignore')

--- a/tests/resources/selenium/generated_from_requests_v2.py
+++ b/tests/resources/selenium/generated_from_requests_v2.py
@@ -21,10 +21,10 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import dialogs_answer_on_next_confirm, dialogs_get_next_prompt, dialogs_get_next_alert, dialogs_answer_on_next_alert, wait_for, action_start, get_locator, action_end, waiter, dialogs_answer_on_next_prompt, dialogs_replace, switch_frame, open_window, close_window, dialogs_get_next_confirm, switch_window
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import dialogs_answer_on_next_confirm, dialogs_get_next_prompt, dialogs_get_next_alert, dialogs_answer_on_next_alert, wait_for, action_start, get_locator, action_end, waiter, dialogs_answer_on_next_prompt, dialogs_replace, switch_frame, open_window, close_window, dialogs_get_next_confirm, switch_window
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -41,7 +41,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/generated_from_requests_v2_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_v2_4_10.py
@@ -23,6 +23,29 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import dialogs_answer_on_next_confirm, dialogs_get_next_prompt, dialogs_get_next_alert, dialogs_answer_on_next_alert, wait_for, action_start, get_locator, action_end, waiter, dialogs_answer_on_next_prompt, dialogs_replace, switch_frame, open_window, close_window, dialogs_get_next_confirm, switch_window
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
+
 class TestLocSc(unittest.TestCase):
 
     def setUp(self):
@@ -33,27 +56,6 @@ class TestLocSc(unittest.TestCase):
 
             timeout = 3.5
             options = webdriver.FirefoxOptions()
-            from selenium.webdriver.remote.remote_connection import RemoteConnection
-            import copy
-            _original_execute = RemoteConnection.execute
-
-            def execute_with_retries(self, command, params=None):
-                params_copy = copy.deepcopy(params)
-                retries = 3
-                delay = 2
-                last_exc = None
-                for attempt in range(retries):
-                    try:
-                        if (params != params_copy):
-                            return _original_execute(self, command, params_copy)
-                        else:
-                            return _original_execute(self, command, params)
-                    except Exception as e:
-                        last_exc = e
-                        print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                        sleep(delay)
-                raise last_exc
-            RemoteConnection.execute = execute_with_retries
             profile = webdriver.FirefoxProfile()
             profile.set_preference('webdriver.log.file', '/somewhere/webdriver.log')
             options.set_capability('unhandledPromptBehavior', 'ignore')

--- a/tests/resources/selenium/generated_from_requests_v2_4_10.py
+++ b/tests/resources/selenium/generated_from_requests_v2_4_10.py
@@ -21,10 +21,10 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import dialogs_answer_on_next_confirm, dialogs_get_next_prompt, dialogs_get_next_alert, dialogs_answer_on_next_alert, wait_for, action_start, get_locator, action_end, waiter, dialogs_answer_on_next_prompt, dialogs_replace, switch_frame, open_window, close_window, dialogs_get_next_confirm, switch_window
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import dialogs_answer_on_next_confirm, dialogs_get_next_prompt, dialogs_get_next_alert, dialogs_answer_on_next_alert, wait_for, action_start, get_locator, action_end, waiter, dialogs_answer_on_next_prompt, dialogs_replace, switch_frame, open_window, close_window, dialogs_get_next_confirm, switch_window
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -41,7 +41,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/loop_over_data_all.py
+++ b/tests/resources/selenium/loop_over_data_all.py
@@ -20,11 +20,11 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
 from bzt.resources.selenium_extras import get_csv_reader_for_entity_loop, waiter, get_locator
 reader_1 = apiritif.CSVReaderPerThread('/somewhere/cities.csv', fieldnames=['name', ' country'], loop=True, quoted=False, delimiter=',', encoding='utf-8')
 
-from selenium.webdriver.remote.remote_connection import RemoteConnection
-import copy
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -41,7 +41,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/loop_over_data_all.py
+++ b/tests/resources/selenium/loop_over_data_all.py
@@ -23,6 +23,28 @@ from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import get_csv_reader_for_entity_loop, waiter, get_locator
 reader_1 = apiritif.CSVReaderPerThread('/somewhere/cities.csv', fieldnames=['name', ' country'], loop=True, quoted=False, delimiter=',', encoding='utf-8')
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
 
 class TestScenario1(unittest.TestCase):
 
@@ -33,27 +55,6 @@ class TestScenario1(unittest.TestCase):
 
         timeout = 30.0
         options = webdriver.FirefoxOptions()
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         profile = webdriver.FirefoxProfile()
         profile.set_preference('webdriver.log.file', '/somewhere/webdriver.log')
         options.set_capability('unhandledPromptBehavior', 'ignore')

--- a/tests/resources/selenium/loop_over_data_no_indexes.py
+++ b/tests/resources/selenium/loop_over_data_no_indexes.py
@@ -20,11 +20,11 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
 from bzt.resources.selenium_extras import waiter, get_csv_reader_for_entity_loop, get_locator
 reader_1 = apiritif.CSVReaderPerThread('/somewhere/cities.csv', fieldnames=['name', ' country'], loop=True, quoted=False, delimiter=',', encoding='utf-8')
 
-from selenium.webdriver.remote.remote_connection import RemoteConnection
-import copy
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -41,7 +41,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/loop_over_data_no_indexes.py
+++ b/tests/resources/selenium/loop_over_data_no_indexes.py
@@ -23,6 +23,28 @@ from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import waiter, get_csv_reader_for_entity_loop, get_locator
 reader_1 = apiritif.CSVReaderPerThread('/somewhere/cities.csv', fieldnames=['name', ' country'], loop=True, quoted=False, delimiter=',', encoding='utf-8')
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
 
 class TestScenario1(unittest.TestCase):
 
@@ -33,27 +55,6 @@ class TestScenario1(unittest.TestCase):
 
         timeout = 30.0
         options = webdriver.FirefoxOptions()
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         profile = webdriver.FirefoxProfile()
         profile.set_preference('webdriver.log.file', '/somewhere/webdriver.log')
         options.set_capability('unhandledPromptBehavior', 'ignore')

--- a/tests/resources/selenium/loop_over_data_only_from_ix.py
+++ b/tests/resources/selenium/loop_over_data_only_from_ix.py
@@ -20,11 +20,11 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
 from bzt.resources.selenium_extras import get_locator, get_csv_reader_for_entity_loop, waiter
 reader_1 = apiritif.CSVReaderPerThread('/somewhere/cities.csv', fieldnames=['name', ' country'], loop=True, quoted=False, delimiter=',', encoding='utf-8')
 
-from selenium.webdriver.remote.remote_connection import RemoteConnection
-import copy
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -41,7 +41,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/loop_over_data_only_from_ix.py
+++ b/tests/resources/selenium/loop_over_data_only_from_ix.py
@@ -23,6 +23,28 @@ from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import get_locator, get_csv_reader_for_entity_loop, waiter
 reader_1 = apiritif.CSVReaderPerThread('/somewhere/cities.csv', fieldnames=['name', ' country'], loop=True, quoted=False, delimiter=',', encoding='utf-8')
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
 
 class TestScenario1(unittest.TestCase):
 
@@ -33,27 +55,6 @@ class TestScenario1(unittest.TestCase):
 
         timeout = 30.0
         options = webdriver.FirefoxOptions()
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         profile = webdriver.FirefoxProfile()
         profile.set_preference('webdriver.log.file', '/somewhere/webdriver.log')
         options.set_capability('unhandledPromptBehavior', 'ignore')

--- a/tests/resources/selenium/loop_over_data_only_to_ix.py
+++ b/tests/resources/selenium/loop_over_data_only_to_ix.py
@@ -20,11 +20,11 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
 from bzt.resources.selenium_extras import waiter, get_csv_reader_for_entity_loop, get_locator
 reader_1 = apiritif.CSVReaderPerThread('/somewhere/cities.csv', fieldnames=['name', ' country'], loop=True, quoted=False, delimiter=',', encoding='utf-8')
 
-from selenium.webdriver.remote.remote_connection import RemoteConnection
-import copy
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -41,7 +41,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/loop_over_data_only_to_ix.py
+++ b/tests/resources/selenium/loop_over_data_only_to_ix.py
@@ -23,6 +23,28 @@ from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import waiter, get_csv_reader_for_entity_loop, get_locator
 reader_1 = apiritif.CSVReaderPerThread('/somewhere/cities.csv', fieldnames=['name', ' country'], loop=True, quoted=False, delimiter=',', encoding='utf-8')
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
 
 class TestScenario1(unittest.TestCase):
 
@@ -33,27 +55,6 @@ class TestScenario1(unittest.TestCase):
 
         timeout = 30.0
         options = webdriver.FirefoxOptions()
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         profile = webdriver.FirefoxProfile()
         profile.set_preference('webdriver.log.file', '/somewhere/webdriver.log')
         options.set_capability('unhandledPromptBehavior', 'ignore')

--- a/tests/resources/selenium/test_action_start.py
+++ b/tests/resources/selenium/test_action_start.py
@@ -22,6 +22,29 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from bzt.resources.selenium_extras import waiter, action_start, action_end, get_locator
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
+
 class TestBlazedemoTestSelenium(unittest.TestCase):
 
     def setUp(self):
@@ -32,27 +55,6 @@ class TestBlazedemoTestSelenium(unittest.TestCase):
             
             timeout = 30.0
             options = webdriver.FirefoxOptions()
-            from selenium.webdriver.remote.remote_connection import RemoteConnection
-            import copy
-            _original_execute = RemoteConnection.execute
-
-            def execute_with_retries(self, command, params=None):
-                params_copy = copy.deepcopy(params)
-                retries = 3
-                delay = 2
-                last_exc = None
-                for attempt in range(retries):
-                    try:
-                        if (params != params_copy):
-                            return _original_execute(self, command, params_copy)
-                        else:
-                            return _original_execute(self, command, params)
-                    except Exception as e:
-                        last_exc = e
-                        print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                        sleep(delay)
-                raise last_exc
-            RemoteConnection.execute = execute_with_retries
             profile = webdriver.FirefoxProfile()
             profile.set_preference('webdriver.log.file', '/somewhere/webdriver.log')
             options.set_capability('unhandledPromptBehavior', 'ignore')

--- a/tests/resources/selenium/test_action_start.py
+++ b/tests/resources/selenium/test_action_start.py
@@ -20,10 +20,10 @@ from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from bzt.resources.selenium_extras import waiter, action_start, action_end, get_locator
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import waiter, action_start, action_end, get_locator
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -40,7 +40,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/test_nfc.py
+++ b/tests/resources/selenium/test_nfc.py
@@ -22,6 +22,29 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import get_locator, waiter
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
+
 class TestSc1(unittest.TestCase):
 
     def setUp(self):
@@ -29,27 +52,6 @@ class TestSc1(unittest.TestCase):
 
         timeout = 2.0
         options = webdriver.FirefoxOptions()
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         profile = webdriver.FirefoxProfile()
         profile.set_preference('webdriver.log.file', '/somewhere/webdriver.log')
         options.set_capability('unhandledPromptBehavior', 'ignore')

--- a/tests/resources/selenium/test_nfc.py
+++ b/tests/resources/selenium/test_nfc.py
@@ -20,10 +20,10 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import get_locator, waiter
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import get_locator, waiter
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -40,7 +40,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 

--- a/tests/resources/selenium/test_nfc_4_10.py
+++ b/tests/resources/selenium/test_nfc_4_10.py
@@ -22,6 +22,29 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
 from bzt.resources.selenium_extras import get_locator, waiter
 
+from selenium.webdriver.remote.remote_connection import RemoteConnection
+import copy
+_original_execute = RemoteConnection.execute
+
+def execute_with_retries(self, command, params=None):
+    params_copy = copy.deepcopy(params)
+    retries = 3
+    delay = 2
+    last_exc = None
+    for attempt in range(retries):
+        try:
+            if (params != params_copy):
+                return _original_execute(self, command, params_copy)
+            else:
+                return _original_execute(self, command, params)
+        except Exception as e:
+            last_exc = e
+            print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
+            sleep(delay)
+    raise last_exc
+RemoteConnection.execute = execute_with_retries
+
+
 class TestSc1(unittest.TestCase):
 
     def setUp(self):
@@ -29,27 +52,6 @@ class TestSc1(unittest.TestCase):
 
         timeout = 2.0
         options = webdriver.FirefoxOptions()
-        from selenium.webdriver.remote.remote_connection import RemoteConnection
-        import copy
-        _original_execute = RemoteConnection.execute
-
-        def execute_with_retries(self, command, params=None):
-            params_copy = copy.deepcopy(params)
-            retries = 3
-            delay = 2
-            last_exc = None
-            for attempt in range(retries):
-                try:
-                    if (params != params_copy):
-                        return _original_execute(self, command, params_copy)
-                    else:
-                        return _original_execute(self, command, params)
-                except Exception as e:
-                    last_exc = e
-                    print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-                    sleep(delay)
-            raise last_exc
-        RemoteConnection.execute = execute_with_retries
         profile = webdriver.FirefoxProfile()
         profile.set_preference('webdriver.log.file', '/somewhere/webdriver.log')
         options.profile = profile

--- a/tests/resources/selenium/test_nfc_4_10.py
+++ b/tests/resources/selenium/test_nfc_4_10.py
@@ -20,10 +20,10 @@ from selenium.webdriver.support import expected_conditions as econd
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.options import ArgOptions
-from bzt.resources.selenium_extras import get_locator, waiter
-
 from selenium.webdriver.remote.remote_connection import RemoteConnection
 import copy
+from bzt.resources.selenium_extras import get_locator, waiter
+
 _original_execute = RemoteConnection.execute
 
 def execute_with_retries(self, command, params=None):
@@ -40,7 +40,8 @@ def execute_with_retries(self, command, params=None):
         except Exception as e:
             last_exc = e
             print(f'[Retry] RemoteConnection.execute failed on attempt {(attempt + 1)}: {e}')
-            sleep(delay)
+            if (attempt < (retries - 1)):
+                sleep(delay)
     raise last_exc
 RemoteConnection.execute = execute_with_retries
 


### PR DESCRIPTION
- Jira: https://perforce.atlassian.net/browse/MOB-43620
- Every time a test iteration started, the retry wrapper re-wrapped itself on top of the previous one. After 55 iterations, when Chrome finally crashed, the retry logic called itself 55 layers deep — each layer retrying 3 times — and the test hung for 50 minutes instead of failing cleanly. The fix just moves the wrapper setup to run once when the script loads, so it never stacks.
- Tested locally via jenkins build: https://blazect-jenkins.blazemeter.com/job/taurus-branch-builder/547/
- Regression suites on Dev Env
  - Scriptless: https://blazect-jenkins.blazemeter.com/job/guiTests_Scriptless/3052/
  - API GRID Tests: https://blazect-jenkins.blazemeter.com/job/API_TESTS_GRID/2520/