### PR TITLE
MOB-53825: Playwright - install offline via symlinks instead of per-run npm reinstall

### DIFF
--- a/bzt/modules/javascript.py
+++ b/bzt/modules/javascript.py
@@ -500,6 +500,12 @@ def _link_frozen_path(tools_dir, relative_parts):
     """
     source = _frozen_store_path(*relative_parts)
     target = os.path.join(tools_dir, "node_modules", *relative_parts)
+    if os.path.realpath(target) == os.path.realpath(source):
+        # tools_dir IS the frozen store itself (e.g. re-running -install-tools inside an
+        # already-configured shell in the built image, where the freeze env var is already
+        # set): source and target are the same path, so there's nothing to link, and the
+        # deletion below would destroy the frozen store's own content.
+        return
     os.makedirs(os.path.dirname(target), exist_ok=True)
     if os.path.islink(target):
         os.remove(target)
@@ -513,7 +519,7 @@ def _link_frozen_path(tools_dir, relative_parts):
 def _is_linked_to_frozen_path(tools_dir, relative_parts):
     source = _frozen_store_path(*relative_parts)
     target = os.path.join(tools_dir, "node_modules", *relative_parts)
-    return os.path.islink(target) and os.path.realpath(target) == os.path.realpath(source)
+    return os.path.realpath(target) == os.path.realpath(source)
 
 
 def _read_frozen_installed_version(relative_parts):
@@ -658,11 +664,13 @@ class NPMLocalModulePackage(NPMPackage):
             self.package_local_path = os.path.normpath(os.path.join(RESOURCES_DIR, self.package_local_path))
 
     def install(self):
-        # This local module rarely changes between runs, so try --offline first: if npm's
-        # cache from a previous run (or, in the frozen cloud image, from the Docker build
-        # itself) already has everything, this succeeds instantly with no network at all.
-        # Only fall back to --prefer-offline (reuse what's cached, fetch only what's
-        # genuinely missing) when something truly isn't cached yet, e.g. the very first run.
+        # Shared by PlaywrightCustomReporter (a local module that rarely changes between
+        # runs) and NPMModuleInstaller (a customer's own, unpredictable dependency tree) -
+        # try --offline first either way: if npm's cache already has everything (from a
+        # previous run, or in the frozen cloud image, from the Docker build itself), this
+        # succeeds instantly with no network at all. Only fall back to --prefer-offline
+        # (reuse what's cached, fetch only what's genuinely missing) when something truly
+        # isn't cached yet.
         cmdline = [self.npm.tool_path, 'install', ".", '--install-links', '--prefix', self.tools_dir]
 
         for i, extra_arg in enumerate(OFFLINE_INSTALL_ARGS):
@@ -726,6 +734,17 @@ class PlaywrightTypesNodePackage(FrozenPackageLink):
     specifically-requested package.
     """
     PACKAGE_NAME = "@types/node"
+
+    def check_if_installed(self):
+        if self._frozen_version() is not None:
+            return super().check_if_installed()
+        # @types/node has no requirable entry point at all (pure .d.ts, no main .js), so
+        # the inherited require()-based check would always return False here - even right
+        # after a successful install - forcing a redundant reinstall (and a real network
+        # round-trip) on every single non-frozen run. Check for the installed package's
+        # own metadata file instead.
+        pkg_json = os.path.join(self.tools_dir, "node_modules", "@types", "node", "package.json")
+        return os.path.exists(pkg_json)
 
     def _frozen_version(self):
         if os.environ.get("PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION", None) is None:

--- a/bzt/modules/javascript.py
+++ b/bzt/modules/javascript.py
@@ -751,13 +751,32 @@ class PlaywrightTestPackage(FrozenPackageLink):
 
 
 class PlaywrightCustomReporter(NPMLocalModulePackage):
+    """
+    Ships inside the bzt package itself (RESOURCES_DIR), so there's no registry involved -
+    but `npm install . --prefix <tools_dir>` still reifies the customer's entire package.json
+    in that directory, so an unrelated uncached customer dependency sharing the same
+    tools_dir collaterally blocks this too. At frozen cloud runtime, link the copy already
+    installed once into the frozen store (~/.bzt/playwright) at Docker build time instead,
+    the same way as the registry-backed frozen packages.
+    """
     PACKAGE_NAME = "@taurus/playwright-custom-reporter@1.0.1"
     PACKAGE_LOCAL_PATH = "./playwright-custom-reporter"
 
+    def _frozen(self):
+        return os.environ.get("PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION", None) is not None
+
     def check_if_installed(self):
-        # always run install for local module to update to latest version
-        # npm version resolving for local modules is not reliable
-        return False
+        if not self._frozen():
+            # always run install for local module to update to latest version
+            # npm version resolving for local modules is not reliable
+            return False
+        return _is_linked_to_frozen_path(self.tools_dir, self.package_name.split("/"))
+
+    def install(self):
+        if not self._frozen():
+            super().install()
+            return
+        _link_frozen_path(self.tools_dir, self.package_name.split("/"))
 
 class PLAYWRIGHT(RequiredTool):
     def __init__(self, tools_dir, **kwargs):

--- a/bzt/modules/javascript.py
+++ b/bzt/modules/javascript.py
@@ -111,8 +111,8 @@ class PlaywrightTester(JavaScriptExecutor):
 
         # Runs first so a customer declaration for it in tools_dir's package.json gets
         # resolved before PlaywrightTestPackage has to reconcile the same file.
-        npm_types_node = self._get_tool(PlaywrightTypesNodePackage, tools_dir=self.get_launch_cwd(),
-                                         node_tool=self.node, npm_tool=self.npm)
+        npm_types_node = self._get_tool(
+            PlaywrightTypesNodePackage, tools_dir=self.get_launch_cwd(), node_tool=self.node, npm_tool=self.npm)
 
         npm_playwright_test = self._get_tool(PlaywrightTestPackage, tools_dir=self.get_launch_cwd(), node_tool=self.node, npm_tool=self.npm)
         playwright = self._get_tool(PLAYWRIGHT, tools_dir=self.get_launch_cwd())
@@ -120,8 +120,14 @@ class PlaywrightTester(JavaScriptExecutor):
 
         npm_all_packages = self._get_tool(NPMModuleInstaller,node_tool=self.node, npm_tool=self.npm, tools_dir=self.get_launch_cwd())
 
+        # Must run last: NPMModuleInstaller may have just reified a customer-declared
+        # top-level "playwright" dependency, which overwrites node_modules/.bin/playwright
+        # (same bin name as @playwright/test) if it does. Reassert the correct target here,
+        # after everything else that could touch it has already run.
+        playwright_bin_link = self._get_tool(PlaywrightBinLink, tools_dir=self.get_launch_cwd())
+
         tools = [tcl_lib, self.node, self.npm, npm_types_node, npm_playwright_test, npm_all_packages,
-                 playwright, playwright_reporter]
+                 playwright, playwright_reporter, playwright_bin_link]
         self._check_tools(tools)
 
     def get_launch_cmdline(self, *args):
@@ -735,19 +741,30 @@ class PlaywrightTestPackage(FrozenPackageLink):
             return None
         return _read_frozen_installed_version(("@playwright", "test"))
 
