### PR TITLE
CVE fixes - 2026-06-18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,6 +120,11 @@ RUN current_version=$(dpkg -l firefox | tail -1 | awk '{print $3}' | grep -oP '[
     snap_version="1:${current_version}snap1-0ubuntu1" && \
     sed -i "/^Package: firefox$/,/^$/{s/^Version: .*/Version: $snap_version/}" /var/lib/dpkg/status
 
+# Fix OS package CVEs: pull latest security updates for vulnerable libs (gnutls28, libgcrypt20, librabbitmq)
+RUN apt-get update && \
+    apt-get install -y --only-upgrade libgnutls30 libgcrypt20 librabbitmq4 && \
+    rm -rf /var/lib/apt/lists/*
+
 # Set up Python alternatives
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_VERSION} 1
@@ -153,6 +158,11 @@ RUN git clone --depth 1 https://github.com/rbenv/rbenv.git ${RBENV_ROOT} && \
 RUN eval "$(${RBENV_ROOT}/bin/rbenv init -)" && \
     rbenv install ${RUBY_VERSION} && \
     rbenv global ${RUBY_VERSION} && \
+    rbenv rehash
+
+# Fix CVE-2026-42257 / CVE-2026-42258 (net-imap) and erb gem CVEs: update vulnerable default gems
+RUN eval "$(${RBENV_ROOT}/bin/rbenv init -)" && \
+    gem update net-imap erb && \
     rbenv rehash
 
 # Set up Ruby alternatives
@@ -216,9 +226,9 @@ RUN npm install newman --prefix /tmp/newman-check --silent \
  && NEWMAN_VERSION=$(node -p "require('/tmp/newman-check/node_modules/newman/package.json').version") \
  && rm -rf /tmp/newman-check \
  && if [ "$NEWMAN_VERSION" = "6.2.2" ] && [ ! -f /root/.bzt/newman/package.json ]; then \
-        echo "Applying Newman dependency overrides for CVE fix (node-forge, flatted, handlebars, lodash, uuid, underscore)" \
+        echo "Applying Newman dependency overrides for CVE fix (node-forge, flatted, handlebars, lodash, uuid, underscore, qs, jose)" \
      && mkdir -p /root/.bzt/newman \
-     && printf '{\n  "overrides": {\n    "node-forge": "^1.4.0",\n    "flatted": "^3.4.2",\n    "handlebars": "^4.7.9",\n    "lodash": "^4.18.1",\n    "uuid": "^11.1.1",\n    "httpntlm": {\n      "underscore": "^1.13.8"\n    }\n  }\n}\n' > /root/.bzt/newman/package.json; \
+     && printf '{\n  "overrides": {\n    "node-forge": "^1.4.0",\n    "flatted": "^3.4.2",\n    "handlebars": "^4.7.9",\n    "lodash": "^4.18.1",\n    "uuid": "^11.1.1",\n    "qs": "^6.15.2",\n    "jose": "^4.15.9",\n    "httpntlm": {\n      "underscore": "^1.13.8"\n    }\n  }\n}\n' > /root/.bzt/newman/package.json; \
     elif [ "$NEWMAN_VERSION" != "6.2.2" ]; then \
         echo "WARNING: Newman $NEWMAN_VERSION found (expected 6.2.2); skipping dependency overrides"; \
     fi
@@ -226,8 +236,8 @@ RUN npm install newman --prefix /tmp/newman-check --silent \
 # Pre-seed Mocha dependency overrides (CVE fix for serialize-javascript)
 RUN mkdir -p /root/.bzt/selenium-taurus/mocha \
  && if [ ! -f /root/.bzt/selenium-taurus/mocha/package.json ]; then \
-        echo "Applying Mocha dependency overrides for CVE fix (serialize-javascript)" \
-     && printf '{\n  "overrides": {\n    "serialize-javascript": "^7.0.5"\n  }\n}\n' > /root/.bzt/selenium-taurus/mocha/package.json; \
+        echo "Applying Mocha dependency overrides for CVE fix (serialize-javascript, diff)" \
+     && printf '{\n  "overrides": {\n    "serialize-javascript": "^7.0.5",\n    "diff": "^5.2.2"\n  }\n}\n' > /root/.bzt/selenium-taurus/mocha/package.json; \
     fi
 
 # Install BZT tools

--- a/bzt/modules/gatling.py
+++ b/bzt/modules/gatling.py
@@ -945,7 +945,8 @@ class Gatling(RequiredTool):
     """
     DOWNLOAD_LINK = "https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle" \
                     "/{version}/gatling-charts-highcharts-bundle-{version}-bundle.zip"
-    VERSION = "3.9.5"
+    # 3.10.5 is the last version distributed as a downloadable bundle ZIP; 3.11.0+ is maven-plugin-only
+    VERSION = "3.10.5"
     LOCAL_PATH = "~/.bzt/gatling-taurus/{version}/bin/gatling{suffix}"
     LOCAL_PATH_MVN = "~/.bzt/gatling-taurus/{version}/gatling{suffix}"
     LOCAL_PATH_MVN_POM = "~/.bzt/gatling-taurus/{version}/pom.xml"

--- a/bzt/modules/jmeter.py
+++ b/bzt/modules/jmeter.py
@@ -1494,7 +1494,7 @@ class JMeter(RequiredTool):
     PLUGINS_MANAGER_LINK = 'https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-manager/{version}/jmeter-plugins-manager-{version}.jar'
     COMMAND_RUNNER_VERSION = "2.3"
     COMMAND_RUNNER_LINK = 'https://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/{version}/cmdrunner-{version}.jar'
-    VERSION = "5.5"
+    VERSION = "5.6.3"
     VERSION_LATEST = "5.6.3"
 
     def __init__(self, config=None, props=None, **kwargs):


### PR DESCRIPTION
## Summary

Automated CVE remediation for `blazemeter/taurus:unstable` from Prisma Cloud scan **build 150** (2026-06-17). Of 288 reported vulnerabilities, this PR applies the subset that can be cleanly fixed in-source/in-Dockerfile and bumps the JMeter/Gatling versions to refresh bundled jars. Remaining items require manual intervention or are infeasible in a standard build (see below).

> ⚠️ Unit tests validate the Python changes only — the Dockerfile changes (gem/npm/apt) are **not** exercised by the unit suite and are verified by the next Prisma scan after merge. Net CVE reduction must be confirmed by re-running `/prisma-taurus` after Jenkins builds a new `unstable` image.

## Auto-fixed CVEs

### Clean dependency fixes (~30 CVEs, incl. 2 critical)

| CVE(s) | Package | Old → New | Severity | Where |
|---|---|---|---|---|
| CVE-2026-42257, CVE-2026-42258 | net-imap (ruby) | 0.5.8 → ≥0.5.15 | **critical** | Dockerfile `gem update` |
| CVE-2026-42246, CVE-2026-42245 | net-imap (ruby) | 0.5.8 → ≥0.5.15 | high | Dockerfile `gem update` |
| CVE-2026-42256, -47240, -47241, -47242 | net-imap (ruby) | 0.5.8 → ≥0.5.15 | medium/low | Dockerfile `gem update` |
| CVE-2026-41316 | erb (ruby) | 4.0.4 → latest | high | Dockerfile `gem update` |
| CVE-2026-8723, CVE-2025-15284 | qs (npm, newman) | 6.14.2/6.5.5 → ^6.15.2 | medium/low | Newman overrides |
| CVE-2024-28176 | jose (npm, newman) | 4.14.4 → ^4.15.9 | medium | Newman overrides |
| CVE-2026-24001 | diff (npm, mocha) | 7.0.0 → ^5.2.2 | low | Mocha overrides |
| CVE-2026-5260, -3832, -3833, -33845, -33846, -42009..42015, -5419 (×13) | gnutls28 | → 3.8.3-1.1ubuntu3.6 | medium | apt --only-upgrade |
| CVE-2023-35789, CVE-2026-44235, CVE-2026-44236 | librabbitmq | → 0.11.0-1ubuntu0.1 | medium/low | apt --only-upgrade |
| CVE-2026-41989 | libgcrypt20 | → 1.10.3-2ubuntu0.1 | medium | apt --only-upgrade |

### Version bumps (refresh bundled jars — partial; net effect confirmed by rescan)

| Tool | Old → New | Notes |
|---|---|---|
| JMeter (default `VERSION`) | 5.5 → 5.6.3 | Refreshes bundled xstream, batik-bridge, jackson-databind, commons-io, etc. log4j/tika **not** cleared (5.6.3 still ships older). |
| Gatling `VERSION` | 3.9.5 → 3.10.5 | Last bundle-ZIP version before 3.11 maven-only switch. Refreshes logback/jackson; netty **not** cleared (needs ≥4.1.135). |

## Deliberately excluded

- **file-type** (newman): 3.9.0 → 16.5.4 is a breaking major-version API change; forcing it via override would break Newman's tree. Needs upstream fix.
- **mesa** (1 medium): uncertain binary package names; skipped to avoid breaking the build.

## NOT fixed — manual intervention required (not in this PR)

- **Ubuntu Pro ESM packages** (~48 CVEs): ffmpeg, gnuplot, openexr, python-pip, qtbase, gst-plugins-bad, fonttools — fixed versions are `+esmN`/`~esm1`, only available with an Ubuntu Pro subscription. Plain `apt-get` cannot install them.
- **k6 Go libs** (9 CVEs): golang.org/x/net, crypto/x509, etc. compiled into `/usr/bin/k6` — require a newer k6 build.
- **Bundled JMeter/Gatling jars** surviving the version bump: log4j (needs 2.25.4), **tika-core/tika-parsers (critical CVE-2025-54988, CVE-2025-66516; need 3.2.2/2.0.0)**, netty (needs ≥4.1.135), batik-transcoder/script (1.17), jackson-core (2.18.6) — require manual jar replacement in the Dockerfile or a larger framework upgrade.

## Next steps

1. Review and merge this PR.
2. Wait for Jenkins to build a new `blazemeter/taurus:unstable` from master.
3. Re-run `/prisma-taurus` to verify the auto-fixed CVEs are resolved.
4. Address the manual-intervention items separately (notably the tika critical jars and the ESM packages / k6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
