### PR TITLE
MOB-48124: playwright test step reporting

### DIFF
--- a/bzt/modules/javascript.py
+++ b/bzt/modules/javascript.py
@@ -167,9 +167,9 @@ class PlaywrightTester(JavaScriptExecutor):
         self.env.set({"TAURUS_PWREPORT_DIR": self.engine.artifacts_dir})
         if max_duration:
             self.env.set({"TAURUS_PWREPORT_DURATION": str(int(max_duration * 1000))})
-        granularity = str(self.get_scenario().get("report-granularity", "step")).upper().replace("-", "_")
-        if granularity not in ("STEP", "TEST", "STEP_LEAF"):
-            self.log.warning("Unknown report-granularity '%s', reporter will default to STEP", granularity)
+        granularity = str(self.get_scenario().get("report-granularity", "auto")).upper().replace("-", "_")
+        if granularity not in ("STEP", "TEST", "STEP_LEAF", "AUTO"):
+            self.log.warning("Unknown report-granularity '%s', reporter will default to AUTO", granularity)
         self.env.set({"TAURUS_PWREPORT_GRANULARITY": granularity})
         self.env.set({"TAURUS_PWREPORT_NOREPORT_PREFIX": self.get_scenario().get("report-exclude-prefix", "")})
         options = ["--reporter \"" + reporter + "\"",

--- a/bzt/modules/javascript.py
+++ b/bzt/modules/javascript.py
@@ -167,10 +167,11 @@ class PlaywrightTester(JavaScriptExecutor):
         self.env.set({"TAURUS_PWREPORT_DIR": self.engine.artifacts_dir})
         if max_duration:
             self.env.set({"TAURUS_PWREPORT_DURATION": str(int(max_duration * 1000))})
-        # TODO: read granularity from customer YAML configuration (scenario option) instead of hardcoding
-        self.env.set({"TAURUS_PWREPORT_GRANULARITY": "STEP"})
-        # TODO: read noReportPrefix from customer YAML configuration (scenario option) instead of hardcoding
-        self.env.set({"TAURUS_PWREPORT_NOREPORT_PREFIX": ""})
+        granularity = str(self.get_scenario().get("report-granularity", "step")).upper().replace("-", "_")
+        if granularity not in ("STEP", "TEST", "STEP_LEAF"):
+            self.log.warning("Unknown report-granularity '%s', reporter will default to STEP", granularity)
+        self.env.set({"TAURUS_PWREPORT_GRANULARITY": granularity})
+        self.env.set({"TAURUS_PWREPORT_NOREPORT_PREFIX": self.get_scenario().get("report-exclude-prefix", "")})
         options = ["--reporter \"" + reporter + "\"",
                    "--output " + self.engine.artifacts_dir + "/test-output",
                    "--workers " + str(concurrency),

--- a/bzt/modules/javascript.py
+++ b/bzt/modules/javascript.py
@@ -169,6 +169,8 @@ class PlaywrightTester(JavaScriptExecutor):
             self.env.set({"TAURUS_PWREPORT_DURATION": str(int(max_duration * 1000))})
         # TODO: read granularity from customer YAML configuration (scenario option) instead of hardcoding
         self.env.set({"TAURUS_PWREPORT_GRANULARITY": "STEP"})
+        # TODO: read noReportPrefix from customer YAML configuration (scenario option) instead of hardcoding
+        self.env.set({"TAURUS_PWREPORT_NOREPORT_PREFIX": ""})
         options = ["--reporter \"" + reporter + "\"",
                    "--output " + self.engine.artifacts_dir + "/test-output",
                    "--workers " + str(concurrency),

--- a/bzt/modules/javascript.py
+++ b/bzt/modules/javascript.py
@@ -570,7 +570,7 @@ class PlaywrightTestPackage(NPMPackage):
             return False
 
 class PlaywrightCustomReporter(NPMLocalModulePackage):
-    PACKAGE_NAME = "@taurus/playwright-custom-reporter@1.0.0"
+    PACKAGE_NAME = "@taurus/playwright-custom-reporter@1.0.1"
     PACKAGE_LOCAL_PATH = "./playwright-custom-reporter"
 
     def check_if_installed(self):

--- a/bzt/modules/javascript.py
+++ b/bzt/modules/javascript.py
@@ -167,6 +167,8 @@ class PlaywrightTester(JavaScriptExecutor):
         self.env.set({"TAURUS_PWREPORT_DIR": self.engine.artifacts_dir})
         if max_duration:
             self.env.set({"TAURUS_PWREPORT_DURATION": str(int(max_duration * 1000))})
+        # TODO: read granularity from customer YAML configuration (scenario option) instead of hardcoding
+        self.env.set({"TAURUS_PWREPORT_GRANULARITY": "STEP"})
         options = ["--reporter \"" + reporter + "\"",
                    "--output " + self.engine.artifacts_dir + "/test-output",
                    "--workers " + str(concurrency),

--- a/bzt/resources/playwright-custom-reporter/package.json
+++ b/bzt/resources/playwright-custom-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@taurus/playwright-custom-reporter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "playwright-custom-reporter.js",
   "scripts": {

--- a/bzt/resources/playwright-custom-reporter/playwright-custom-reporter.js
+++ b/bzt/resources/playwright-custom-reporter/playwright-custom-reporter.js
@@ -192,7 +192,7 @@ class TaurusReporter {
       "error": result.status === 'passed' ? null : "Test failed: " + (result.error ? result.error.message : (result.status === 'interrupted'
           ? 'Interrupted' : 'Unknown error')),
       "runDetails": test.title + ":" + result.parallelIndex + ":" + test.repeatEachIndex
-          + ":" + test.parent.parent?.title,
+          + ":" + test.parent?.parent?.title,
       "logs": test.logs && test.logs.length > 0 ? test.logs.join('\n') : null,
       "byte_count": null,
     };
@@ -217,7 +217,7 @@ class TaurusReporter {
       "expectedStatus": test.expectedStatus,
       "error": `Test "${test.title}" ${result.status}, no step captured it: ${reason}`,
       "runDetails": test.title + ":" + result.parallelIndex + ":" + test.repeatEachIndex
-          + ":" + test.parent.parent?.title,
+          + ":" + test.parent?.parent?.title,
       "logs": test.logs && test.logs.length > 0 ? test.logs.join('\n') : null,
       "byte_count": 0,
     };
@@ -353,7 +353,7 @@ class TaurusReporter {
         "expectedStatus": test.expectedStatus,
         "error": step.error ? "Step failed: " + step.error.message : null,
         "runDetails": test.title + ":" + result.parallelIndex + ":" + test.repeatEachIndex
-            + ":" + test.parent.parent?.title,
+            + ":" + test.parent?.parent?.title,
         "logs": step.logs && step.logs.length > 0 ? step.logs.join('\n') : null,
         "byte_count": null,
       };

--- a/bzt/resources/playwright-custom-reporter/playwright-custom-reporter.js
+++ b/bzt/resources/playwright-custom-reporter/playwright-custom-reporter.js
@@ -22,6 +22,7 @@ class TaurusReporter {
       statTime: 15000,
       verbose: false,
       consoleLog: true,
+      granularity: 'STEP',
     };
     this.options = {...defaultOptions, ...userOptions};
 
@@ -38,6 +39,10 @@ class TaurusReporter {
     if (typeof process.env.TAURUS_PWREPORT_DURATION !== 'undefined') {
       this.options.maxDuration = parseInt(process.env.TAURUS_PWREPORT_DURATION);
     }
+    if (typeof process.env.TAURUS_PWREPORT_GRANULARITY !== 'undefined') {
+      this.options.granularity = process.env.TAURUS_PWREPORT_GRANULARITY;
+    }
+    this.options.granularity = `${this.options.granularity}`.toUpperCase() === 'TEST' ? 'TEST' : 'STEP';
 
     if (fs.existsSync(this.options.outputFile)) {
       fs.rmSync(this.options.outputFile, {
@@ -132,6 +137,10 @@ class TaurusReporter {
       console.log(`Finished test ${test.title}: ${result.status} in ${result.duration}ms`);
     }
 
+    if (this.options.granularity !== 'TEST') {
+      return;
+    }
+
     const timestamp = test.timestamps ? test.timestamps[test.timestamps.length - 1] : Date.now();
 
     const line = {
@@ -156,6 +165,55 @@ class TaurusReporter {
     }
     if (this.options.consoleLog === true && this.options.verbose === true) {
       console.log(`Test result: ${JSON.stringify(line)}`);
+    }
+  }
+
+  // Only first-level test.step() calls are reported (nested test.step calls are skipped).
+  // Playwright's own category enum reserves 'test.step' exclusively for explicit
+  // test.step() calls, so this already excludes hooks, fixtures, expects and pw:api steps.
+  isReportableStep(step) {
+    if (!step || step.category !== 'test.step') {
+      return false;
+    }
+    if (step.parent) {
+      return false;
+    }
+    return true;
+  }
+
+  onStepEnd(test, result, step) {
+    if (this.options.granularity !== 'STEP') {
+      return;
+    }
+    if (!this.isReportableStep(step)) {
+      return;
+    }
+
+    if (this.options.consoleLog === true && this.options.verbose === true) {
+      console.log(`Finished step ${step.title}: ${step.error ? 'failed' : 'passed'} in ${step.duration}ms`);
+    }
+
+    const line = {
+      "timestamp": step.startTime.getTime(),
+      "label": step.title,
+      "ok": !step.error,
+      "concurency": this.config?.workers || 1,
+      "duration": step.duration,
+      "connectTime": null,
+      "latency": null,
+      "status": step.error ? "failed" : "passed",
+      "expectedStatus": test.expectedStatus,
+      "error": step.error ? "Step failed: " + step.error.message : null,
+      "runDetails": test.title + ":" + result.parallelIndex + ":" + test.repeatEachIndex
+          + ":" + test.parent.parent?.title,
+      "logs": null,
+      "byte_count": null,
+    };
+    if (this.options.outputFile) {
+      appendLineToFile(this.options.outputFile, JSON.stringify(line) + '\n');
+    }
+    if (this.options.consoleLog === true && this.options.verbose === true) {
+      console.log(`Step result: ${JSON.stringify(line)}`);
     }
   }
 

--- a/bzt/resources/playwright-custom-reporter/playwright-custom-reporter.js
+++ b/bzt/resources/playwright-custom-reporter/playwright-custom-reporter.js
@@ -203,14 +203,20 @@ class TaurusReporter {
   }
 
   // Only first-level test.step() calls are reported (nested test.step calls are skipped).
-  // Playwright's own category enum reserves 'test.step' exclusively for explicit
-  // test.step() calls, so this already excludes hooks, fixtures, expects and pw:api steps.
+  // "First-level" means no ancestor in the parent chain is itself a test.step. A parent
+  // that is a hook/fixture/pw:api step does not count as nesting - it isn't something the
+  // test author wrote. This matters because Playwright can attribute still-running
+  // test.step() calls to its own teardown fixture (e.g. "Fixture \"context\"") as their
+  // parent when a whole-test timeout races with in-flight user code, which would otherwise
+  // make a genuinely top-level step look nested and get silently dropped.
   isFirstLevelStep(step) {
     if (!step || step.category !== 'test.step') {
       return false;
     }
-    if (step.parent) {
-      return false;
+    for (let current = step.parent; current; current = current.parent) {
+      if (current.category === 'test.step') {
+        return false;
+      }
     }
     return true;
   }

--- a/bzt/resources/playwright-custom-reporter/playwright-custom-reporter.js
+++ b/bzt/resources/playwright-custom-reporter/playwright-custom-reporter.js
@@ -23,6 +23,7 @@ class TaurusReporter {
       verbose: false,
       consoleLog: true,
       granularity: 'STEP',
+      noReportPrefix: '',
     };
     this.options = {...defaultOptions, ...userOptions};
 
@@ -45,6 +46,9 @@ class TaurusReporter {
     const normalizedGranularity = `${this.options.granularity}`.toUpperCase();
     this.options.granularity = ['TEST', 'STEP', 'STEP_LEAF'].includes(normalizedGranularity)
         ? normalizedGranularity : 'STEP';
+    if (typeof process.env.TAURUS_PWREPORT_NOREPORT_PREFIX !== 'undefined') {
+      this.options.noReportPrefix = process.env.TAURUS_PWREPORT_NOREPORT_PREFIX;
+    }
 
     if (fs.existsSync(this.options.outputFile)) {
       fs.rmSync(this.options.outputFile, {
@@ -101,6 +105,14 @@ class TaurusReporter {
     }
   }
 
+  // Empty prefix (the default) means nothing is excluded.
+  isSkippedByNoReportPrefix(title) {
+    if (!this.options.noReportPrefix) {
+      return false;
+    }
+    return typeof title === 'string' && title.startsWith(this.options.noReportPrefix);
+  }
+
   onBegin(config, suite) {
     this.config = config;
     this.root = suite;
@@ -140,6 +152,9 @@ class TaurusReporter {
     }
 
     if (this.options.granularity !== 'TEST') {
+      return;
+    }
+    if (this.isSkippedByNoReportPrefix(test.title)) {
       return;
     }
 
@@ -203,6 +218,9 @@ class TaurusReporter {
         return;
       }
     } else {
+      return;
+    }
+    if (this.isSkippedByNoReportPrefix(step.title)) {
       return;
     }
 

--- a/bzt/resources/playwright-custom-reporter/playwright-custom-reporter.js
+++ b/bzt/resources/playwright-custom-reporter/playwright-custom-reporter.js
@@ -113,6 +113,23 @@ class TaurusReporter {
     return typeof title === 'string' && title.startsWith(this.options.noReportPrefix);
   }
 
+  // The no-report prefix disables the whole tree under the step/test it is found on:
+  // checks the test title and every step from the given one up through its parents.
+  isExcludedByNoReportPrefix(test, step) {
+    if (!this.options.noReportPrefix) {
+      return false;
+    }
+    if (this.isSkippedByNoReportPrefix(test?.title)) {
+      return true;
+    }
+    for (let current = step; current; current = current.parent) {
+      if (this.isSkippedByNoReportPrefix(current.title)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   onBegin(config, suite) {
     this.config = config;
     this.root = suite;
@@ -200,12 +217,23 @@ class TaurusReporter {
 
   // Only leaf test.step() calls are reported - i.e. steps that do not themselves
   // contain a nested test.step() call, regardless of how deep they are in the hierarchy.
-  isLeafStep(step) {
+  // A step also counts as a leaf when every one of its test.step children is excluded by
+  // the no-report prefix: that step becomes the effective leaf for whatever survived under it.
+  isLeafStep(test, step) {
     if (!step || step.category !== 'test.step') {
       return false;
     }
-    const hasNestedStep = Array.isArray(step.steps) && step.steps.some(child => child.category === 'test.step');
-    return !hasNestedStep;
+    if (this.isExcludedByNoReportPrefix(test, step)) {
+      return false;
+    }
+    const children = Array.isArray(step.steps) ? step.steps : [];
+    if (!this.options.noReportPrefix) {
+      // No prefix configured - nothing can be excluded, skip checking children for it.
+      return !children.some(child => child.category === 'test.step');
+    }
+    const hasReportableChildStep = children.some(child =>
+        child.category === 'test.step' && !this.isExcludedByNoReportPrefix(test, child));
+    return !hasReportableChildStep;
   }
 
   onStepEnd(test, result, step) {
@@ -213,14 +241,16 @@ class TaurusReporter {
       if (!this.isFirstLevelStep(step)) {
         return;
       }
+      if (this.isExcludedByNoReportPrefix(test, step)) {
+        return;
+      }
     } else if (this.options.granularity === 'STEP_LEAF') {
-      if (!this.isLeafStep(step)) {
+      // isLeafStep() already accounts for the no-report prefix (both self- and
+      // children-exclusion), no separate isExcludedByNoReportPrefix check needed here.
+      if (!this.isLeafStep(test, step)) {
         return;
       }
     } else {
-      return;
-    }
-    if (this.isSkippedByNoReportPrefix(step.title)) {
       return;
     }
 

--- a/bzt/resources/playwright-custom-reporter/playwright-custom-reporter.js
+++ b/bzt/resources/playwright-custom-reporter/playwright-custom-reporter.js
@@ -22,7 +22,7 @@ class TaurusReporter {
       statTime: 15000,
       verbose: false,
       consoleLog: true,
-      granularity: 'STEP',
+      granularity: 'AUTO',
       noReportPrefix: '',
     };
     this.options = {...defaultOptions, ...userOptions};
@@ -44,8 +44,8 @@ class TaurusReporter {
       this.options.granularity = process.env.TAURUS_PWREPORT_GRANULARITY;
     }
     const normalizedGranularity = `${this.options.granularity}`.toUpperCase();
-    this.options.granularity = ['TEST', 'STEP', 'STEP_LEAF'].includes(normalizedGranularity)
-        ? normalizedGranularity : 'STEP';
+    this.options.granularity = ['TEST', 'STEP', 'STEP_LEAF', 'AUTO'].includes(normalizedGranularity)
+        ? normalizedGranularity : 'AUTO';
     if (typeof process.env.TAURUS_PWREPORT_NOREPORT_PREFIX !== 'undefined') {
       this.options.noReportPrefix = process.env.TAURUS_PWREPORT_NOREPORT_PREFIX;
     }
@@ -156,6 +156,10 @@ class TaurusReporter {
     // Tracks whether any step already reported this attempt's failure, so onTestEnd
     // knows whether a fallback whole-test line is needed under STEP/STEP_LEAF granularity.
     test.reportedFailure = false;
+    // Tracks whether any step was reported at all this attempt, so onTestEnd can decide,
+    // under AUTO granularity, whether to report this test like STEP (steps already
+    // covered it) or fall back to one whole-test line (this test used no test.step()).
+    test.reportedAnyStep = false;
 
     this.testMap.set(test.id, test);
 
@@ -240,10 +244,25 @@ class TaurusReporter {
       return;
     }
 
-    // STEP / STEP_LEAF granularity: if the test didn't pass and no step already
-    // reported the failure (e.g. a whole-test timeout with every step showing passed,
-    // or a failure outside any test.step), fall back to a synthetic marker line -
-    // otherwise this failure would be completely invisible at this granularity.
+    // AUTO granularity, and this test never reported a step (either it doesn't use
+    // test.step() at all, or every step was excluded by report-exclude-prefix): report
+    // it like TEST, unconditionally (pass or fail) - so it's never silently dropped.
+    if (this.options.granularity === 'AUTO' && !test.reportedAnyStep) {
+      const line = this.buildTestLine(test, result);
+      if (this.options.outputFile) {
+        appendLineToFile(this.options.outputFile, JSON.stringify(line) + '\n');
+      }
+      if (this.options.consoleLog === true && this.options.verbose === true) {
+        console.log(`Test result: ${JSON.stringify(line)}`);
+      }
+      return;
+    }
+
+    // STEP / STEP_LEAF granularity, or AUTO with at least one reported step: if the
+    // test didn't pass and no step already reported the failure (e.g. a whole-test
+    // timeout with every step showing passed, or a failure outside any test.step),
+    // fall back to a synthetic marker line - otherwise this failure would be
+    // completely invisible at this granularity.
     if (result.status !== 'passed' && !test.reportedFailure) {
       const line = this.buildUntrackedFailureLine(test, result);
       if (this.options.outputFile) {
@@ -304,7 +323,10 @@ class TaurusReporter {
 
   onStepEnd(test, result, step) {
     let shouldReport;
-    if (this.options.granularity === 'STEP') {
+    if (this.options.granularity === 'STEP' || this.options.granularity === 'AUTO') {
+      // AUTO decides per-test (in onTestEnd) whether to behave like STEP or TEST, based
+      // on whether the test reports any step at all - so while a step is being reported,
+      // it's always evaluated with plain first-level STEP rules.
       shouldReport = this.isFirstLevelStep(step) && !this.isExcludedByNoReportPrefix(test, step);
     } else if (this.options.granularity === 'STEP_LEAF') {
       // isLeafStep() already accounts for the no-report prefix (both self- and
@@ -337,6 +359,9 @@ class TaurusReporter {
       };
       if (step.error && test) {
         test.reportedFailure = true;
+      }
+      if (test) {
+        test.reportedAnyStep = true;
       }
       if (this.options.outputFile) {
         appendLineToFile(this.options.outputFile, JSON.stringify(line) + '\n');

--- a/bzt/resources/playwright-custom-reporter/playwright-custom-reporter.js
+++ b/bzt/resources/playwright-custom-reporter/playwright-custom-reporter.js
@@ -105,6 +105,13 @@ class TaurusReporter {
     }
   }
 
+  addStepLog(step, log) {
+    if (step && step.logs) {
+      // log could be Buffer
+      step.logs.push(`${log}`);
+    }
+  }
+
   // Empty prefix (the default) means nothing is excluded.
   isSkippedByNoReportPrefix(title) {
     if (!this.options.noReportPrefix) {
@@ -145,6 +152,10 @@ class TaurusReporter {
   onTestBegin(test, result) {
     // For logs when no test is running
     this.lastTest = test;
+    this.lastStep = undefined;
+    // Tracks whether any step already reported this attempt's failure, so onTestEnd
+    // knows whether a fallback whole-test line is needed under STEP/STEP_LEAF granularity.
+    test.reportedFailure = false;
 
     this.testMap.set(test.id, test);
 
@@ -162,22 +173,9 @@ class TaurusReporter {
     }
   }
 
-  onTestEnd(test, result) {
-
-    if (this.options.consoleLog === true && this.options.verbose === true) {
-      console.log(`Finished test ${test.title}: ${result.status} in ${result.duration}ms`);
-    }
-
-    if (this.options.granularity !== 'TEST') {
-      return;
-    }
-    if (this.isSkippedByNoReportPrefix(test.title)) {
-      return;
-    }
-
+  buildTestLine(test, result) {
     const timestamp = test.timestamps ? test.timestamps[test.timestamps.length - 1] : Date.now();
-
-    const line = {
+    return {
       "timestamp": timestamp,
       "label": test.title,
       "ok": test.ok() && result.status !== 'interrupted',
@@ -194,11 +192,66 @@ class TaurusReporter {
       "logs": test.logs && test.logs.length > 0 ? test.logs.join('\n') : null,
       "byte_count": null,
     };
-    if (this.options.outputFile) {
-      appendLineToFile(this.options.outputFile, JSON.stringify(line) + '\n');
-    }
+  }
+
+  // Generic marker line used when STEP/STEP_LEAF granularity has no step-level failure
+  // to attribute a problem to (whole-test timeout, failure outside any test.step, etc).
+  // Uses a fixed, clearly-synthetic label (not the test title) so it reads as one bucket
+  // across all tests, and zeroes out the fields that would otherwise be treated as real
+  // performance measurements - only the "error" message carries the actual test title.
+  buildUntrackedFailureLine(test, result) {
+    const reason = result.error ? result.error.message : (result.status === 'interrupted' ? 'Interrupted' : 'Unknown error');
+    return {
+      "timestamp": test.timestamps ? test.timestamps[test.timestamps.length - 1] : Date.now(),
+      "label": "__untracked_failure__",
+      "ok": false,
+      "concurency": this.config?.workers || 1,
+      "duration": 0,
+      "connectTime": null,
+      "latency": null,
+      "status": result.status,
+      "expectedStatus": test.expectedStatus,
+      "error": `Test "${test.title}" ${result.status}, no step captured it: ${reason}`,
+      "runDetails": test.title + ":" + result.parallelIndex + ":" + test.repeatEachIndex
+          + ":" + test.parent.parent?.title,
+      "logs": test.logs && test.logs.length > 0 ? test.logs.join('\n') : null,
+      "byte_count": 0,
+    };
+  }
+
+  onTestEnd(test, result) {
+
     if (this.options.consoleLog === true && this.options.verbose === true) {
-      console.log(`Test result: ${JSON.stringify(line)}`);
+      console.log(`Finished test ${test.title}: ${result.status} in ${result.duration}ms`);
+    }
+
+    if (this.isSkippedByNoReportPrefix(test.title)) {
+      return;
+    }
+
+    if (this.options.granularity === 'TEST') {
+      const line = this.buildTestLine(test, result);
+      if (this.options.outputFile) {
+        appendLineToFile(this.options.outputFile, JSON.stringify(line) + '\n');
+      }
+      if (this.options.consoleLog === true && this.options.verbose === true) {
+        console.log(`Test result: ${JSON.stringify(line)}`);
+      }
+      return;
+    }
+
+    // STEP / STEP_LEAF granularity: if the test didn't pass and no step already
+    // reported the failure (e.g. a whole-test timeout with every step showing passed,
+    // or a failure outside any test.step), fall back to a synthetic marker line -
+    // otherwise this failure would be completely invisible at this granularity.
+    if (result.status !== 'passed' && !test.reportedFailure) {
+      const line = this.buildUntrackedFailureLine(test, result);
+      if (this.options.outputFile) {
+        appendLineToFile(this.options.outputFile, JSON.stringify(line) + '\n');
+      }
+      if (this.options.consoleLog === true) {
+        console.log(EC.yellow(`Untracked test failure, emitting synthetic marker line: ${JSON.stringify(line)}`));
+      }
     }
   }
 
@@ -242,55 +295,65 @@ class TaurusReporter {
     return !hasReportableChildStep;
   }
 
+  onStepBegin(test, result, step) {
+    this.lastStep = step;
+    if (!step.logs) {
+      step.logs = [];
+    }
+  }
+
   onStepEnd(test, result, step) {
+    let shouldReport;
     if (this.options.granularity === 'STEP') {
-      if (!this.isFirstLevelStep(step)) {
-        return;
-      }
-      if (this.isExcludedByNoReportPrefix(test, step)) {
-        return;
-      }
+      shouldReport = this.isFirstLevelStep(step) && !this.isExcludedByNoReportPrefix(test, step);
     } else if (this.options.granularity === 'STEP_LEAF') {
       // isLeafStep() already accounts for the no-report prefix (both self- and
       // children-exclusion), no separate isExcludedByNoReportPrefix check needed here.
-      if (!this.isLeafStep(test, step)) {
-        return;
-      }
+      shouldReport = this.isLeafStep(test, step);
     } else {
-      return;
+      shouldReport = false;
     }
 
-    if (this.options.consoleLog === true && this.options.verbose === true) {
-      console.log(`Finished step ${step.title}: ${step.error ? 'failed' : 'passed'} in ${step.duration}ms`);
+    if (shouldReport) {
+      if (this.options.consoleLog === true && this.options.verbose === true) {
+        console.log(`Finished step ${step.title}: ${step.error ? 'failed' : 'passed'} in ${step.duration}ms`);
+      }
+
+      const line = {
+        "timestamp": step.startTime.getTime(),
+        "label": step.title,
+        "ok": !step.error,
+        "concurency": this.config?.workers || 1,
+        "duration": step.duration,
+        "connectTime": null,
+        "latency": null,
+        "status": step.error ? "failed" : "passed",
+        "expectedStatus": test.expectedStatus,
+        "error": step.error ? "Step failed: " + step.error.message : null,
+        "runDetails": test.title + ":" + result.parallelIndex + ":" + test.repeatEachIndex
+            + ":" + test.parent.parent?.title,
+        "logs": step.logs && step.logs.length > 0 ? step.logs.join('\n') : null,
+        "byte_count": null,
+      };
+      if (step.error && test) {
+        test.reportedFailure = true;
+      }
+      if (this.options.outputFile) {
+        appendLineToFile(this.options.outputFile, JSON.stringify(line) + '\n');
+      }
+      if (this.options.consoleLog === true && this.options.verbose === true) {
+        console.log(`Step result: ${JSON.stringify(line)}`);
+      }
     }
 
-    const line = {
-      "timestamp": step.startTime.getTime(),
-      "label": step.title,
-      "ok": !step.error,
-      "concurency": this.config?.workers || 1,
-      "duration": step.duration,
-      "connectTime": null,
-      "latency": null,
-      "status": step.error ? "failed" : "passed",
-      "expectedStatus": test.expectedStatus,
-      "error": step.error ? "Step failed: " + step.error.message : null,
-      "runDetails": test.title + ":" + result.parallelIndex + ":" + test.repeatEachIndex
-          + ":" + test.parent.parent?.title,
-      "logs": null,
-      "byte_count": null,
-    };
-    if (this.options.outputFile) {
-      appendLineToFile(this.options.outputFile, JSON.stringify(line) + '\n');
-    }
-    if (this.options.consoleLog === true && this.options.verbose === true) {
-      console.log(`Step result: ${JSON.stringify(line)}`);
-    }
+    // Leaving this step's scope - current step becomes its parent (or none, at top level).
+    this.lastStep = step ? step.parent : this.lastStep;
   }
 
   onStdErr(chunk, test, result) {
     // Note that output may happen when no test is running, in which case this will be void.
     this.addTestLog(test || this.lastTest, EC.red(`${chunk}`));
+    this.addStepLog(this.lastStep, EC.red(`${chunk}`));
     if (this.options.consoleLog === true) {
       console.log(EC.red(`${chunk}`));
     }
@@ -299,6 +362,7 @@ class TaurusReporter {
   onStdOut(chunk, test, result) {
     // Note that output may happen when no test is running, in which case this will be void.
     this.addTestLog(test || this.lastTest, `${chunk}`);
+    this.addStepLog(this.lastStep, `${chunk}`);
     if (this.options.consoleLog === true) {
       console.log(`${chunk}`);
     }
@@ -306,8 +370,9 @@ class TaurusReporter {
 
   // Called on some global error, for example unhandled exception in the worker process.
   onError(error) {
-    // add the error to test logs
+    // add the error to test and step logs
     this.addTestLog(this.lastTest, EC.red(error.message || "Unknown Error"));
+    this.addStepLog(this.lastStep, EC.red(error.message || "Unknown Error"));
     if (this.options.consoleLog === true) {
       console.log(EC.red(error.message || "Unknown Error"));
     }
@@ -326,6 +391,7 @@ class TaurusReporter {
       console.log(`Finished the run: ${result.status}`);
     }
     this.lastTest = undefined;
+    this.lastStep = undefined;
     this.testMap.clear();
   }
 }

--- a/bzt/resources/playwright-custom-reporter/playwright-custom-reporter.js
+++ b/bzt/resources/playwright-custom-reporter/playwright-custom-reporter.js
@@ -42,7 +42,9 @@ class TaurusReporter {
     if (typeof process.env.TAURUS_PWREPORT_GRANULARITY !== 'undefined') {
       this.options.granularity = process.env.TAURUS_PWREPORT_GRANULARITY;
     }
-    this.options.granularity = `${this.options.granularity}`.toUpperCase() === 'TEST' ? 'TEST' : 'STEP';
+    const normalizedGranularity = `${this.options.granularity}`.toUpperCase();
+    this.options.granularity = ['TEST', 'STEP', 'STEP_LEAF'].includes(normalizedGranularity)
+        ? normalizedGranularity : 'STEP';
 
     if (fs.existsSync(this.options.outputFile)) {
       fs.rmSync(this.options.outputFile, {
@@ -171,7 +173,7 @@ class TaurusReporter {
   // Only first-level test.step() calls are reported (nested test.step calls are skipped).
   // Playwright's own category enum reserves 'test.step' exclusively for explicit
   // test.step() calls, so this already excludes hooks, fixtures, expects and pw:api steps.
-  isReportableStep(step) {
+  isFirstLevelStep(step) {
     if (!step || step.category !== 'test.step') {
       return false;
     }
@@ -181,11 +183,26 @@ class TaurusReporter {
     return true;
   }
 
-  onStepEnd(test, result, step) {
-    if (this.options.granularity !== 'STEP') {
-      return;
+  // Only leaf test.step() calls are reported - i.e. steps that do not themselves
+  // contain a nested test.step() call, regardless of how deep they are in the hierarchy.
+  isLeafStep(step) {
+    if (!step || step.category !== 'test.step') {
+      return false;
     }
-    if (!this.isReportableStep(step)) {
+    const hasNestedStep = Array.isArray(step.steps) && step.steps.some(child => child.category === 'test.step');
+    return !hasNestedStep;
+  }
+
+  onStepEnd(test, result, step) {
+    if (this.options.granularity === 'STEP') {
+      if (!this.isFirstLevelStep(step)) {
+        return;
+      }
+    } else if (this.options.granularity === 'STEP_LEAF') {
+      if (!this.isLeafStep(step)) {
+        return;
+      }
+    } else {
       return;
     }
 

--- a/site/dat/docs/Playwright.md
+++ b/site/dat/docs/Playwright.md
@@ -141,3 +141,72 @@ scenarios:
       reporters: # Your list of additional reporters
       - json
 ```
+
+## Report granularity
+
+By default, Taurus reports one result per first-level `test.step()` call in your test (a step not nested inside
+another step). Use the `report-granularity` scenario option to change this.
+
+Supported values:
+- `step` (default): report each first-level `test.step()` call.
+- `step-leaf`: report each innermost `test.step()` call instead - i.e. the most nested step in each chain.
+- `test`: report one result per whole test; `test.step()` calls are not reported individually.
+
+```yaml
+scenarios:
+    playwright_test:
+      script: example.spec.ts
+      report-granularity: step-leaf # step (default), step-leaf, or test
+```
+
+For example, given this adapted version of the `reserve flight` test:
+```javascript
+test('reserve flight', async ({ page }) => {
+  await page.goto('/');
+
+  await test.step('search flight', async () => {
+    await test.step('select departure city', async () => {
+      await page.getByRole('button', { name: 'Find Flights' }).click();
+    });
+    await expect(page).toHaveTitle(/reserve/);
+  });
+
+  await page.getByRole('button', { name: 'Choose This Flight' }).nth(1).click();
+  await expect(page).toHaveTitle(/Purchase/);
+});
+```
+- `step` reports `search flight`.
+- `step-leaf` reports `select departure city`.
+- `test` reports `reserve flight`.
+
+*NOTE*: Code that runs directly inside a test, outside of any `test.step()` call, is not included in the report when
+using `step` or `step-leaf`. If such a test fails or times out without any `test.step()` call reporting the failure,
+Taurus still reports it as a single result labeled `__untracked_failure__`, instead of dropping it silently. The
+actual test name and failure reason are included in that result's error message.
+
+## Exclude steps from the report
+
+Use the `report-exclude-prefix` scenario option to exclude tests or `test.step()` calls whose title starts with the
+given prefix - useful for excluding setup steps you don't want counted in your results. By default no prefix is set,
+so nothing is excluded.
+
+```yaml
+scenarios:
+    playwright_test:
+      script: example.spec.ts
+      report-exclude-prefix: 'NOREPORT:'
+```
+
+```javascript
+test('has title', async ({ page }) => {
+  await test.step('NOREPORT: warm up', async () => {
+    await page.goto('/');
+  });
+
+  await test.step('verify title', async () => {
+    await expect(page).toHaveTitle(/BlazeDemo/);
+  });
+});
+```
+With this configuration, only `verify title` appears in the report - `NOREPORT: warm up` is excluded. If an excluded
+test or step contains nested `test.step()` calls, those are excluded too.

--- a/site/dat/docs/Playwright.md
+++ b/site/dat/docs/Playwright.md
@@ -144,19 +144,22 @@ scenarios:
 
 ## Report granularity
 
-By default, Taurus reports one result per first-level `test.step()` call in your test (a step not nested inside
-another step). Use the `report-granularity` scenario option to change this.
+By default (`report-granularity: auto`), Taurus reports step-level detail for a test that uses `test.step()`, and
+one result for the whole test for a test that doesn't. Use the `report-granularity` scenario option to pick a
+different, fixed behavior instead.
 
 Supported values:
-- `step` (default): report each first-level `test.step()` call.
-- `step-leaf`: report each innermost `test.step()` call instead - i.e. the most nested step in each chain.
-- `test`: report one result per whole test; `test.step()` calls are not reported individually.
+- `auto` (default): report step-level detail for a test that uses `test.step()`; report the whole test as one
+  result otherwise.
+- `step`: always report each first-level `test.step()` call.
+- `step-leaf`: always report each innermost `test.step()` call instead - i.e. the most nested step in each chain.
+- `test`: always report one result per whole test; `test.step()` calls are not reported individually.
 
 ```yaml
 scenarios:
     playwright_test:
       script: example.spec.ts
-      report-granularity: step-leaf # step (default), step-leaf, or test
+      report-granularity: step-leaf # auto (default), step, step-leaf, or test
 ```
 
 For example, given this adapted version of the `reserve flight` test:
@@ -175,14 +178,16 @@ test('reserve flight', async ({ page }) => {
   await expect(page).toHaveTitle(/Purchase/);
 });
 ```
-- `step` reports `search flight`.
+- `auto` and `step` both report `search flight`.
 - `step-leaf` reports `select departure city`.
 - `test` reports `reserve flight`.
 
-*NOTE*: Code that runs directly inside a test, outside of any `test.step()` call, is not included in the report when
-using `step` or `step-leaf`. If such a test fails or times out without any `test.step()` call reporting the failure,
-Taurus still reports it as a single result labeled `__untracked_failure__`, instead of dropping it silently. The
-actual test name and failure reason are included in that result's error message.
+*NOTE*: For a test that uses `test.step()`, code outside of those calls is not included in the report when using
+`step`, `step-leaf`, or `auto`. If such a test fails or times out without any `test.step()` call reporting the
+failure, Taurus still reports it as a single result labeled `__untracked_failure__`, instead of dropping it silently.
+The actual test name and failure reason are included in that result's error message. A test that doesn't use
+`test.step()` at all is unaffected by this under `auto` (the default) - it's always reported as one whole-test
+result, whether it passes or fails.
 
 ## Exclude steps from the report
 

--- a/tests/unit/modules/_selenium/test_javascript.py
+++ b/tests/unit/modules/_selenium/test_javascript.py
@@ -325,7 +325,7 @@ class TestPlaywrightExecutor(SeleniumTestCase):
         self.assertEqual('true', self.ENV.get("TAURUS_PWREPORT_STDOUT"))
 
     def test_playwright_granularity_env_default(self):
-        """Test TAURUS_PWREPORT_GRANULARITY defaults to STEP"""
+        """Test TAURUS_PWREPORT_GRANULARITY defaults to AUTO"""
         self.simple_run({
             'execution': {
                 'iterations': 1,
@@ -335,7 +335,7 @@ class TestPlaywrightExecutor(SeleniumTestCase):
                 'executor': 'playwright',
             },
         })
-        self.assertEqual('STEP', self.ENV.get("TAURUS_PWREPORT_GRANULARITY"))
+        self.assertEqual('AUTO', self.ENV.get("TAURUS_PWREPORT_GRANULARITY"))
 
     def test_playwright_noreport_prefix_env_default(self):
         """Test TAURUS_PWREPORT_NOREPORT_PREFIX defaults to empty string"""
@@ -364,6 +364,20 @@ class TestPlaywrightExecutor(SeleniumTestCase):
         })
         self.assertEqual('STEP_LEAF', self.ENV.get("TAURUS_PWREPORT_GRANULARITY"))
 
+    def test_playwright_granularity_env_explicit_auto(self):
+        """Test report-granularity: auto is translated into TAURUS_PWREPORT_GRANULARITY=AUTO"""
+        self.simple_run({
+            'execution': {
+                'iterations': 1,
+                'scenario': {
+                    "script": RESOURCES_DIR + "playwright",
+                    "report-granularity": "auto",
+                },
+                'executor': 'playwright',
+            },
+        })
+        self.assertEqual('AUTO', self.ENV.get("TAURUS_PWREPORT_GRANULARITY"))
+
     def test_playwright_granularity_unknown_value_logs_warning(self):
         """Test an unrecognized report-granularity value is passed through with a warning"""
         self.prepare({
@@ -384,6 +398,7 @@ class TestPlaywrightExecutor(SeleniumTestCase):
         self.assertEqual('BOGUS', self.ENV.get("TAURUS_PWREPORT_GRANULARITY"))
         self.assertTrue(any("Unknown report-granularity" in msg
                              for msg in self.log_recorder.warn_buff.getvalue().split('\n')))
+        self.assertIn("default to AUTO", self.log_recorder.warn_buff.getvalue())
 
     def test_playwright_noreport_prefix_env_from_scenario(self):
         """Test report-exclude-prefix scenario option is passed through to TAURUS_PWREPORT_NOREPORT_PREFIX"""

--- a/tests/unit/modules/_selenium/test_javascript.py
+++ b/tests/unit/modules/_selenium/test_javascript.py
@@ -324,6 +324,19 @@ class TestPlaywrightExecutor(SeleniumTestCase):
         })
         self.assertEqual('true', self.ENV.get("TAURUS_PWREPORT_STDOUT"))
 
+    def test_playwright_granularity_env_default(self):
+        """Test TAURUS_PWREPORT_GRANULARITY defaults to STEP"""
+        self.simple_run({
+            'execution': {
+                'iterations': 1,
+                'scenario': {
+                    "script": RESOURCES_DIR + "playwright",
+                },
+                'executor': 'playwright',
+            },
+        })
+        self.assertEqual('STEP', self.ENV.get("TAURUS_PWREPORT_GRANULARITY"))
+
     def test_playwright_reporter_sanitization(self):
         """Test that reporter names are sanitized (spaces, quotes, etc. removed)"""
         self.simple_run({

--- a/tests/unit/modules/_selenium/test_javascript.py
+++ b/tests/unit/modules/_selenium/test_javascript.py
@@ -350,6 +350,55 @@ class TestPlaywrightExecutor(SeleniumTestCase):
         })
         self.assertEqual('', self.ENV.get("TAURUS_PWREPORT_NOREPORT_PREFIX"))
 
+    def test_playwright_granularity_env_from_scenario(self):
+        """Test report-granularity scenario option is translated into TAURUS_PWREPORT_GRANULARITY"""
+        self.simple_run({
+            'execution': {
+                'iterations': 1,
+                'scenario': {
+                    "script": RESOURCES_DIR + "playwright",
+                    "report-granularity": "step-leaf",
+                },
+                'executor': 'playwright',
+            },
+        })
+        self.assertEqual('STEP_LEAF', self.ENV.get("TAURUS_PWREPORT_GRANULARITY"))
+
+    def test_playwright_granularity_unknown_value_logs_warning(self):
+        """Test an unrecognized report-granularity value is passed through with a warning"""
+        self.prepare({
+            'execution': {
+                'iterations': 1,
+                'scenario': {
+                    "script": RESOURCES_DIR + "playwright",
+                    "report-granularity": "bogus",
+                },
+                'executor': 'playwright',
+            },
+        })
+        self.sniff_log(self.obj.runner.log)
+        self.obj.engine.start_subprocess = self.start_subprocess
+        self.obj.startup()
+        self.obj.post_process()
+
+        self.assertEqual('BOGUS', self.ENV.get("TAURUS_PWREPORT_GRANULARITY"))
+        self.assertTrue(any("Unknown report-granularity" in msg
+                             for msg in self.log_recorder.warn_buff.getvalue().split('\n')))
+
+    def test_playwright_noreport_prefix_env_from_scenario(self):
+        """Test report-exclude-prefix scenario option is passed through to TAURUS_PWREPORT_NOREPORT_PREFIX"""
+        self.simple_run({
+            'execution': {
+                'iterations': 1,
+                'scenario': {
+                    "script": RESOURCES_DIR + "playwright",
+                    "report-exclude-prefix": "NOREPORT:",
+                },
+                'executor': 'playwright',
+            },
+        })
+        self.assertEqual('NOREPORT:', self.ENV.get("TAURUS_PWREPORT_NOREPORT_PREFIX"))
+
     def test_playwright_reporter_sanitization(self):
         """Test that reporter names are sanitized (spaces, quotes, etc. removed)"""
         self.simple_run({

--- a/tests/unit/modules/_selenium/test_javascript.py
+++ b/tests/unit/modules/_selenium/test_javascript.py
@@ -337,6 +337,19 @@ class TestPlaywrightExecutor(SeleniumTestCase):
         })
         self.assertEqual('STEP', self.ENV.get("TAURUS_PWREPORT_GRANULARITY"))
 
+    def test_playwright_noreport_prefix_env_default(self):
+        """Test TAURUS_PWREPORT_NOREPORT_PREFIX defaults to empty string"""
+        self.simple_run({
+            'execution': {
+                'iterations': 1,
+                'scenario': {
+                    "script": RESOURCES_DIR + "playwright",
+                },
+                'executor': 'playwright',
+            },
+        })
+        self.assertEqual('', self.ENV.get("TAURUS_PWREPORT_NOREPORT_PREFIX"))
+
     def test_playwright_reporter_sanitization(self):
         """Test that reporter names are sanitized (spaces, quotes, etc. removed)"""
         self.simple_run({


### PR DESCRIPTION

 
Adds `test.step()`-aware reporting to the Playwright custom reporter, replacing the previous whole-test-only output with configurable granularity, plus a fix for a real step-attribution
bug found during investigation.

### New scenario options

- **`report-granularity`** (`auto` (default) / `step` / `step-leaf` / `test`) — controls what one reported result corresponds to:
  - `auto` (new default): reports step-level detail for tests that use `test.step()`, and one whole-test result for tests that don't. Fixes a regression where a passing test with zero
`test.step()` calls would previously produce no output line at all.
  - `step`: one result per first-level `test.step()` call.
  - `step-leaf`: one result per innermost `test.step()` call in each chain.
  - `test`: one result per whole test (original/legacy behavior).
- **`report-exclude-prefix`** — excludes tests/steps whose title starts with a given prefix from reporting; exclusion cascades to the whole subtree, with pruned-parent promotion under
`step-leaf` so nothing goes silently missing.

### Bug fix

Root-caused and fixed a case where legitimate first-level `test.step()` results were silently dropped: when a whole-test timeout races with in-flight `test.step()` code, Playwright can
attribute a still-running step's parent to its own teardown fixture instead of `null`. `isFirstLevelStep()` now walks the full ancestor chain and only disqualifies a step if a genuine
`test.step` ancestor is found, ignoring `hook`/`fixture` ancestors from this race.

### Safety net

Added a synthetic `__untracked_failure__` marker line, emitted when a test fails/times out under STEP/STEP_LEAF/AUTO granularity with no step already capturing the failure (e.g. a
whole-test timeout where every step reported as passed, or a failure in code outside any `test.step()`), so such failures are never silently lost.