+
+class PlaywrightBinLink(RequiredTool):
+    """
+    The unscoped `playwright` package declares the same `bin.playwright` entry as
+    @playwright/test. If a customer's own package.json also depends on plain `playwright`
+    (common - their own test code often imports it directly), NPMModuleInstaller's reify of
+    that dependency overwrites node_modules/.bin/playwright to point at THAT package's
+    cli.js instead, so `npx playwright test` ends up loading a second, different
+    @playwright/test instance internally and fails with "did not expect test() to be
+    called here". Runs last in install_required_tools() (after NPMModuleInstaller) to
+    reassert the correct target every time, regardless of what ran in between.
+    """
+
+    def __init__(self, tools_dir, **kwargs):
+        super(PlaywrightBinLink, self).__init__(installable=True, **kwargs)
+        self.tools_dir = tools_dir
+
     def check_if_installed(self):
-        if not super().check_if_installed():
-            return False
-        if self._frozen_version() is None:
+        if os.environ.get("PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION", None) is None:
             return True
-        # Also make sure the npx-resolvable `playwright` CLI binary (used to launch the
-        # actual test run) is linked, not just the @playwright/test package itself.
         return _is_linked_to_frozen_path(self.tools_dir, (".bin", "playwright"))
 
     def install(self):
-        super().install()
-        if self._frozen_version() is not None:
-            _link_frozen_path(self.tools_dir, (".bin", "playwright"))
+        _link_frozen_path(self.tools_dir, (".bin", "playwright"))
 
 
 class PlaywrightCustomReporter(NPMLocalModulePackage):

--- a/bzt/modules/javascript.py
+++ b/bzt/modules/javascript.py
@@ -16,6 +16,7 @@ limitations under the License.
 import json
 import os
 import re
+import shutil
 from abc import abstractmethod
 
 from bzt import TaurusConfigError, ToolError
@@ -108,13 +109,19 @@ class PlaywrightTester(JavaScriptExecutor):
         self.node = self._get_tool(Node)
         self.npm = self._get_tool(NPM)
 
+        # Runs first so a customer declaration for it in tools_dir's package.json gets
+        # resolved before PlaywrightTestPackage has to reconcile the same file.
+        npm_types_node = self._get_tool(PlaywrightTypesNodePackage, tools_dir=self.get_launch_cwd(),
+                                         node_tool=self.node, npm_tool=self.npm)
+
         npm_playwright_test = self._get_tool(PlaywrightTestPackage, tools_dir=self.get_launch_cwd(), node_tool=self.node, npm_tool=self.npm)
         playwright = self._get_tool(PLAYWRIGHT, tools_dir=self.get_launch_cwd())
         playwright_reporter = self._get_tool(PlaywrightCustomReporter, tools_dir=self.get_launch_cwd(), node_tool=self.node, npm_tool=self.npm)
 
         npm_all_packages = self._get_tool(NPMModuleInstaller,node_tool=self.node, npm_tool=self.npm, tools_dir=self.get_launch_cwd())
 
-        tools = [tcl_lib, self.node, self.npm, npm_playwright_test, npm_all_packages, playwright, playwright_reporter]
+        tools = [tcl_lib, self.node, self.npm, npm_types_node, npm_playwright_test, npm_all_packages,
+                 playwright, playwright_reporter]
         self._check_tools(tools)
 
     def get_launch_cmdline(self, *args):
@@ -468,6 +475,73 @@ class NPM(RequiredTool):
         return False
 
 
+OFFLINE_INSTALL_ARGS = ("--offline", "--prefer-offline")
+
+
+def _frozen_store_path(*relative_parts):
+    return os.path.join(get_full_path("~/.bzt/playwright"), "node_modules", *relative_parts)
+
+
+def _link_frozen_path(tools_dir, relative_parts):
+    """
+    Symlink <tools_dir>/node_modules/<relative_parts> to the same relative path under the
+    frozen store's (~/.bzt/playwright) node_modules, replacing whatever - if anything - is
+    already there. Used for packages Taurus itself owns and freezes at Docker build time:
+    once installed into the frozen store once, every actual test run just links to that
+    single copy instead of running npm, so it never depends on the registry - or even on
+    the active npm cache - being reachable, and it's immune to whichever registry is
+    configured at runtime differing from the one used at build time.
+    """
+    source = _frozen_store_path(*relative_parts)
+    target = os.path.join(tools_dir, "node_modules", *relative_parts)
+    os.makedirs(os.path.dirname(target), exist_ok=True)
+    if os.path.islink(target):
+        os.remove(target)
+    elif os.path.isdir(target):
+        shutil.rmtree(target)
+    elif os.path.exists(target):
+        os.remove(target)
+    os.symlink(source, target)
+
+
+def _is_linked_to_frozen_path(tools_dir, relative_parts):
+    source = _frozen_store_path(*relative_parts)
+    target = os.path.join(tools_dir, "node_modules", *relative_parts)
+    return os.path.islink(target) and os.path.realpath(target) == os.path.realpath(source)
+
+
+def _read_frozen_installed_version(relative_parts):
+    pkg_json = _frozen_store_path(*relative_parts, "package.json")
+    try:
+        with open(pkg_json) as fds:
+            return json.load(fds).get("version")
+    except (OSError, ValueError):
+        return None
+
+
+def _pin_package_json_dependency(tools_dir, package_name, version):
+    """
+    Force <package_name> to resolve to <version> in <tools_dir>/package.json, matching what's
+    actually linked into node_modules there, so a later `npm install .` for the rest of a
+    customer's own declared dependencies sees an already-consistent tree and leaves this
+    entry alone.
+    """
+    pkg_json_path = os.path.join(tools_dir, "package.json")
+    try:
+        with open(pkg_json_path) as fds:
+            data = json.load(fds)
+    except (OSError, ValueError):
+        data = {}
+    section = "devDependencies"
+    for candidate in ("dependencies", "devDependencies"):
+        if package_name in data.get(candidate, {}):
+            section = candidate
+            break
+    data.setdefault(section, {})[package_name] = "^" + version
+    with open(pkg_json_path, "w") as fds:
+        json.dump(data, fds, indent=2)
+
+
 class NPMPackage(RequiredTool):
     PACKAGE_NAME = ""
 
@@ -523,11 +597,43 @@ class NPMPackage(RequiredTool):
             out, err = self.call(cmdline)
         except CALL_PROBLEMS as exc:
             self.log.debug("%s install failed: %s", self.package_name, exc)
+            self.log.warning("Failed to install %s", self.package_name)
             return
 
         self.log.debug("%s install stdout: %s", self.tool_name, out)
         if err:
             self.log.warning("%s install stderr: %s", self.tool_name, err)
+
+
+class FrozenPackageLink(NPMPackage):
+    """
+    For npm packages Taurus itself owns and freezes at Docker build time (not
+    customer-declared, unpredictable content): once a real npm install has happened once
+    into the frozen store (~/.bzt/playwright), every actual test run just links the
+    already-installed package into its own ephemeral directory instead of running npm at
+    all. No install command ever touches the registry - or whichever one is currently
+    configured, if it differs from the one used at build time - for these packages again.
+    """
+
+    def _frozen_version(self):
+        """Version to force-link to, or None when not running frozen."""
+        raise NotImplementedError
+
+    def check_if_installed(self):
+        frozen_version = self._frozen_version()
+        if frozen_version is None:
+            return super().check_if_installed()
+        return _is_linked_to_frozen_path(self.tools_dir, self.package_name.split("/"))
+
+    def install(self):
+        frozen_version = self._frozen_version()
+        if frozen_version is None:
+            super().install()
+            return
+
+        _link_frozen_path(self.tools_dir, self.package_name.split("/"))
+        _pin_package_json_dependency(self.tools_dir, self.package_name, frozen_version)
+
 
 class NPMModulePackage(NPMPackage):
     def __init__(self, tools_dir, node_tool, npm_tool, **kwargs):
