### PR TITLE
fix: pin urwid to ~=3.0.2 to avoid urwid 4.0.0 breaking bzt (#1972)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ psutil>=7.2.2,<7.3.0
 pyvirtualdisplay; sys_platform != 'win32'
 pyyaml
 requests>=2.32.4
-urwid>=3.0.2,<4.0.0
+urwid~=3.0.2
 terminaltables3>=4.0.0
 molotov>=2.6
 influxdb >= 5.3.2


### PR DESCRIPTION
Fixes #1972
