### PR TITLE
MOB-51648: CVE fixes - 2026-07-07

### DIFF
--- a/.claude/skills/prisma-taurus/vulnerability_history.md
+++ b/.claude/skills/prisma-taurus/vulnerability_history.md
@@ -368,6 +368,11 @@ The first attempt removed net-imap 0.5.8's gemspec + lib dir but **not** its cac
 - **Ubuntu Pro ESM packages** — fixed version ends in `+esmN` or `~esm1` (e.g. ffmpeg, gnuplot, openexr, qtbase, gst-plugins-bad, fonttools, the apt `python-pip`). Not installable without an Ubuntu Pro subscription; plain `apt-get` fails.
 - **Go libraries compiled into a binary** — e.g. `golang.org/x/net`, `crypto/x509` reported with `Path` `/usr/bin/k6`. Can only change by upgrading the binary's apt package (k6), not by patching the libs.
 
+### Baseline scan job can fail *after* twistcli succeeds — fall back to `taurus.json`
+- The `prisma-cloud-ondemand-scan` pipeline can finish **FAILURE** even though the scan ran fine. Seen 2026-07-07, build #172: twistcli completed and printed the full vulnerability table, but the pipeline then died in its `write_to_csv` post-step with `java.lang.NullPointerException: Cannot get property 'repoTag' on null object` (`WorkflowScript:62`). Result: **no `taurus.csv` artifact was archived.**
+- Don't treat that FAILURE as "scan broken / no data." Check the archived artifacts: twistcli writes `taurus.json` (its `--ci-results-file`) regardless, and it holds the same findings. Fetch `.../<BUILD>/artifact/taurus.json`.
+- `taurus.json` shape: `results[0].entityInfo.vulnerabilities[]` has `cve/severity/cvss/status/packageName/packageVersion/packageType` **but no path**. Recover each finding's `Path` (needed for classification) by joining `(packageName, packageVersion)` to `results[0].entityInfo.packages[].pkgs[]` (grouped by `pkgsType`: package/jar/gem/nodejs/python/nuget/go), each of which carries `path`. OS `package` pkgs have empty paths (→ apt). This reproduces the CSV's Path column.
+
 ### General
 - Always reference the CVE ID in the commit message
 - One CVE/component per commit where possible — broad sweep commits are hard to audit

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,7 +133,11 @@ RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTH
 #   libxml2:                CVE-2026-6653 (-> 2.9.14+dfsg-1.3ubuntu3.8)
 #   libsqlite3-0 (sqlite3): CVE-2026-11822, CVE-2026-11824 (-> 3.45.1-1ubuntu2.6)
 #   libnss3 (nss):          CVE-2026-12318 (-> 2:3.98-1ubuntu0.2)
-#   tar:                    CVE-2026-5704 (-> 1.35+dfsg-3ubuntu0.1)
+#   tar:                    CVE-2026-5704 (-> 1.35+dfsg-3ubuntu0.1), CVE-2025-45582 (-> 1.35+dfsg-3ubuntu0.2)
+#   python3.12:             CVE-2026-6100/9669, CVE-2025-69534, CVE-2026-4786/4519/7774/3276/4224/3644/1299/8328/2297/1502/6019, CVE-2025-13462 (-> 3.12.3-1ubuntu0.15)
+#   gzip:                   CVE-2026-41992, CVE-2026-41991 (-> 1.12-1ubuntu3.2)
+#   libnghttp2-14 (nghttp2):CVE-2026-58055 (-> 1.59.0-1ubuntu0.4)
+#   ncurses libs:           CVE-2025-69720 (-> 6.4+20240113-1ubuntu2.1)
 # (--only-upgrade never installs new packages; absent ones are skipped.)
 # remove each when the base image ships the fixed version natively (CVE drops from baseline scan)
 RUN apt-get update && \
@@ -149,7 +153,16 @@ RUN apt-get update && \
         libxml2 \
         libsqlite3-0 \
         libnss3 \