@@ -546,17 +652,27 @@ class NPMLocalModulePackage(NPMPackage):
             self.package_local_path = os.path.normpath(os.path.join(RESOURCES_DIR, self.package_local_path))
 
     def install(self):
+        # This local module rarely changes between runs, so try --offline first: if npm's
+        # cache from a previous run (or, in the frozen cloud image, from the Docker build
+        # itself) already has everything, this succeeds instantly with no network at all.
+        # Only fall back to --prefer-offline (reuse what's cached, fetch only what's
+        # genuinely missing) when something truly isn't cached yet, e.g. the very first run.
         cmdline = [self.npm.tool_path, 'install', ".", '--install-links', '--prefix', self.tools_dir]
 
-        try:
-            out, err = self.call(cmdline, cwd=self.package_local_path)
-        except CALL_PROBLEMS as exc:
-            self.log.debug("%s install failed: %s", self.package_name, exc)
-            return
+        for i, extra_arg in enumerate(OFFLINE_INSTALL_ARGS):
+            try:
+                out, err = self.call(cmdline + [extra_arg], cwd=self.package_local_path)
+                self.log.debug("%s install stdout: %s", self.tool_name, out)
+                if err:
+                    self.log.warning("%s install stderr: %s", self.tool_name, err)
+                return
+            except CALL_PROBLEMS as exc:
+                self.log.debug("%s install with %s failed: %s", self.package_name, extra_arg, exc)
+                if i + 1 < len(OFFLINE_INSTALL_ARGS):
+                    self.log.info("Failed to install %s with %s, retrying with %s",
+                                  self.package_name, extra_arg, OFFLINE_INSTALL_ARGS[i + 1])
 
-        self.log.debug("%s install stdout: %s", self.tool_name, out)
-        if err:
-            self.log.warning("%s install stderr: %s", self.tool_name, err)
+        self.log.warning("%s install failed with all attempts: %s", self.package_name, ", ".join(OFFLINE_INSTALL_ARGS))
 
 
 class NPMModuleInstaller(NPMLocalModulePackage):
@@ -592,32 +708,47 @@ class TaurusNewmanPlugin(RequiredTool):
         tool_path = os.path.join(RESOURCES_DIR, "newman-reporter-taurus.js")
         super(TaurusNewmanPlugin, self).__init__(tool_path=tool_path, installable=False, **kwargs)
 
-class PlaywrightTestPackage(NPMPackage):
-    PACKAGE_NAME = "@playwright/test" if os.environ.get("PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION", None) is None \
-        else "@playwright/test@" + os.environ.get("PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION")
+class PlaywrightTypesNodePackage(FrozenPackageLink):
+    """
+    Playwright's own official TypeScript scaffolding (`npm init playwright@latest`) always
+    adds @types/node as a devDependency alongside @playwright/test. It has no runtime code
+    at all (pure .d.ts type declarations, consulted only by the TypeScript compiler - never
+    by Node's own require()/import), but it typically lives in the SAME package.json that
+    PlaywrightTestPackage/PLAYWRIGHT also install into (the customer's own tools_dir). An
+    unresolvable copy of it (uncached, registry unreachable) can block THEIR install too,
+    since npm's reify step resolves the whole declared tree in that directory, not just the
+    specifically-requested package.
+    """
+    PACKAGE_NAME = "@types/node"
+
+    def _frozen_version(self):
+        if os.environ.get("PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION", None) is None:
+            return None
+        return _read_frozen_installed_version(("@types", "node"))
+
+
+class PlaywrightTestPackage(FrozenPackageLink):
+    PACKAGE_NAME = "@playwright/test"
+
+    def _frozen_version(self):
+        if os.environ.get("PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION", None) is None:
+            return None
+        return _read_frozen_installed_version(("@playwright", "test"))
 
     def check_if_installed(self):
         if not super().check_if_installed():
             return False
-        # Check if installed version is expected version if we force version
-        forced_version = os.environ.get("PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION", None)
-        if forced_version is None:
-            # Not forcing version, any installed is good
+        if self._frozen_version() is None:
             return True
+        # Also make sure the npx-resolvable `playwright` CLI binary (used to launch the
+        # actual test run) is linked, not just the @playwright/test package itself.
+        return _is_linked_to_frozen_path(self.tools_dir, (".bin", "playwright"))
 
-        # `npx --no` reads the locally-installed version without fetching from the
-        # registry. Mirrors the freeze step in taurus-cloud Dockerfile-reduced.
-        cmdline = ["npx", "--no", "--", "@playwright/test", "--version"]
-        try:
-            out, _ = self.call(cmdline, cwd=self.tools_dir)
-            installed = (out or "").strip().split()[-1] if (out or "").strip() else ""
-            version_changed = installed != forced_version
-            if version_changed:
-                self.log.warning("Frozen version not found in installed packages, will re-install %s", self.PACKAGE_NAME)
-            return not version_changed
-        except CALL_PROBLEMS as exc:
-            self.log.debug("%s check of forced version failed: %s", self.PACKAGE_NAME, exc)
-            return False
+    def install(self):
+        super().install()
+        if self._frozen_version() is not None:
+            _link_frozen_path(self.tools_dir, (".bin", "playwright"))
+
 
 class PlaywrightCustomReporter(NPMLocalModulePackage):
     PACKAGE_NAME = "@taurus/playwright-custom-reporter@1.0.1"
@@ -643,10 +774,11 @@ class PLAYWRIGHT(RequiredTool):
         version_changed = False
         if frozen_version:
             # `npx --no` reads the locally-installed version without fetching from the
-            # registry. Mirrors the freeze step in taurus-cloud Dockerfile-reduced.
+            # registry, run against ~/.bzt/playwright: taurus-cloud's Dockerfile-reduced
+            # freezes the version by installing into that directory.
             cmdline = ["npx", "--no", "--", "playwright", "--version"]
             try:
-                out, _ = self.call(cmdline, cwd=self.tools_dir)
+                out, _ = self.call(cmdline, cwd=get_full_path("~/.bzt/playwright"))
                 installed = (out or "").strip().split()[-1] if (out or "").strip() else ""
                 version_changed = installed != frozen_version
                 if version_changed:

--- a/tests/unit/modules/_selenium/test_javascript.py
+++ b/tests/unit/modules/_selenium/test_javascript.py
@@ -7,7 +7,9 @@ import bzt
 
 from bzt import ToolError
 from bzt.modules.javascript import NPMPackage, JavaScriptExecutor, NewmanExecutor, Mocha, JSSeleniumWebdriver, \
-    PlaywrightTester, PLAYWRIGHT, PlaywrightTestPackage, PlaywrightLogReader
+    PlaywrightTester, PLAYWRIGHT, PlaywrightTestPackage, PlaywrightTypesNodePackage, PlaywrightCustomReporter, \
+    NPMModuleInstaller, PlaywrightLogReader, OFFLINE_INSTALL_ARGS, _link_frozen_path, _is_linked_to_frozen_path, \
+    _pin_package_json_dependency, _read_frozen_installed_version
 from bzt.utils import get_full_path, EXE_SUFFIX
 
 from tests.unit import RESOURCES_DIR, BZTestCase, EngineEmul
@@ -698,10 +700,11 @@ class TestPlaywrightInstallation(BZTestCase):
         with patch.dict(os.environ, {'PLAYWRIGHT_PACKAGE_FORCED_VERSION': '1.40.0'}):
             playwright.install()
 
