### PR TITLE
MOB-52862 Fix chromedriver version check timeout in OPL environments

### DIFF
--- a/bzt/modules/_selenium.py
+++ b/bzt/modules/_selenium.py
@@ -259,9 +259,6 @@ class WebDriver(RequiredTool):
         # version from yml config (override)
         settings_version = settings.get("version")
 
-        # latest if no override in settings
-        latest_version = self._get_latest_version(driver_name)
-
         # try to use latest existed...
         drivers_dir = os.path.join(base_dir, 'drivers', driver_name)
         drivers_dir_content = os.path.exists(drivers_dir) and os.listdir(drivers_dir)
@@ -274,7 +271,12 @@ class WebDriver(RequiredTool):
         # decide, which version to use:
         if not self._is_running_in_cloud():
             version = settings_version
-        version = version or installed_version or latest_version
+        version = version or installed_version
+
+        # only fetch latest version from network if no version resolved yet
+        if not version:
+            latest_version = self._get_latest_version(driver_name)
+            version = latest_version
 
         version = str(version)  # let's fix reading version as number from yaml
         self.log.info(f'Used version of {driver_name} is {version}')
@@ -336,7 +338,8 @@ class ChromeDriver(WebDriver):
         try:
             if (chrome_milestone):
                 response = requests.get(
-                    'https://googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone.json')
+                    'https://googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone.json',
+                    timeout=10)
                 data = response.json()
                 milestone_version = data["milestones"].get(str(chrome_milestone), {"version": None})["version"]
                 if milestone_version:
@@ -344,12 +347,13 @@ class ChromeDriver(WebDriver):
 
             # Unable to detect chrome version / or find milestone, download driver for latest stable version
             response = requests.get(
-                'https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json')
+                'https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json',
+                timeout=10)
             data = response.json()
             stable_version = data["channels"]["Stable"]["version"]
             return stable_version
         except Exception as e:
-            print("An error occurred:", e)
+            self.log.warning("Failed to get latest chromedriver version: %s", e)
             return self.VERSION
 
     def _get_arch_and_ext_for_chromedriver(self):
@@ -402,7 +406,8 @@ class GeckoDriver(WebDriver):
         "https://github.com/mozilla/geckodriver/releases/download/v{version}/geckodriver-v{version}-{arch}.{ext}"
 
     def _get_latest_version_from_inet(self):
-        return requests.get("https://api.github.com/repos/mozilla/geckodriver/releases/latest").json()["name"]
+        return requests.get("https://api.github.com/repos/mozilla/geckodriver/releases/latest",
+                            timeout=10).json()["name"]
 
     def _expand_download_link(self):
         if is_windows():

--- a/tests/unit/modules/_selenium/test_selenium_executor.py
+++ b/tests/unit/modules/_selenium/test_selenium_executor.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import shutil
+from unittest.mock import patch
 
 import yaml
 from io import BytesIO
@@ -456,3 +457,14 @@ class TestReportReader(BZTestCase):
         self.assertEqual("https://chromedriver.storage.googleapis.com"
                          "/110.0.5481.77/chromedriver_" + arch + ".zip",
                          chrome_driver.download_link)
+
+    @patch('bzt.modules._selenium.requests.get')
+    def test_chromedriver_version_fallback_on_network_error(self, mock_get):
+        mock_get.side_effect = Exception("Connection timed out")
+        log = logging.getLogger('')
+        driver = ChromeDriver(settings={}, log=log)
+        # When network fails and no installed version, should fall back to VERSION constant
+        version = driver._get_latest_version_from_inet()
+        self.assertEqual(version, ChromeDriver.VERSION)
+        # Verify requests.get was called (and failed)
+        mock_get.assert_called()


### PR DESCRIPTION
## Summary

- Jira: https://perforce.atlassian.net/browse/MOB-52862
- Skip unnecessary network call to `googlechromelabs.github.io` when chromedriver is already pre-installed in the container image (cloud/OPL environments)
- Add `timeout=10s` to all external version check HTTP calls (ChromeDriver + GeckoDriver)
- Fix `print()` → `self.log.warning()` for proper error logging
- Tested via jenkins build: https://blazect-jenkins.blazemeter.com/job/taurus-branch-builder/582/

## Problem

BPT tests with EUX (Chrome + video recording) in OPL environments hang for 15-20 minutes during initialization. The taurus Selenium module unconditionally calls `googlechromelabs.github.io` to check the latest chromedriver version — even when chromedriver is already pre-installed in the Docker image. In OPL environments where this URL is unreachable, the `requests.get()` call (with no timeout set) hangs until TCP gives up.

The fetched version is never used in cloud containers — the code picks the pre-installed version anyway.

## Changes

1. **Lazy network call**: Only fetch latest version from internet when no `settings_version` or `installed_version` exists. In cloud/OPL containers where chromedriver is pre-baked, the network call is skipped entirely.
2. **`timeout=10`** on ChromeDriver `requests.get()` calls — fail fast instead of hanging 15-20 min
3. **`timeout=10`** on GeckoDriver `requests.get()` call — same fix for Firefox
4. **`print()` → `self.log.warning()`** — proper error logging

## Test plan

- [x] Verify BPT+EUX test works on K8s OPL with restricted networking (no access to `googlechromelabs.github.io`)
- [x] Verify BPT+EUX test still works on public cloud (no regression)
- [x] Verify local `bzt` usage still downloads chromedriver when not pre-installed
- [x] Verify GeckoDriver (Firefox) version check also respects timeout

## Jira

https://perforce.atlassian.net/browse/MOB-52862

🤖 Generated with [Claude Code](https://claude.com/claude-code)