-        tar && \
+        tar \
+        python3.12 \
+        python3.12-dev \
+        gzip \
+        libnghttp2-14 \
+        libtinfo6 \
+        libncurses6 \
+        libncursesw6 \
+        ncurses-base \
+        ncurses-bin && \
     rm -rf /var/lib/apt/lists/*
 
 # ================================
@@ -190,6 +203,7 @@ RUN update-alternatives --install /usr/local/bin/ruby ruby ${RBENV_ROOT}/shims/r
 # Patch vulnerable Ruby default/bundled gems (CVE fix).
 #   net-imap 0.5.8 -> 0.5.15: CVE-2026-42245/42246/42256/42257/42258/47240/47241/47242 (incl. 2 critical)
 #   erb      4.0.4 -> 4.0.4.1: CVE-2026-41316
+#   json     2.9.1 -> 2.19.9:  CVE-2026-54696
 # These ship with Ruby. Installing the patched gem is NOT enough: Prisma reads the OLD version
 # from THREE places that `gem install`/`gem update` leave behind:
 #   1. the gemspec   -> specifications[/default]/<gem>-<old>.gemspec
@@ -201,17 +215,18 @@ RUN update-alternatives --install /usr/local/bin/ruby ruby ${RBENV_ROOT}/shims/r
 RUN eval "$(${RBENV_ROOT}/bin/rbenv init -)" && \
     gem install net-imap -v 0.5.15 --no-document && \
     gem install erb -v 4.0.4.1 --no-document && \
+    gem install json -v 2.19.9 --no-document && \
     GEMS_DIR="$(ruby -e 'print Gem.dir')" && \
-    for OLD in net-imap-0.5.8 erb-4.0.4; do \
+    for OLD in net-imap-0.5.8 erb-4.0.4 json-2.9.1; do \
         rm -rf "$GEMS_DIR/gems/$OLD" \
                "$GEMS_DIR/specifications/$OLD.gemspec" \
                "$GEMS_DIR/specifications/default/$OLD.gemspec"; \
     done && \
     rm -f "$GEMS_DIR"/cache/*.gem && \
     rbenv rehash && \
-    if find "${RBENV_ROOT}" -name 'net-imap-0.5.8.gem*' -o -name 'erb-4.0.4.gem' -o -name 'erb-4.0.4.gemspec' | grep -q .; then \
+    if find "${RBENV_ROOT}" -name 'net-imap-0.5.8.gem*' -o -name 'erb-4.0.4.gem' -o -name 'erb-4.0.4.gemspec' -o -name 'json-2.9.1.gem' -o -name 'json-2.9.1.gemspec' | grep -q .; then \
         echo 'ERROR: vulnerable Ruby gem version still on disk after patch (build aborted)' >&2; \
-        find "${RBENV_ROOT}" -name 'net-imap-0.5.8.gem*' -o -name 'erb-4.0.4.gem' -o -name 'erb-4.0.4.gemspec' >&2; \
+        find "${RBENV_ROOT}" -name 'net-imap-0.5.8.gem*' -o -name 'erb-4.0.4.gem' -o -name 'erb-4.0.4.gemspec' -o -name 'json-2.9.1.gem' -o -name 'json-2.9.1.gemspec' >&2; \
         exit 1; \
     fi
 


### PR DESCRIPTION
**Jira:** MOB-51648

Fixed 20 of 26 addressable findings (1 self-resolves on rebuild, 5 deferred/skipped for cause).

Verified against the `taurus-branch-builder` image scan (build #573) before opening — integration passed and every fixed package's vulnerable version is confirmed gone from the branch image.

### Fixes confirmed in the image
| CVE(s) | Package | Old → New | Severity |
|---|---|---|---|
| CVE-2026-6100, 9669, CVE-2025-69534, CVE-2026-4786/4519/7774/3276/4224/3644/1299/8328/2297/1502/6019, CVE-2025-13462 | python3.12 (apt) | 3.12.3-1ubuntu0.13 → 0.15 | medium (up to CVSS 9.1) |
| CVE-2026-41992, CVE-2026-41991 | gzip (apt) | 1.12-1ubuntu3.1 → 3.2 | medium |
| CVE-2026-58055 | libnghttp2-14 (apt) | 1.59.0-1ubuntu0.3 → 0.4 | medium |
| CVE-2025-69720 | ncurses libs (apt) | 6.4+20240113-1ubuntu2 → 2.1 | low |
| CVE-2026-54696 | json (Ruby default gem) | 2.9.1 → 2.19.9 | low |

### Branch-scan comparison (build #573)
Baseline (`unstable`, scan #172) **290 → 269 (−21)**. Critical 4→4, high 44→44 (all out of scope), medium 179→160, low 63→61. All 21 targeted findings gone; no fixed package flagged at its old version.

### Self-resolves on next clean build (no change needed)
- CVE-2025-45582 — `tar` → 1.35+dfsg-3ubuntu0.2 (existing unpinned `apt --only-upgrade tar` picks up the newer version).

### Addressable but deferred/skipped for cause (NOT in this PR)
- CVE-2022-36313 — `file-type` (Newman): breaking 3.9.0 → 16/17 major jump would break Newman's dep tree.
- CVE-2026-24001 — `diff` (Mocha): mocha@11 pins `diff ^7`; the fix crosses a major, low value (CVSS 2.7).
- CVE-2026-24049 (`wheel`), CVE-2026-23949 (`jaraco.context`): vendored inside setuptools, low value.
- CVE-2026-45591 — `asp.net-core`: CVSS 0; a full .NET SDK bump is not warranted for a zero-severity finding.

### Not counted (not ours to fix)
- JMeter/Gatling bundled jars (policy — never remediated here): 103
- No released patch (open/needed/deferred): 101
- Ubuntu Pro ESM: 50; k6 Go binary internals: 9; system `pip` (apt can't reach 26.1.2): 1
- Raw scan total for reference only: baseline 290 → branch 269.

Also documents a new operational lesson in `vulnerability_history.md`: the `prisma-cloud-ondemand-scan` job can report FAILURE after twistcli succeeds (its `write_to_csv` post-step crashed on build #172), leaving no `taurus.csv` — fall back to the archived `taurus.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