-            # Should call npx --no -- playwright --version once to check the installed version
+            # Should call npx --no -- playwright --version once, against the frozen
+            # build-time location (~/.bzt/playwright), not tools_dir.
             playwright.call.assert_called_once_with(
                 ["npx", "--no", "--", "playwright", "--version"],
-                cwd=self.tools_dir,
+                cwd=get_full_path("~/.bzt/playwright"),
             )
 
     @patch('bzt.modules.javascript.is_linux')
@@ -718,10 +721,10 @@ class TestPlaywrightInstallation(BZTestCase):
         with patch.dict(os.environ, {'PLAYWRIGHT_PACKAGE_FORCED_VERSION': '1.40.0'}):
             playwright.install()
 
-            # First call: version probe
+            # First call: version probe, run against the frozen build-time location
             first_call_args = playwright.call.call_args_list[0][0][0]
             self.assertEqual(first_call_args, ["npx", "--no", "--", "playwright", "--version"])
-            self.assertEqual(playwright.call.call_args_list[0][1].get('cwd'), self.tools_dir)
+            self.assertEqual(playwright.call.call_args_list[0][1].get('cwd'), get_full_path("~/.bzt/playwright"))
 
             # Second call: npx playwright@1.40.0 install --with-deps
             self.assertEqual(playwright.call.call_count, 2)
@@ -826,16 +829,131 @@ class TestPlaywrightInstallation(BZTestCase):
             self.assertTrue(any("playwright" in str(arg) and "@" not in str(arg) for arg in call_args if "playwright" in str(arg)))
 
 
+class TestFrozenPackageLinkHelpers(BZTestCase):
+    """Tests for the module-level symlink/pin helpers shared by all frozen packages"""
+
+    def setUp(self):
+        super(TestFrozenPackageLinkHelpers, self).setUp()
+        import tempfile
+        self.frozen_store = tempfile.mkdtemp()
+        self.tools_dir = tempfile.mkdtemp()
+        self.get_full_path_patcher = patch('bzt.modules.javascript.get_full_path', return_value=self.frozen_store)
+        self.get_full_path_patcher.start()
+        self.addCleanup(self.get_full_path_patcher.stop)
+
+    def _make_frozen_package(self, relative_parts, contents=b"module.exports = {};"):
+        path = os.path.join(self.frozen_store, "node_modules", *relative_parts)
+        os.makedirs(path, exist_ok=True)
+        with open(os.path.join(path, "index.js"), "wb") as fds:
+            fds.write(contents)
+        return path
+
+    def test_link_frozen_path_creates_symlink(self):
+        source = self._make_frozen_package(("@types", "node"))
+        _link_frozen_path(self.tools_dir, ("@types", "node"))
+
+        target = os.path.join(self.tools_dir, "node_modules", "@types", "node")
+        self.assertTrue(os.path.islink(target))
+        self.assertEqual(os.path.realpath(target), os.path.realpath(source))
+
+    def test_link_frozen_path_replaces_existing_real_directory(self):
+        self._make_frozen_package(("@types", "node"))
+        stale = os.path.join(self.tools_dir, "node_modules", "@types", "node")
+        os.makedirs(stale, exist_ok=True)
+        with open(os.path.join(stale, "stale.txt"), "w") as fds:
+            fds.write("stale customer-declared copy")
+
+        _link_frozen_path(self.tools_dir, ("@types", "node"))
+
+        self.assertTrue(os.path.islink(stale))
+
+    def test_link_frozen_path_replaces_existing_symlink(self):
+        self._make_frozen_package(("@types", "node"))
+        target = os.path.join(self.tools_dir, "node_modules", "@types", "node")
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        os.symlink("/nonexistent", target)
+
+        _link_frozen_path(self.tools_dir, ("@types", "node"))
+
+        self.assertTrue(os.path.exists(os.path.join(target, "index.js")))
+
+    def test_is_linked_to_frozen_path_true_after_linking(self):
+        self._make_frozen_package(("@playwright", "test"))
+        _link_frozen_path(self.tools_dir, ("@playwright", "test"))
+
+        self.assertTrue(_is_linked_to_frozen_path(self.tools_dir, ("@playwright", "test")))
+
+    def test_is_linked_to_frozen_path_false_when_missing(self):
+        self._make_frozen_package(("@playwright", "test"))
+        self.assertFalse(_is_linked_to_frozen_path(self.tools_dir, ("@playwright", "test")))
+
+    def test_is_linked_to_frozen_path_false_for_unrelated_symlink(self):
+        target = os.path.join(self.tools_dir, "node_modules", "@playwright", "test")
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        os.symlink("/somewhere/else", target)
+
+        self.assertFalse(_is_linked_to_frozen_path(self.tools_dir, ("@playwright", "test")))
+
+    def test_pin_package_json_dependency_updates_existing_devDependencies_entry(self):
+        pkg_json = os.path.join(self.tools_dir, "package.json")
+        with open(pkg_json, "w") as fds:
+            json.dump({"devDependencies": {"@types/node": "^22.15.21"}}, fds)
+
+        _pin_package_json_dependency(self.tools_dir, "@types/node", "26.5.0")
+
+        with open(pkg_json) as fds:
+            data = json.load(fds)
+        self.assertEqual(data["devDependencies"]["@types/node"], "^26.5.0")
+
+    def test_pin_package_json_dependency_updates_existing_dependencies_entry(self):
+        pkg_json = os.path.join(self.tools_dir, "package.json")
+        with open(pkg_json, "w") as fds:
+            json.dump({"dependencies": {"@playwright/test": "^1.58.1"}}, fds)
+
+        _pin_package_json_dependency(self.tools_dir, "@playwright/test", "1.63.0")
+
+        with open(pkg_json) as fds:
+            data = json.load(fds)
+        self.assertEqual(data["dependencies"]["@playwright/test"], "^1.63.0")
+        self.assertNotIn("@playwright/test", data.get("devDependencies", {}))
+
+    def test_pin_package_json_dependency_adds_missing_entry(self):
+        pkg_json = os.path.join(self.tools_dir, "package.json")
+        with open(pkg_json, "w") as fds:
+            json.dump({"devDependencies": {"@playwright/test": "^1.58.1"}}, fds)
+
+        _pin_package_json_dependency(self.tools_dir, "@types/node", "26.5.0")
+
+        with open(pkg_json) as fds:
+            data = json.load(fds)
+        self.assertEqual(data["devDependencies"]["@types/node"], "^26.5.0")
+
+    def test_read_frozen_installed_version_reads_actual_version(self):
+        path = self._make_frozen_package(("@types", "node"))
+        with open(os.path.join(path, "package.json"), "w") as fds:
+            json.dump({"version": "26.5.0"}, fds)
+
+        self.assertEqual(_read_frozen_installed_version(("@types", "node")), "26.5.0")
+
+    def test_read_frozen_installed_version_missing_returns_none(self):
+        self.assertIsNone(_read_frozen_installed_version(("@types", "node")))
+
+
 class TestPlaywrightTestPackageInstallation(BZTestCase):
-    """Tests for PlaywrightTestPackage.check_if_installed()"""
+    """Tests for PlaywrightTestPackage: symlink-based when frozen, normal npm install otherwise"""
 
     def setUp(self):
         super(TestPlaywrightTestPackageInstallation, self).setUp()
+        import tempfile
         self.node_mock = MagicMock()
         self.node_mock.tool_path = "node"
         self.npm_mock = MagicMock()
         self.npm_mock.tool_path = "npm"
-        self.tools_dir = "~/.bzt/playwright"
+        self.frozen_store = tempfile.mkdtemp()
+        self.tools_dir = tempfile.mkdtemp()
+        self.get_full_path_patcher = patch('bzt.modules.javascript.get_full_path', return_value=self.frozen_store)
+        self.get_full_path_patcher.start()
+        self.addCleanup(self.get_full_path_patcher.stop)
 
     def _create_package(self):
         return PlaywrightTestPackage(
@@ -844,72 +962,267 @@ class TestPlaywrightTestPackageInstallation(BZTestCase):
             npm_tool=self.npm_mock,
         )
 
