### PR TITLE
MOB-53647 Aggregator: propagate extend-aggregation to nested underlings

### DIFF
--- a/bzt/modules/aggregator.py
+++ b/bzt/modules/aggregator.py
@@ -580,6 +580,11 @@ class ResultsProvider(object):
 
     def set_aggregation(self, aggregation):
         self._redundant_aggregation = aggregation
+        # MOB-53647: propagate to nested underlings (e.g. ApiritifLoadReader
+        # is a ConsolidatingAggregator whose startup() is never called by the
+        # engine, so its own underlings never received the flag).
+        for underling in getattr(self, 'underlings', []):
+            underling.set_aggregation(aggregation)
 
     @staticmethod
     def _fuzzy_fold(key, dataset, limit):

--- a/tests/unit/modules/test_consolidatingAggregator.py
+++ b/tests/unit/modules/test_consolidatingAggregator.py
@@ -199,6 +199,40 @@ class TestConsolidatingAggregator(BZTestCase):
                 for state in written_kpis[label].keys():
                     self.assertIn(state, allowed_states, f"Wrong state '{state}' for label '{label}'")
 
+    def test_nested_aggregator_propagates_extend_aggregation(self):
+        """MOB-53647: When an underling is itself a ConsolidatingAggregator (e.g.
+        ApiritifLoadReader), set_aggregation must propagate to the inner's
+        underlings so that get_mixed_label adds the '-state' suffix. Without
+        propagation, the inner's JTLReader produces raw labels that crash
+        __extend_reported_data on key.rindex('-')."""
+        self.obj.settings['extend-aggregation'] = True
+
+        # Build a nested aggregator chain: outer -> inner -> reader
+        inner = ConsolidatingAggregator()
+        inner.engine = self.obj.engine
+        inner.track_percentiles = self.obj.track_percentiles
+
+        reader = MockReader()
+        reader.buffer_scale_idx = '100.0'
+        reader.data.append((1, "Navigate to site", 1, 2, 0, 0, '200', None, '', 2))
+        inner.add_underling(reader)
+
+        self.obj.add_underling(inner)
+
+        self.obj.prepare()
+        self.obj.startup()
+
+        # verify the reader got the flag propagated through the nested chain
+        self.assertTrue(reader._redundant_aggregation,
+                        'set_aggregation must propagate to nested underlings')
+
+        # verify the reader produces mixed labels with '-state' suffix
+        for dp in reader.datapoints(True):
+            mixed_labels = set(dp[DataPoint.CURRENT].keys()) - {''}
+            for label in mixed_labels:
+                self.assertIn('-', label,
+                              f"Label '{label}' missing '-state' suffix — get_mixed_label was not called")
+
     def test_two_executions(self):
         self.obj.track_percentiles = [0, 50, 100]
         self.obj.prepare()


### PR DESCRIPTION
## Summary

Fixes `ValueError: substring not found` crash in `__extend_reported_data` when `extend-aggregation: true` is enabled for BBT (selenium) tests.

## Root Cause

`ApiritifLoadReader` extends `ConsolidatingAggregator` and is added as an underling of the outer `ConsolidatingAggregator`. The chain:

```
Outer ConsolidatingAggregator (engine module, startup() called)
  └── ApiritifLoadReader (inner ConsolidatingAggregator, startup() NOT called)
       └── JTLReader (reads CSV samples)
```

The outer's `startup()` propagates `_redundant_aggregation=True` to the inner via `set_aggregation()`. But the inner's `startup()` is never called by the engine (it's just an underling, not a module). So the inner never propagates the flag to **its** underlings (JTLReader).

Without the flag, JTLReader's `__add_sample` skips `get_mixed_label()`, producing raw labels like `"Navigate to site"` without the required `-state` suffix. When the outer's `converter` runs `__extend_reported_data`, `key.rindex('-')` raises `ValueError`.

## Fix

`set_aggregation()` now recursively propagates to nested underlings:

```python
def set_aggregation(self, aggregation):
    self._redundant_aggregation = aggregation
    for underling in getattr(self, 'underlings', []):
        underling.set_aggregation(aggregation)
```

No risk of infinite loop — the underling tree is a DAG (directed acyclic graph). Leaf nodes like `JTLReader` have `underlings = []`, so recursion terminates. Underlings never reference their parent, so no cycles are possible.

## Test plan

- [x] `test_nested_aggregator_propagates_extend_aggregation` — verifies flag propagation and mixed labels
- [x] All 19 existing consolidating aggregator tests pass

Companion fix: Blazemeter/a.blazemeter.com#8329 (allows BBT executors in `isTransactionFilterAllowed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)