### PR TITLE
[MOB-38657] Functional + BPT: Assert Dialog and Answer Dialog actions do not work

### DIFF
--- a/bzt/resources/selenium_extras.py
+++ b/bzt/resources/selenium_extras.py
@@ -224,26 +224,18 @@ def dialogs_replace():
     _get_driver().execute_script("""
           if (window.__webdriverAlerts) { return; }
           window.__webdriverAlerts = [];
-          window.__webdriverOriginalAlert = window.alert;
           window.__webdriverNextAlert = null;
           window.alert = function(msg) {
-            if (window.__webdriverNextAlert === null) {
-                window.__webdriverOriginalAlert(msg);
-            }
-            window.__webdriverNextAlert = null; 
-            window.__webdriverAlerts.push(msg); 
+            window.__webdriverNextAlert = null;
+            window.__webdriverAlerts.push(msg);
           };
           window.__webdriverConfirms = [];
           window.__webdriverNextConfirm = null;
-          window.__webdriverPrevConfirm = window.confirm;
           window.confirm = function(msg) {
             window.__webdriverConfirms.push(msg);
             var res = window.__webdriverNextConfirm;
-            if (res === null) {
-                return window.__webdriverPrevConfirm(msg);
-            }
             window.__webdriverNextConfirm = null;
-            return res;
+            return res !== null ? res : true;
           };
           window.__webdriverPrompts = [];
           window.__webdriverNextPrompts = true;


### PR DESCRIPTION
- Jira: https://perforce.atlassian.net/browse/MOB-38657
- Updated dialogs_replace() in bzt/resources/selenium_extras.py to stop calling the original native dialog. The override now just captures the message in a JS array, which is all it ever needed to do. The native pop-up was never useful in automated execution.
- The fix is pure JS, works across all browsers, and only affects tests using dialog actions. Verified on DEV BZM — tests pass.
- Tested via jira: https://blazect-jenkins.blazemeter.com/job/taurus-branch-builder/550/
- Regression Tests on DEV BZM
   - Scriptless: https://blazect-jenkins.blazemeter.com/job/guiTests_Scriptless/3057/
   - API GRID Test:  https://blazect-jenkins.blazemeter.com/job/API_TESTS_GRID/2526/