-    def test_check_if_installed_super_returns_false(self):
-        """When the parent require() check fails, return False without probing version"""
-        pkg = self._create_package()
-        pkg.call = MagicMock(return_value=("", ""))
+    def _freeze_playwright_test(self, version="1.63.0"):
+        path = os.path.join(self.frozen_store, "node_modules", "@playwright", "test")
+        os.makedirs(path, exist_ok=True)
+        with open(os.path.join(path, "package.json"), "w") as fds:
+            json.dump({"version": version}, fds)
+        bin_dir = os.path.join(self.frozen_store, "node_modules", ".bin")
+        os.makedirs(bin_dir, exist_ok=True)
+        with open(os.path.join(bin_dir, "playwright"), "w") as fds:
+            fds.write("#!/bin/sh\n")
+        return version
 
-        result = pkg.check_if_installed()
-
-        self.assertFalse(result)
-        pkg.call.assert_called_once()
-
-    def test_check_if_installed_no_forced_version(self):
-        """When no forced version is set, any installed version is acceptable and the probe is not called"""
+    def test_check_if_installed_not_frozen_delegates_to_super(self):
+        """Without a forced version, behaves like a plain NPMPackage (require() check only)"""
         pkg = self._create_package()
         pkg.call = MagicMock(return_value=("@playwright/test is installed", ""))
 
         with patch.dict(os.environ, {}, clear=False):
-            if 'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION' in os.environ:
-                del os.environ['PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION']
-
+            os.environ.pop('PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION', None)
             result = pkg.check_if_installed()
 
         self.assertTrue(result)
         pkg.call.assert_called_once()
 
-    def test_check_if_installed_forced_version_correct(self):
-        """When forced version matches the installed version, return True"""
+    def test_install_not_frozen_delegates_to_super(self):
+        """Without a forced version, install() runs a normal npm install"""
         pkg = self._create_package()
-        pkg.call = MagicMock(side_effect=[
-            ("@playwright/test is installed", ""),
-            ("Version 1.40.0\n", ""),
-        ])
+        pkg.call = MagicMock(return_value=("", ""))
 
-        with patch.object(PlaywrightTestPackage, 'PACKAGE_NAME', '@playwright/test@1.40.0'):
-            with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': '1.40.0'}):
-                result = pkg.check_if_installed()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop('PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION', None)
+            pkg.install()
 
-        self.assertTrue(result)
-        self.assertEqual(pkg.call.call_count, 2)
-        second_call_args = pkg.call.call_args_list[1][0][0]
-        self.assertEqual(second_call_args, ["npx", "--no", "--", "@playwright/test", "--version"])
-        self.assertEqual(pkg.call.call_args_list[1][1].get('cwd'), self.tools_dir)
+        cmdline = pkg.call.call_args[0][0]
+        self.assertEqual(cmdline, ["npm", "install", "@playwright/test", "--prefix", self.tools_dir])
 
-    def test_check_if_installed_forced_version_mismatch(self):
-        """When the probed version differs from the forced version, return False"""
+    def test_install_frozen_links_package_and_bin(self):
+        """When frozen, install() symlinks both the package and the .bin/playwright entry"""
+        version = self._freeze_playwright_test()
         pkg = self._create_package()
-        pkg.call = MagicMock(side_effect=[
-            ("@playwright/test is installed", ""),
-            ("Version 1.39.0\n", ""),
-        ])
+        pkg.call = MagicMock()
 
-        with patch.object(PlaywrightTestPackage, 'PACKAGE_NAME', '@playwright/test@1.40.0'):
-            with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': '1.40.0'}):
-                result = pkg.check_if_installed()
+        with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': version}):
+            pkg.install()
 
-        self.assertFalse(result)
-        self.assertEqual(pkg.call.call_count, 2)
+        pkg_target = os.path.join(self.tools_dir, "node_modules", "@playwright", "test")
+        bin_target = os.path.join(self.tools_dir, "node_modules", ".bin", "playwright")
+        self.assertTrue(os.path.islink(pkg_target))
+        self.assertTrue(os.path.islink(bin_target))
+        pkg.call.assert_not_called()
 
-    def test_check_if_installed_version_probe_fails(self):
-        """When the version probe raises an OSError, return False"""
+    def test_install_frozen_pins_package_json(self):
+        version = self._freeze_playwright_test(version="1.63.0")
         pkg = self._create_package()
-        pkg.call = MagicMock(side_effect=[
-            ("@playwright/test is installed", ""),
-            OSError("npx probe failed"),
-        ])
+        with open(os.path.join(self.tools_dir, "package.json"), "w") as fds:
+            json.dump({"devDependencies": {"@playwright/test": "^1.58.1"}}, fds)
 
-        with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': '1.40.0'}):
+        with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': version}):
+            pkg.install()
+
+        with open(os.path.join(self.tools_dir, "package.json")) as fds:
+            data = json.load(fds)
+        self.assertEqual(data["devDependencies"]["@playwright/test"], "^1.63.0")
+
+    def test_check_if_installed_frozen_true_after_install(self):
+        version = self._freeze_playwright_test()
+        pkg = self._create_package()
+        with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': version}):
+            pkg.install()
+            self.assertTrue(pkg.check_if_installed())
+
+    def test_check_if_installed_frozen_false_before_install(self):
+        version = self._freeze_playwright_test()
+        pkg = self._create_package()
+        with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': version}):
+            self.assertFalse(pkg.check_if_installed())
+
+    def test_check_if_installed_frozen_false_when_bin_missing(self):
+        """Package linked but .bin/playwright missing (e.g. interrupted prior run) -> not installed"""
+        version = self._freeze_playwright_test()
+        pkg = self._create_package()
+        with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': version}):
+            pkg.install()
+            os.remove(os.path.join(self.tools_dir, "node_modules", ".bin", "playwright"))
+            self.assertFalse(pkg.check_if_installed())
+
+
+class TestPlaywrightTypesNodePackage(BZTestCase):
+    """Tests for PlaywrightTypesNodePackage: symlink-based when frozen, normal npm install otherwise"""
+
+    def setUp(self):
+        super(TestPlaywrightTypesNodePackage, self).setUp()
+        import tempfile
+        self.node_mock = MagicMock()
+        self.node_mock.tool_path = "node"
+        self.npm_mock = MagicMock()
+        self.npm_mock.tool_path = "npm"
+        self.frozen_store = tempfile.mkdtemp()
+        self.tools_dir = tempfile.mkdtemp()
+        self.get_full_path_patcher = patch('bzt.modules.javascript.get_full_path', return_value=self.frozen_store)
+        self.get_full_path_patcher.start()
+        self.addCleanup(self.get_full_path_patcher.stop)
+
+    def _create_package(self):
+        return PlaywrightTypesNodePackage(
+            tools_dir=self.tools_dir,
+            node_tool=self.node_mock,
+            npm_tool=self.npm_mock,
+        )
+
+    def _freeze_types_node(self, version="26.5.0"):
+        path = os.path.join(self.frozen_store, "node_modules", "@types", "node")
+        os.makedirs(path, exist_ok=True)
+        with open(os.path.join(path, "package.json"), "w") as fds:
+            json.dump({"version": version}, fds)
+        return version
+
+    def test_check_if_installed_not_frozen_delegates_to_super(self):
+        pkg = self._create_package()
+        pkg.call = MagicMock(return_value=("", ""))
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop('PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION', None)
+            # @types/node has no requirable entry point at all - always False, as expected
             result = pkg.check_if_installed()
 
         self.assertFalse(result)
