### PR TITLE
MOB-49408: MOB-49406: Add empty string as return code to fix averages…

### DIFF
--- a/bzt/modules/javascript.py
+++ b/bzt/modules/javascript.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 import json
 import os
+import re
 from abc import abstractmethod
 
 from bzt import TaurusConfigError, ToolError
@@ -217,6 +218,12 @@ class PlaywrightLogReader(ResultsReader):
             return t / 1000.0
         return t
 
+    def _strip_ansi(self, text):
+        if not text:
+            return text
+        ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+        return ansi_escape.sub('', text)
+
     def _read(self, final_pass=False):
         for line in self.jsonl_reader.read(final_pass):
             content = json.loads(line)
@@ -225,9 +232,9 @@ class PlaywrightLogReader(ResultsReader):
                    self._safe_ms_to_s(content.get("duration")),
                    self._safe_ms_to_s(content.get("connectTime", None)),
                    self._safe_ms_to_s(content.get("latency",  None)),
-                   None,
-                   content.get("error", None),
-                   content.get("runDetails", None),
+                   "", # return code
+                   self._strip_ansi(content.get("error", None)),
+                   self._strip_ansi(content.get("runDetails", None)),
                    content.get("byte_count", 0))
 
 

--- a/tests/unit/modules/_selenium/test_javascript.py
+++ b/tests/unit/modules/_selenium/test_javascript.py
@@ -7,7 +7,7 @@ import bzt
 
 from bzt import ToolError
 from bzt.modules.javascript import NPMPackage, JavaScriptExecutor, NewmanExecutor, Mocha, JSSeleniumWebdriver, \
-    PlaywrightTester, PLAYWRIGHT, PlaywrightTestPackage
+    PlaywrightTester, PLAYWRIGHT, PlaywrightTestPackage, PlaywrightLogReader
 from bzt.utils import get_full_path, EXE_SUFFIX
 
 from tests.unit import RESOURCES_DIR, BZTestCase, EngineEmul
@@ -238,9 +238,9 @@ class TestPlaywrightExecutor(SeleniumTestCase):
         samples = [sample for sample in self.obj.runner.reader._read(final_pass=True)]
         self.assertEqual(2, len(samples))
         self.assertEqual(samples[0][1], "destination of week")
-        self.assertEqual(samples[0][6], None)
+        self.assertEqual(samples[0][6], "")
         self.assertEqual(samples[1][1], "reserve flight")
-        self.assertEqual(samples[1][6], None)
+        self.assertEqual(samples[1][6], "")
 
     def test_command_line(self):
         self.simple_run({
@@ -504,6 +504,20 @@ class TestPlaywrightExecutor(SeleniumTestCase):
         })
         self.obj.runner.reader = None
         self.assertFalse(self.obj.runner._tests_ran())
+
+
+class TestPlaywrightLogReaderStripAnsi(BZTestCase):
+    def setUp(self):
+        super().setUp()
+        self.reader = PlaywrightLogReader("nonexistent.jsonl", self.log)
+
+    def test_strip_ansi_empty_input_returned_unchanged(self):
+        self.assertIsNone(self.reader._strip_ansi(None))
+        self.assertEqual("", self.reader._strip_ansi(""))
+
+    def test_strip_ansi_removes_ansi_escapes(self):
+        colored = "\x1b[31mfail\x1b[0m at \x1b[1;33mline 5\x1b[0m"
+        self.assertEqual("fail at line 5", self.reader._strip_ansi(colored))
 
 
 class TestPlaywrightInstallation(BZTestCase):


### PR DESCRIPTION
… and no error on Errors tab

Also stripped ANSI coloring from playwright to have text more readable in logs and on Errors tab
