### PR TITLE
MOB-53647 Aggregator: skip labels without dash in extend-aggregation

### DIFF
--- a/bzt/modules/aggregator.py
+++ b/bzt/modules/aggregator.py
@@ -898,6 +898,8 @@ class ConsolidatingAggregator(Aggregator, ResultsProvider):
         mixed_labels = set(data.keys()) - {overall_label}
         data[overall_label] = dict()
         for key in mixed_labels:
+            if '-' not in key:
+                continue  # label has no pass/fail state suffix, skip extension
             sep = key.rindex('-')
             original_label, state = key[:sep], key[sep + 1:]
             kpi_set = data.pop(key)

--- a/tests/unit/modules/test_consolidatingAggregator.py
+++ b/tests/unit/modules/test_consolidatingAggregator.py
@@ -200,7 +200,7 @@ class TestConsolidatingAggregator(BZTestCase):
                     self.assertIn(state, allowed_states, f"Wrong state '{state}' for label '{label}'")
 
     def test_extend_data_labels_without_dash(self):
-        """MOB-43135: Labels without a '-' separator must not crash __extend_reported_data."""
+        """MOB-53647: Labels without a '-' separator must not crash __extend_reported_data."""
         self.obj.settings['extend-aggregation'] = True
         reader = MockReader()
         watcher = MockListener()

--- a/tests/unit/modules/test_consolidatingAggregator.py
+++ b/tests/unit/modules/test_consolidatingAggregator.py
@@ -199,6 +199,31 @@ class TestConsolidatingAggregator(BZTestCase):
                 for state in written_kpis[label].keys():
                     self.assertIn(state, allowed_states, f"Wrong state '{state}' for label '{label}'")
 
+    def test_extend_data_labels_without_dash(self):
+        """MOB-43135: Labels without a '-' separator must not crash __extend_reported_data."""
+        self.obj.settings['extend-aggregation'] = True
+        reader = MockReader()
+        watcher = MockListener()
+        watcher.engine = self.obj.engine
+
+        reader.buffer_scale_idx = '100.0'
+        # Inject a label without '-' directly into the DataPoint to simulate
+        # edge cases where mixed labels lack the expected state suffix.
+        reader.data.append((1, "test_index", 1, 1, 1, 1, '200', None, '', 1))
+
+        self.obj.add_underling(reader)
+        self.obj.add_listener(watcher)
+
+        self.obj.prepare()
+        self.obj.startup()
+        self.obj.check()
+        self.obj.shutdown()
+        self.obj.post_process()
+
+        # Converter must not raise ValueError on labels without '-'
+        for dp in watcher.results:
+            self.obj.converter(dp)  # should not raise
+
     def test_two_executions(self):
         self.obj.track_percentiles = [0, 50, 100]
         self.obj.prepare()


### PR DESCRIPTION
## Summary

- Defensive fix in `__extend_reported_data`: skip labels without `-` separator instead of crashing with `ValueError: substring not found`
- When `extend-aggregation: true` is injected by the BZM backend, labels without a `-state` suffix (e.g. selenium test labels like `test_index`) caused `key.rindex('-')` to crash taurus

## Root Cause

`isTransactionFilterAllowed()` (a.blazemeter.com) was broadened to include selenium executors, which set `hasTransactionsFilter = true` → `TaurusExecutorConfiguration` injected `extend-aggregation: true` → `ConsolidatingAggregator.__extend_reported_data()` crashed on labels without `-`.

Companion PHP fix: Blazemeter/a.blazemeter.com (narrows `isTransactionFilterAllowed()` to BBT-only selenium).

## Test plan

- [x] `test_extend_data_labels_without_dash` — new unit test for labels without `-`
- [x] `test_extend_data` and `test_extend_data_avg` — existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)