### PR TITLE
MOB-48124: Never report skipped tests or steps

### DIFF
--- a/bzt/resources/playwright-custom-reporter/playwright-custom-reporter.js
+++ b/bzt/resources/playwright-custom-reporter/playwright-custom-reporter.js
@@ -233,6 +233,14 @@ class TaurusReporter {
       return;
     }
 
+    // A skipped test (test.skip(), a mid-test skip, or a test.describe.serial() group
+    // skipping the rest of its tests after an earlier failure) is not reported at all,
+    // at any granularity - there's nothing to report, and a skip must never be mistaken
+    // for a failure (e.g. by the untracked-failure fallback below).
+    if (result.status === 'skipped') {
+      return;
+    }
+
     if (this.options.granularity === 'TEST') {
       const line = this.buildTestLine(test, result);
       if (this.options.outputFile) {
@@ -314,6 +322,14 @@ class TaurusReporter {
     return !hasReportableChildStep;
   }
 
+  // A step explicitly skipped via step.skip()/step.skip(condition, description) never
+  // throws (so step.error stays falsy) - Playwright records it as a 'skip' annotation on
+  // the step instead. Without this check such a step would be indistinguishable from one
+  // that genuinely ran and passed.
+  isStepSkipped(step) {
+    return Array.isArray(step.annotations) && step.annotations.some(a => a.type === 'skip');
+  }
+
   onStepBegin(test, result, step) {
     this.lastStep = step;
     if (!step.logs) {
@@ -333,6 +349,12 @@ class TaurusReporter {
       // children-exclusion), no separate isExcludedByNoReportPrefix check needed here.
       shouldReport = this.isLeafStep(test, step);
     } else {
+      shouldReport = false;
+    }
+
+    // A skipped step is never reported - like a skipped test, it must not be mistaken
+    // for a passed one (step.error stays falsy for a skip, same as for a genuine pass).
+    if (shouldReport && this.isStepSkipped(step)) {
       shouldReport = false;
     }
 


### PR DESCRIPTION
Both a whole skipped test (test.skip(), a mid-test skip() call, or a test.describe.serial() group skipping the rest of its tests after an earlier failure) and an explicitly skipped test.step() (step.skip() / step.skip(condition, description)) are now excluded from the report entirely, at every granularity - not reported as "passed" (steps never threw, so step.error alone couldn't distinguish a skip from a pass) and not reported at all as a skip.

Also fixes a related bug: a test that ran some steps and then skipped mid-body was incorrectly triggering the __untracked_failure__ synthetic marker (any result.status !== 'passed' was treated as a failure needing the fallback). Excluding 'skipped' upfront in onTestEnd fixes this too, without needing a separate check in the fallback condition.

result.status is read at onTestEnd, which is safe: dispatcher.js sets result.status = params.status (the worker's authoritative final status) immediately before invoking the reporter's onTestEnd hook - a different, reliable read from the "skipped" placeholder default we found earlier during onStepBegin/onStepEnd (before a test concludes).

Verified via repro specs covering all skip variants (declarative test.skip(), mid-test skip after steps already ran, immediate skip with zero steps, explicit step.skip()) across TEST/STEP/STEP_LEAF/AUTO, plus re-confirmed the original test.describe.serial() cascade-skip case (fakeTestSteps.spec.ts) no longer reports the skipped tests, and a full realistic-flow.spec.ts regression showing unchanged counts for the non-skip path.

Each PR must conform to [Developer's Guide](https://gettaurus.org/docs/DeveloperGuide/#Rules-for-Contributing).

Quick checklist:
- [ ] Description of PR explains the context of change
- [ ] Unit tests cover the change, no broken tests
- [ ] No static analysis warnings (Codacy etc.)
- [ ] Documentation update ('available in the unstable snapshot' warning if necessary)
- [ ] Changes file inside `site/dat/docs/changes` directory, one-line note of change inside