+
+    def test_install_not_frozen_delegates_to_super(self):
+        pkg = self._create_package()
+        pkg.call = MagicMock(return_value=("", ""))
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop('PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION', None)
+            pkg.install()
+
+        cmdline = pkg.call.call_args[0][0]
+        self.assertEqual(cmdline, ["npm", "install", "@types/node", "--prefix", self.tools_dir])
+
+    def test_install_frozen_links_package(self):
+        version = self._freeze_types_node()
+        pkg = self._create_package()
+        pkg.call = MagicMock()
+
+        with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': version}):
+            pkg.install()
+
+        target = os.path.join(self.tools_dir, "node_modules", "@types", "node")
+        self.assertTrue(os.path.islink(target))
+        pkg.call.assert_not_called()
+
+    def test_check_if_installed_frozen_true_after_install(self):
+        version = self._freeze_types_node()
+        pkg = self._create_package()
+        with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': version}):
+            pkg.install()
+            self.assertTrue(pkg.check_if_installed())
+
+    def test_check_if_installed_frozen_false_before_install(self):
+        version = self._freeze_types_node()
+        pkg = self._create_package()
+        with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': version}):
+            self.assertFalse(pkg.check_if_installed())
+
+
+class TestPlaywrightCustomReporterInstallation(BZTestCase):
+    """
+    Tests for PlaywrightCustomReporter: always a local (registry-free) install, every run -
+    it ships inside the bzt package itself, so there's no registry-unreachable problem for
+    it to solve and no reason to freeze/symlink it like the registry-backed packages.
+    """
+
+    def setUp(self):
+        super(TestPlaywrightCustomReporterInstallation, self).setUp()
+        self.node_mock = MagicMock()
+        self.node_mock.tool_path = "node"
+        self.npm_mock = MagicMock()
+        self.npm_mock.tool_path = "npm"
+        self.tools_dir = "/tmp/customer-tools-dir"
+
+    def _create_package(self):
+        return PlaywrightCustomReporter(
+            tools_dir=self.tools_dir,
+            node_tool=self.node_mock,
+            npm_tool=self.npm_mock,
+        )
+
+    def test_check_if_installed_always_false(self):
+        """Always reinstall: npm version resolving for local modules is not reliable"""
+        pkg = self._create_package()
+        with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': '1.63.0'}):
+            self.assertFalse(pkg.check_if_installed())
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop('PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION', None)
+            self.assertFalse(pkg.check_if_installed())
+
+    def test_install_runs_local_npm_install(self):
+        pkg = self._create_package()
+        pkg.call = MagicMock(return_value=("", ""))
+
+        pkg.install()
+
+        args, kwargs = pkg.call.call_args
+        self.assertEqual(args[0], ["npm", "install", ".", "--install-links", "--prefix", self.tools_dir, "--offline"])
+        self.assertEqual(kwargs.get("cwd"), pkg.package_local_path)
+
+
+class TestNPMModuleInstallerInstallation(BZTestCase):
+    """Tests for NPMModuleInstaller (customer's own arbitrary deps): offline-first, then --prefer-offline"""
+
+    def setUp(self):
+        super(TestNPMModuleInstallerInstallation, self).setUp()
+        self.node_mock = MagicMock()
+        self.node_mock.tool_path = "node"
+        self.npm_mock = MagicMock()
+        self.npm_mock.tool_path = "npm"
+        self.tools_dir = "/tmp/customer-tools-dir"
+
+    def _create_installer(self):
+        return NPMModuleInstaller(
+            tools_dir=self.tools_dir,
+            node_tool=self.node_mock,
+            npm_tool=self.npm_mock,
+        )
+
+    def test_package_local_path_is_tools_dir(self):
+        installer = self._create_installer()
+        self.assertEqual(installer.package_local_path, self.tools_dir)
+
+    def test_install_offline_succeeds(self):
+        installer = self._create_installer()
+        installer.call = MagicMock(return_value=("added 3 packages", ""))
+
+        installer.install()
+
+        installer.call.assert_called_once()
+        cmdline = installer.call.call_args[0][0]
+        self.assertIn("--offline", cmdline)
+        self.assertNotIn("--prefer-offline", cmdline)
+
+    def test_install_offline_fails_prefer_offline_succeeds(self):
+        installer = self._create_installer()
+        installer.call = MagicMock(side_effect=[
+            OSError("ENOTCACHED"),
+            ("added 3 packages", ""),
+        ])
+
+        installer.install()
+
+        self.assertEqual(installer.call.call_count, 2)
+        first_cmdline = installer.call.call_args_list[0][0][0]
+        second_cmdline = installer.call.call_args_list[1][0][0]
+        self.assertIn("--offline", first_cmdline)
+        self.assertIn("--prefer-offline", second_cmdline)
+
+    def test_install_both_offline_attempts_fail(self):
+        installer = self._create_installer()
+        installer.call = MagicMock(side_effect=[
+            OSError("ENOTCACHED"),
+            OSError("ECONNREFUSED"),
+        ])
+
+        installer.install()  # must not raise
+
+        self.assertEqual(installer.call.call_count, len(OFFLINE_INSTALL_ARGS))

--- a/tests/unit/modules/_selenium/test_javascript.py
+++ b/tests/unit/modules/_selenium/test_javascript.py
@@ -8,7 +8,8 @@ import bzt
 from bzt import ToolError
 from bzt.modules.javascript import NPMPackage, JavaScriptExecutor, NewmanExecutor, Mocha, JSSeleniumWebdriver, \
     PlaywrightTester, PLAYWRIGHT, PlaywrightTestPackage, PlaywrightTypesNodePackage, PlaywrightCustomReporter, \
-    NPMModuleInstaller, PlaywrightLogReader, OFFLINE_INSTALL_ARGS, _link_frozen_path, _is_linked_to_frozen_path, \
+    PlaywrightBinLink, NPMModuleInstaller, PlaywrightLogReader, OFFLINE_INSTALL_ARGS, _link_frozen_path, \
+    _is_linked_to_frozen_path, \
     _pin_package_json_dependency, _read_frozen_installed_version
 from bzt.utils import get_full_path, EXE_SUFFIX
 
@@ -967,10 +968,6 @@ class TestPlaywrightTestPackageInstallation(BZTestCase):
         os.makedirs(path, exist_ok=True)
         with open(os.path.join(path, "package.json"), "w") as fds:
             json.dump({"version": version}, fds)
-        bin_dir = os.path.join(self.frozen_store, "node_modules", ".bin")
-        os.makedirs(bin_dir, exist_ok=True)
-        with open(os.path.join(bin_dir, "playwright"), "w") as fds:
-            fds.write("#!/bin/sh\n")
         return version
 
     def test_check_if_installed_not_frozen_delegates_to_super(self):
@@ -997,8 +994,7 @@ class TestPlaywrightTestPackageInstallation(BZTestCase):
         cmdline = pkg.call.call_args[0][0]
         self.assertEqual(cmdline, ["npm", "install", "@playwright/test", "--prefix", self.tools_dir])
 
-    def test_install_frozen_links_package_and_bin(self):
-        """When frozen, install() symlinks both the package and the .bin/playwright entry"""
+    def test_install_frozen_links_package(self):
         version = self._freeze_playwright_test()
         pkg = self._create_package()
         pkg.call = MagicMock()
@@ -1007,9 +1003,7 @@ class TestPlaywrightTestPackageInstallation(BZTestCase):
             pkg.install()
 
         pkg_target = os.path.join(self.tools_dir, "node_modules", "@playwright", "test")
-        bin_target = os.path.join(self.tools_dir, "node_modules", ".bin", "playwright")
         self.assertTrue(os.path.islink(pkg_target))
-        self.assertTrue(os.path.islink(bin_target))
         pkg.call.assert_not_called()
 
     def test_install_frozen_pins_package_json(self):
@@ -1038,14 +1032,64 @@ class TestPlaywrightTestPackageInstallation(BZTestCase):
         with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': version}):
             self.assertFalse(pkg.check_if_installed())
 
-    def test_check_if_installed_frozen_false_when_bin_missing(self):
-        """Package linked but .bin/playwright missing (e.g. interrupted prior run) -> not installed"""
-        version = self._freeze_playwright_test()
-        pkg = self._create_package()
-        with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': version}):
-            pkg.install()
-            os.remove(os.path.join(self.tools_dir, "node_modules", ".bin", "playwright"))
-            self.assertFalse(pkg.check_if_installed())
+
+class TestPlaywrightBinLink(BZTestCase):
+    """
+    Tests for PlaywrightBinLink: reasserts node_modules/.bin/playwright -> @playwright/test's
+    cli.js as the last install step, since NPMModuleInstaller may have just overwritten it
+    while reifying a customer-declared top-level "playwright" dependency of their own (same
+    bin name, different package).
+    """
+
+    def setUp(self):
+        super(TestPlaywrightBinLink, self).setUp()
+        import tempfile
+        self.frozen_store = tempfile.mkdtemp()
+        self.tools_dir = tempfile.mkdtemp()
+        self.get_full_path_patcher = patch('bzt.modules.javascript.get_full_path', return_value=self.frozen_store)
+        self.get_full_path_patcher.start()
+        self.addCleanup(self.get_full_path_patcher.stop)
+
+    def _freeze_bin(self):
+        bin_dir = os.path.join(self.frozen_store, "node_modules", ".bin")
+        os.makedirs(bin_dir, exist_ok=True)
+        with open(os.path.join(bin_dir, "playwright"), "w") as fds:
+            fds.write("#!/bin/sh\n")
+
+    def test_check_if_installed_not_frozen_always_true(self):
+        link = PlaywrightBinLink(tools_dir=self.tools_dir)
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop('PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION', None)
+            self.assertTrue(link.check_if_installed())
+
+    def test_check_if_installed_frozen_false_when_missing(self):
+        self._freeze_bin()
+        link = PlaywrightBinLink(tools_dir=self.tools_dir)
+        with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': '1.63.0'}):
+            self.assertFalse(link.check_if_installed())
+
+    def test_install_creates_correct_link(self):
+        self._freeze_bin()
+        link = PlaywrightBinLink(tools_dir=self.tools_dir)
+        with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': '1.63.0'}):
+            link.install()
+            self.assertTrue(link.check_if_installed())
+
+    def test_install_overwrites_link_clobbered_by_another_package(self):
+        """Simulates NPMModuleInstaller overwriting .bin/playwright with a different package's cli.js"""
+        self._freeze_bin()
+        bin_target = os.path.join(self.tools_dir, "node_modules", ".bin", "playwright")
+        os.makedirs(os.path.dirname(bin_target), exist_ok=True)
+        os.symlink("../playwright/cli.js", bin_target)
+
+        link = PlaywrightBinLink(tools_dir=self.tools_dir)
+        with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': '1.63.0'}):
+            link.install()
+
+        self.assertEqual(
+            os.path.realpath(bin_target),
+            os.path.realpath(os.path.join(self.frozen_store, "node_modules", ".bin", "playwright")),
+        )
 
 
 class TestPlaywrightTypesNodePackage(BZTestCase):

--- a/tests/unit/modules/_selenium/test_javascript.py
+++ b/tests/unit/modules/_selenium/test_javascript.py
@@ -1128,18 +1128,23 @@ class TestPlaywrightTypesNodePackage(BZTestCase):
 
 class TestPlaywrightCustomReporterInstallation(BZTestCase):
     """
-    Tests for PlaywrightCustomReporter: always a local (registry-free) install, every run -
-    it ships inside the bzt package itself, so there's no registry-unreachable problem for
-    it to solve and no reason to freeze/symlink it like the registry-backed packages.
+    Tests for PlaywrightCustomReporter: local (registry-free) npm install when not frozen,
+    linked from the frozen store when frozen - so an unrelated uncached customer dependency
+    sharing the same tools_dir can no longer collaterally block it.
     """
 
     def setUp(self):
         super(TestPlaywrightCustomReporterInstallation, self).setUp()
+        import tempfile
         self.node_mock = MagicMock()
         self.node_mock.tool_path = "node"
         self.npm_mock = MagicMock()
         self.npm_mock.tool_path = "npm"
-        self.tools_dir = "/tmp/customer-tools-dir"
+        self.frozen_store = tempfile.mkdtemp()
+        self.tools_dir = tempfile.mkdtemp()
+        self.get_full_path_patcher = patch('bzt.modules.javascript.get_full_path', return_value=self.frozen_store)
+        self.get_full_path_patcher.start()
+        self.addCleanup(self.get_full_path_patcher.stop)
 
     def _create_package(self):
         return PlaywrightCustomReporter(
@@ -1148,24 +1153,55 @@ class TestPlaywrightCustomReporterInstallation(BZTestCase):
             npm_tool=self.npm_mock,
         )
 
-    def test_check_if_installed_always_false(self):
-        """Always reinstall: npm version resolving for local modules is not reliable"""
+    def _freeze_reporter(self):
+        path = os.path.join(self.frozen_store, "node_modules", "@taurus", "playwright-custom-reporter")
+        os.makedirs(path, exist_ok=True)
+        with open(os.path.join(path, "index.js"), "w") as fds:
+            fds.write("module.exports = {};")
+
+    def test_check_if_installed_not_frozen_always_false(self):
+        """Not frozen: always reinstall - npm version resolving for local modules is not reliable"""
         pkg = self._create_package()
-        with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': '1.63.0'}):
-            self.assertFalse(pkg.check_if_installed())
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop('PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION', None)
             self.assertFalse(pkg.check_if_installed())
 
-    def test_install_runs_local_npm_install(self):
+    def test_install_not_frozen_runs_local_npm_install(self):
         pkg = self._create_package()
         pkg.call = MagicMock(return_value=("", ""))
 
-        pkg.install()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop('PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION', None)
+            pkg.install()
 
         args, kwargs = pkg.call.call_args
         self.assertEqual(args[0], ["npm", "install", ".", "--install-links", "--prefix", self.tools_dir, "--offline"])
         self.assertEqual(kwargs.get("cwd"), pkg.package_local_path)
+
+    def test_install_frozen_links_reporter(self):
+        self._freeze_reporter()
+        pkg = self._create_package()
+        pkg.call = MagicMock()
+
+        with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': '1.63.0'}):
+            pkg.install()
+
+        target = os.path.join(self.tools_dir, "node_modules", "@taurus", "playwright-custom-reporter")
+        self.assertTrue(os.path.islink(target))
+        pkg.call.assert_not_called()
+
+    def test_check_if_installed_frozen_true_after_install(self):
+        self._freeze_reporter()
+        pkg = self._create_package()
+        with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': '1.63.0'}):
+            pkg.install()
+            self.assertTrue(pkg.check_if_installed())
+
+    def test_check_if_installed_frozen_false_before_install(self):
+        self._freeze_reporter()
+        pkg = self._create_package()
+        with patch.dict(os.environ, {'PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION': '1.63.0'}):
+            self.assertFalse(pkg.check_if_installed())
 
 
 class TestNPMModuleInstallerInstallation(BZTestCase):

--- a/tests/unit/modules/_selenium/test_javascript.py
+++ b/tests/unit/modules/_selenium/test_javascript.py
@@ -878,6 +878,18 @@ class TestFrozenPackageLinkHelpers(BZTestCase):
 
         self.assertTrue(os.path.exists(os.path.join(target, "index.js")))
 
+    def test_link_frozen_path_replaces_existing_plain_file(self):
+        self._make_frozen_package(("@types", "node"))
+        target = os.path.join(self.tools_dir, "node_modules", "@types", "node")
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, "w") as fds:
+            fds.write("stray file, neither a symlink nor a directory")
+
+        _link_frozen_path(self.tools_dir, ("@types", "node"))
+
+        self.assertTrue(os.path.islink(target))
+        self.assertTrue(os.path.exists(os.path.join(target, "index.js")))
+
     def test_is_linked_to_frozen_path_true_after_linking(self):
         self._make_frozen_package(("@playwright", "test"))
         _link_frozen_path(self.tools_dir, ("@playwright", "test"))
@@ -938,6 +950,26 @@ class TestFrozenPackageLinkHelpers(BZTestCase):
 
     def test_read_frozen_installed_version_missing_returns_none(self):
         self.assertIsNone(_read_frozen_installed_version(("@types", "node")))
+
+    def test_link_frozen_path_noop_when_tools_dir_is_frozen_store(self):
+        """
+        If tools_dir resolves to the frozen store itself (e.g. re-running -install-tools
+        inside an already-configured shell), source and target are the same path - must not
+        delete the frozen store's own content.
+        """
+        self._make_frozen_package(("@types", "node"))
+        target = os.path.join(self.frozen_store, "node_modules", "@types", "node")
+        self.assertTrue(os.path.isdir(target))
+
+        _link_frozen_path(self.frozen_store, ("@types", "node"))
+
+        self.assertTrue(os.path.isdir(target))
+        self.assertFalse(os.path.islink(target))
+        self.assertTrue(os.path.exists(os.path.join(target, "index.js")))
+
+    def test_is_linked_to_frozen_path_true_when_tools_dir_is_frozen_store(self):
+        self._make_frozen_package(("@types", "node"))
+        self.assertTrue(_is_linked_to_frozen_path(self.frozen_store, ("@types", "node")))
 
 
 class TestPlaywrightTestPackageInstallation(BZTestCase):
@@ -1122,16 +1154,31 @@ class TestPlaywrightTypesNodePackage(BZTestCase):
             json.dump({"version": version}, fds)
         return version
 
-    def test_check_if_installed_not_frozen_delegates_to_super(self):
+    def test_check_if_installed_not_frozen_false_when_missing(self):
         pkg = self._create_package()
-        pkg.call = MagicMock(return_value=("", ""))
 
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop('PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION', None)
-            # @types/node has no requirable entry point at all - always False, as expected
             result = pkg.check_if_installed()
 
         self.assertFalse(result)
+
+    def test_check_if_installed_not_frozen_true_after_install_no_reinstall(self):
+        """
+        @types/node has no requirable entry point at all (pure .d.ts, no main .js), so a
+        require()-based check would always return False even right after a successful
+        install, forcing a redundant npm install (and network round-trip) on every run.
+        """
+        pkg = self._create_package()
+        path = os.path.join(self.tools_dir, "node_modules", "@types", "node")
+        os.makedirs(path, exist_ok=True)
+        with open(os.path.join(path, "package.json"), "w") as fds:
+            json.dump({"version": "22.15.21"}, fds)
+        pkg.call = MagicMock(side_effect=AssertionError("should not need npm at all"))
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop('PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION', None)
+            self.assertTrue(pkg.check_if_installed())
 
     def test_install_not_frozen_delegates_to_super(self):
         pkg = self._create_package()


### PR DESCRIPTION
## Summary

Cloud runs on private locations with no access to registry.npmjs.org were failing or hanging on Playwright tool installation. `@playwright/test`, `@types/node`, and the local `@taurus/playwright-custom-reporter` are frozen to a specific build into `~/.bzt/playwright` at Docker build time, but every ephemeral test run still needed its own npm install into a fresh directory - which either failed outright when the registry was unreachable, or (with an `--offline`/`--prefer-offline` fallback approach) still hung for ~70s and ultimately failed to install anything whenever the customer had any other uncached dependency declared in the same `package.json`, since `npm install --prefix <dir>` reifies the *entire* tree in that directory, not just the requested package.

This PR replaces the per-run npm reinstall with `os.symlink()`: once a package is installed into the frozen store, every actual test run just links it into place instead of invoking npm at all. No npm command touches these packages again after build time, so they're immune both to the registry being unreachable and to a customer having configured a different registry than the one used at build time.

- `FrozenPackageLink`, a shared base for npm-registry packages Taurus itself owns and freezes: `PlaywrightTestPackage` and the new `PlaywrightTypesNodePackage` (added since Playwright's own official TypeScript scaffolding always declares `@types/node` as a devDependency) extend it.
- `PlaywrightCustomReporter` links its own frozen-store copy at runtime too, since `npm install .` reifying the customer's whole `package.json` was collaterally blocking it whenever an unrelated dependency was uncached, even though the reporter itself is registry-free local content.
- `PLAYWRIGHT`'s frozen-version probe now runs against `~/.bzt/playwright` (the actual frozen build-time location) instead of the ephemeral per-test directory it was incorrectly checking before.
- New `PlaywrightBinLink` tool runs last in `install_required_tools()`: the unscoped `playwright` package declares the same `bin.playwright` entry as `@playwright/test`, so if a customer's own `package.json` also depends on plain `playwright` (common), `NPMModuleInstaller`'s reify of that dependency overwrites `node_modules/.bin/playwright` - this reasserts the correct target afterward.
- `NPMLocalModulePackage` (shared by `PlaywrightCustomReporter`'s non-frozen path and `NPMModuleInstaller`, for genuinely customer-controlled content that can't be frozen/symlinked) tries `--offline` first and falls back to `--prefer-offline`.
- Elevated several previously-silent `debug` failure logs to `warning`/`info` in the install path, so a genuine install failure is visible without full debug logging.

None of this affects local/open-source `bzt` usage - every symlink-creating code path is gated behind `PLAYWRIGHT_TEST_PACKAGE_FORCED_VERSION`, which is only ever set inside the taurus-cloud Docker image.

## Test plan

- [x] Unit tests: `TestFrozenPackageLinkHelpers`, `TestPlaywrightTestPackageInstallation`, `TestPlaywrightTypesNodePackage`, `TestPlaywrightCustomReporterInstallation`, `TestPlaywrightBinLink`, `TestNPMModuleInstallerInstallation`, `TestPlaywrightInstallation` all passing
- [x] flake8 clean (no new warnings vs. master)
- [x] Verified in a real taurus-cloud image with the registry genuinely blocked (via a setuid `/etc/hosts` helper): all frozen packages symlink in single-digit milliseconds, `npx playwright test` resolves fully offline
- [x] Verified immune to a customer having configured a different npm registry than the one used at build time
- [x] Verified a customer's own uncached extra dependency no longer collaterally blocks our frozen packages (previously a ~70s hang-then-fail)
- [x] Verified and fixed the `.bin/playwright` bin-name collision with a customer's own `playwright` dependency (found during manual testing)